### PR TITLE
fix the bug when volume is float on product 

### DIFF
--- a/fmp_data/alternative/models.py
+++ b/fmp_data/alternative/models.py
@@ -119,8 +119,8 @@ class HistoricalPrice(BaseModel):
     adj_close: float | None = Field(
         None, alias="adjClose", description="Adjusted closing price"
     )
-    volume: int = Field(description="Volume traded")
-    unadjusted_volume: int | None = Field(
+    volume: float = Field(description="Volume traded")
+    unadjusted_volume: float | None = Field(
         None, alias="unadjustedVolume", description="Unadjusted trading volume"
     )
     change: float = Field(description="Price change")

--- a/fmp_data/company/models.py
+++ b/fmp_data/company/models.py
@@ -517,7 +517,7 @@ class IntradayPrice(BaseModel):
     low: float = Field(description="Low price")
     high: float = Field(description="High price")
     close: float = Field(description="Closing price")
-    volume: int = Field(description="Trading volume")
+    volume: float = Field(description="Trading volume")
 
 
 class ExecutiveCompensation(BaseModel):


### PR DESCRIPTION
when call https://site.financialmodelingprep.com/developer/docs#intraday-1-min, the volume responses in float

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for IntradayPrice
volume
  Input should be a valid integer, got a number with a fractional part [type=int_from_float, input_value=28541.004200000316, input_type=float]
    For further information visit https://errors.pydantic.dev/2.12/v/int_from_float
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Volume data fields have been updated to support decimal precision instead of whole numbers. This change applies to historical and intraday price data, improving accuracy for trading volume representation across different market sources and instruments, particularly beneficial for fractional share scenarios and detailed volume analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->