### PR TITLE
Fix code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/tests/integration/test_company.py
+++ b/tests/integration/test_company.py
@@ -132,10 +132,13 @@ class TestCompanyEndpoints:
         assert url == f"https://financialmodelingprep.com/image-stock/{test_symbol}.png"
 
         # Verify URL components
-        assert url.startswith("https://financialmodelingprep.com")
-        assert "/image-stock/" in url
-        assert url.endswith(".png")
-        assert test_symbol in url
+        from urllib.parse import urlparse
+        parsed_url = urlparse(url)
+        assert parsed_url.scheme == "https"
+        assert parsed_url.netloc == "financialmodelingprep.com"
+        assert parsed_url.path.startswith("/image-stock/")
+        assert parsed_url.path.endswith(".png")
+        assert test_symbol in parsed_url.path
 
         # Verify no API-related parameters
         assert "apikey" not in url

--- a/tests/integration/test_company.py
+++ b/tests/integration/test_company.py
@@ -133,6 +133,7 @@ class TestCompanyEndpoints:
 
         # Verify URL components
         from urllib.parse import urlparse
+
         parsed_url = urlparse(url)
         assert parsed_url.scheme == "https"
         assert parsed_url.netloc == "financialmodelingprep.com"


### PR DESCRIPTION
Fixes [https://github.com/MehdiZare/fmp-data/security/code-scanning/1](https://github.com/MehdiZare/fmp-data/security/code-scanning/1)

To fix the problem, we should parse the URL and verify its components to ensure it is safe. Specifically, we should:
1. Use the `urlparse` function from the `urllib.parse` module to parse the URL.
2. Check that the hostname of the parsed URL matches the expected hostname (`financialmodelingprep.com`).
3. Ensure that the URL path starts with the expected path segment (`/image-stock/`).

This approach will provide a more reliable and secure way to validate the URL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
