### PR TITLE
release: minor float volume normalization and workflow updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           uv tool run nox -s coverage_local
 
       - name: 📈 Coverage upload
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,17 +25,17 @@ jobs:
 
     steps:
       - name: 🛎️  Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 
       - name: 🐍  Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ matrix.python }}
 
       - name: ⚡  Install uv (with cache)
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           enable-cache: true
 
@@ -70,15 +70,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛎️  Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: 🐍  Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.14"
 
       - name: ⚡  Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
 
       - name: 📊 Run all tests with coverage
         env:
@@ -88,7 +88,7 @@ jobs:
           uv tool run nox -s coverage_local
 
       - name: 📈 Coverage upload
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
@@ -100,10 +100,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛎️  Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: 🐍  Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.14"
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -19,18 +19,18 @@ jobs:
 
     steps:
       - name: 🛎️  Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0  # Needed for version calculation
           fetch-tags: true
 
       - name: 🐍  Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: ⚡  Install uv (with cache)
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           enable-cache: true
 

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -125,7 +125,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
       - name: Generate deployment summary
         run: |

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -39,21 +39,21 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           enable-cache: true
 
       - name: Cache uv dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.4
         with:
           path: |
             ~/.cache/uv
@@ -94,7 +94,7 @@ jobs:
           PACKAGE_VERSION="${{ steps.version.outputs.VERSION }}" uv run mkdocs build --strict
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v4.0.0
         with:
           path: site
 
@@ -125,7 +125,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@v5.0.0
 
       - name: Generate deployment summary
         run: |

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -36,18 +36,18 @@ jobs:
 
     steps:
       - name: 🛎️  Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0  # Needed for version calculation
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: 🐍  Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: ⚡  Install uv (with cache)
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           enable-cache: true
 
@@ -179,17 +179,17 @@ jobs:
 
     steps:
       - name: 🛎️  Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0  # Needed for hatch-vcs versioning
 
       - name: 🐍  Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: ⚡  Install uv (with cache)
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           enable-cache: true
 

--- a/.github/workflows/rebase-reminder.yml
+++ b/.github/workflows/rebase-reminder.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR head
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
@@ -30,7 +30,7 @@ jobs:
 
       - name: Comment if behind
         if: ${{ steps.check.outputs.behind != '0' && github.event.pull_request.head.repo.fork == false }}
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@v5.0.0
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
           ref: dev
 
       - name: Create or Update Release PR
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@v8.1.0
         with:
           branch: release/dev-to-main
           base: main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,18 +26,18 @@ jobs:
 
     steps:
       - name: 🛎️ Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0  # Fetch all history for proper versioning
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🐍 Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: ⚡ Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           enable-cache: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,26 +143,31 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: 🚀 Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.version.outputs.VERSION }}
-          name: Release ${{ steps.version.outputs.VERSION }}
-          body: |
-            ## 🎉 Release ${{ steps.version.outputs.VERSION }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.version.outputs.VERSION }}
+          RELEASE_VERSION: ${{ steps.version.outputs.VERSION_NUMBER }}
+        run: |
+          cat > release-notes.md <<'EOF'
+          ## 🎉 Release ${{ steps.version.outputs.VERSION }}
 
-            ${{ steps.release_notes.outputs.NOTES }}
+          ${{ steps.release_notes.outputs.NOTES }}
 
-            ### 📦 Installation
-            ```bash
-            pip install fmp-data==${{ steps.version.outputs.VERSION_NUMBER }}
-            ```
+          ### 📦 Installation
+          ```bash
+          pip install fmp-data==${{ steps.version.outputs.VERSION_NUMBER }}
+          ```
 
-            ### 🔗 Links
-            - [PyPI Package](https://pypi.org/project/fmp-data/${{ steps.version.outputs.VERSION_NUMBER }}/)
-            - [Documentation](https://mehdizare.github.io/fmp-data/)
-          files: dist/*
-          prerelease: false
-          generate_release_notes: true
+          ### 🔗 Links
+          - [PyPI Package](https://pypi.org/project/fmp-data/${{ steps.version.outputs.VERSION_NUMBER }}/)
+          - [Documentation](https://mehdizare.github.io/fmp-data/)
+          EOF
+
+          gh release create "$RELEASE_TAG" dist/* \
+            --verify-tag \
+            --title "Release $RELEASE_TAG" \
+            --notes-file release-notes.md \
+            --generate-notes
 
       - name: 🚀 Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1.13.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,11 +98,14 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
 
-          # Create annotated tag
-          git tag -a "${{ steps.version.outputs.VERSION }}" -m "Release ${{ steps.version.outputs.VERSION }}"
+          RELEASE_TAG="${{ steps.version.outputs.VERSION }}"
 
-          # Push tag
-          git push origin "${{ steps.version.outputs.VERSION }}"
+          if git rev-parse -q --verify "refs/tags/${RELEASE_TAG}" > /dev/null; then
+            echo "Tag ${RELEASE_TAG} already exists, skipping creation"
+          else
+            git tag -a "$RELEASE_TAG" -m "Release $RELEASE_TAG"
+            git push origin "$RELEASE_TAG"
+          fi
 
       - name: 📦 Build distribution
         run: |
@@ -163,14 +166,21 @@ jobs:
           - [Documentation](https://mehdizare.github.io/fmp-data/)
           EOF
 
-          gh release create "$RELEASE_TAG" dist/* \
-            --verify-tag \
-            --title "Release $RELEASE_TAG" \
-            --notes-file release-notes.md \
-            --generate-notes
+          if gh release view "$RELEASE_TAG" > /dev/null 2>&1; then
+            echo "Release $RELEASE_TAG already exists, updating notes and assets"
+            gh release upload "$RELEASE_TAG" dist/* --clobber
+            gh release edit "$RELEASE_TAG" \
+              --title "Release $RELEASE_TAG" \
+              --notes-file release-notes.md
+          else
+            gh release create "$RELEASE_TAG" dist/* \
+              --verify-tag \
+              --title "Release $RELEASE_TAG" \
+              --notes-file release-notes.md
+          fi
 
       - name: 🚀 Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1.13.0
         with:
           packages-dir: dist/
-          skip-existing: false
+          skip-existing: true

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           ref: main
           fetch-depth: 0
@@ -37,7 +37,7 @@ jobs:
 
       - name: Create Sync PR
         if: steps.diff.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@v8.1.0
         with:
           branch: sync/main-to-dev
           base: dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Cache Payload Isolation** - Prevented mutable cached payloads from being shared by reference:
   - `BaseClient` now deep-copies cache payloads on both cache read and write paths
   - Added sync and async regression coverage to prevent future cache aliasing regressions
+- **Float Volume Handling** - Fixed price models that failed when FMP returned fractional volume values:
+  - `alternative.HistoricalPrice.volume` and `alternative.HistoricalPrice.unadjusted_volume` now accept floats
+  - `company.IntradayPrice.volume` now accepts floats
+  - Added regression tests for both float-volume validation paths
 - **Quote Volume Nullability** - Fixed quote models to accept `null` volume values from the API:
   - `Quote.volume` and `SimpleQuote.volume` now use `int | None`
   - Added regression coverage for `volume=None` model validation
@@ -92,6 +96,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - CI `secret-scan` job explicitly targets `tests/integration/vcr_cassettes/` as an additional safety net
 
 ### Changed
+- **GitHub Actions Maintenance** - Updated workflow actions to current upstream releases:
+  - Bumped `actions/deploy-pages` from `v4` to `v5` in the documentation workflow
+  - Bumped `codecov/codecov-action` from `v5` to `v6` in CI coverage uploads
 - **VCR Cassettes Excluded from Git** - Cassettes are now gitignored (`tests/integration/vcr_cassettes/`) because they are too large for GitHub (130 MB+ individual files). Developers must record cassettes locally with `FMP_TEST_API_KEY`.
 - **CI Secret Scan** - The `secret-scan` job now gracefully skips when no cassette YAML files are present instead of failing.
 - **Cassette Contract Test** - `test_vcr_cassettes_match_endpoint_models` now skips with a clear message when no cassettes are found, instead of silently passing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added per-endpoint TTL overrides, deterministic cache keys, and `force_refresh=True` support to bypass cache reads on demand
   - Added optional `cache-redis` extra for Redis-backed caching
 
+### Changed
+- **Volume Type Normalization** - Normalized price-model volume fields to always deserialize as `float`:
+  - `alternative.HistoricalPrice.volume` and `alternative.HistoricalPrice.unadjusted_volume` now normalize whole-number payloads such as `123` to `123.0`
+  - `company.IntradayPrice.volume` now normalizes whole-number payloads to `float` as well
+  - This keeps a single return type for price-volume fields when FMP mixes integer and fractional responses
+  - Release impact: treat this as a minor release because the runtime type and generated schema change from integer to number for these fields
+
 ### Fixed
 - **Cache Payload Isolation** - Prevented mutable cached payloads from being shared by reference:
   - `BaseClient` now deep-copies cache payloads on both cache read and write paths
   - Added sync and async regression coverage to prevent future cache aliasing regressions
 - **Float Volume Handling** - Fixed price models that failed when FMP returned fractional volume values:
-  - `alternative.HistoricalPrice.volume` and `alternative.HistoricalPrice.unadjusted_volume` now accept floats
-  - `company.IntradayPrice.volume` now accepts floats
+  - `alternative.HistoricalPrice.volume` and `alternative.HistoricalPrice.unadjusted_volume` now validate fractional inputs without raising
+  - `company.IntradayPrice.volume` now validates fractional inputs without raising
   - Added regression tests for both float-volume validation paths
 - **Quote Volume Nullability** - Fixed quote models to accept `null` volume values from the API:
   - `Quote.volume` and `SimpleQuote.volume` now use `int | None`

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ To use this library, you'll need an API key from Financial Modeling Prep (FMP). 
 
 ## Installation
 
+## Launch Notes
+
+- Price-history volume fields now normalize to `float` so integer and fractional FMP payloads share one stable return type.
+- This affects `alternative.HistoricalPrice.volume`, `alternative.HistoricalPrice.unadjusted_volume`, and `company.IntradayPrice.volume`.
+- Whole-number payloads for those models now deserialize as values like `123.0`, which is why this ships as a minor release instead of a patch.
+
 ### Using UV (Recommended)
 
 ```bash

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -235,9 +235,9 @@ Brief description of changes made.
 
 Releases are automated using semantic versioning based on PR labels:
 
-- **Patch**: Bug fixes and minor updates
-- **Minor**: New features and improvements
-- **Major**: Breaking changes
+- **`release:patch`**: Bug fixes and minor updates
+- **`release:minor`**: New features, improvements, and intentional public type/schema changes
+- **`release:major`**: Breaking changes
 
 See our [Releasing Guide](releasing.md) for more details.
 

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -195,9 +195,9 @@ Use conventional commit format for PR titles:
 
 Add appropriate labels for semantic versioning:
 
-- `major`: Breaking changes (bumps major version)
-- `minor`: New features (bumps minor version)
-- `patch`: Bug fixes (bumps patch version)
+- `release:major`: Breaking changes (bumps major version)
+- `release:minor`: New features and intentional public type/schema changes (bumps minor version)
+- `release:patch`: Bug fixes (bumps patch version)
 
 ### PR Description Template
 

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -63,29 +63,36 @@ Our release process is fully automated using GitHub Actions:
 name: Release
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches: [ main ]
 
 jobs:
   release:
+    if: |
+      github.event.pull_request.merged == true &&
+      (contains(github.event.pull_request.labels.*.name, 'release:major') ||
+       contains(github.event.pull_request.labels.*.name, 'release:minor') ||
+       contains(github.event.pull_request.labels.*.name, 'release:patch'))
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: '3.14'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.0.0
 
       - name: Build distribution
         run: python -m build --wheel --sdist
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.12.4
+        uses: pypa/gh-action-pypi-publish@v1.13.0
         with:
           packages-dir: dist/
+          skip-existing: true
 ```
 
 ## Manual Release Process
@@ -137,7 +144,7 @@ For emergency releases or when automation fails:
 
 6. **Create Release PR**
    - Create PR from release branch to main
-   - Add appropriate version label
+   - Add exactly one version label: `release:major`, `release:minor`, or `release:patch`
    - Include release notes in description
 
 7. **Merge and Tag**

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -13,7 +13,7 @@ MAJOR.MINOR.PATCH[-PRERELEASE][+BUILD]
 ```
 
 - **MAJOR**: Breaking changes that require user action
-- **MINOR**: New features that are backward compatible
+- **MINOR**: New features and intentional public API/schema changes that remain source-compatible
 - **PATCH**: Bug fixes and minor improvements
 - **PRERELEASE**: Alpha, beta, or release candidate versions
 - **BUILD**: Build metadata (not used in our releases)
@@ -22,11 +22,11 @@ MAJOR.MINOR.PATCH[-PRERELEASE][+BUILD]
 
 | Change Type | PR Label | Version Bump | Example |
 |-------------|----------|--------------|---------|
-| Breaking Changes | `major` | MAJOR | 1.0.0 → 2.0.0 |
-| New Features | `minor` | MINOR | 1.0.0 → 1.1.0 |
-| Bug Fixes | `patch` | PATCH | 1.0.0 → 1.0.1 |
-| Documentation | `patch` | PATCH | 1.0.0 → 1.0.1 |
-| Chores | `patch` | PATCH | 1.0.0 → 1.0.1 |
+| Breaking Changes | `release:major` | MAJOR | 1.0.0 → 2.0.0 |
+| New Features / Public type changes | `release:minor` | MINOR | 1.0.0 → 1.1.0 |
+| Bug Fixes | `release:patch` | PATCH | 1.0.0 → 1.0.1 |
+| Documentation | `release:patch` | PATCH | 1.0.0 → 1.0.1 |
+| Chores | `release:patch` | PATCH | 1.0.0 → 1.0.1 |
 
 ## Automated Release Process
 
@@ -45,9 +45,9 @@ Our release process is fully automated using GitHub Actions:
 ### Required PR Labels
 
 **Version Bump Labels** (exactly one required):
-- `major`: For breaking changes
-- `minor`: For new features
-- `patch`: For bug fixes and minor changes
+- `release:major`: For breaking changes
+- `release:minor`: For new features and intentional public type/schema changes
+- `release:patch`: For bug fixes and minor changes
 
 **Additional Labels** (optional):
 - `dependencies`: Dependency updates

--- a/docs/contributing/workflow.md
+++ b/docs/contributing/workflow.md
@@ -189,9 +189,9 @@ chore(deps): update httpx to latest version
 
 We use automated semantic versioning based on PR labels:
 
-- **major**: Breaking changes (v1.0.0 → v2.0.0)
-- **minor**: New features (v1.0.0 → v1.1.0)
-- **patch**: Bug fixes (v1.0.0 → v1.0.1)
+- **release:major**: Breaking changes (v1.0.0 → v2.0.0)
+- **release:minor**: New features and intentional public type/schema changes (v1.0.0 → v1.1.0)
+- **release:patch**: Bug fixes (v1.0.0 → v1.0.1)
 
 ### Release Process
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,12 @@ Now with 100% coverage of the FMP stable endpoint catalog.
 
 ## Quick Start
 
+### Launch Notes
+
+- Price-history volume fields now normalize to `float` for a single stable return type when FMP mixes whole-number and fractional payloads.
+- This affects `alternative.HistoricalPrice.volume`, `alternative.HistoricalPrice.unadjusted_volume`, and `company.IntradayPrice.volume`.
+- If your code previously type-checked these values as integers, expect whole-number payloads to deserialize as values like `123.0`.
+
 ### Installation
 
 ```bash

--- a/fmp_data/alternative/models.py
+++ b/fmp_data/alternative/models.py
@@ -119,8 +119,8 @@ class HistoricalPrice(BaseModel):
     adj_close: float | None = Field(
         None, alias="adjClose", description="Adjusted closing price"
     )
-    volume: int = Field(description="Volume traded")
-    unadjusted_volume: int | None = Field(
+    volume: float = Field(description="Volume traded")
+    unadjusted_volume: float | None = Field(
         None, alias="unadjustedVolume", description="Unadjusted trading volume"
     )
     change: float = Field(description="Price change")

--- a/fmp_data/cache/redis_backend.py
+++ b/fmp_data/cache/redis_backend.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any
+from typing import Any, cast
 
 from fmp_data.cache.base import CacheBackend
 
@@ -44,7 +44,7 @@ class RedisCache(CacheBackend):
 
     def get(self, key: str) -> Any | None:
         try:
-            raw = self._client.get(self._prefixed(key))
+            raw = cast(str | None, self._client.get(self._prefixed(key)))
         except Exception:
             logger.warning("Redis get error for key %s", key, exc_info=True)
             return None
@@ -74,7 +74,10 @@ class RedisCache(CacheBackend):
         cursor: int = 0
         try:
             while True:
-                cursor, keys = self._client.scan(cursor, match=pattern, count=100)
+                cursor, keys = cast(
+                    tuple[int, list[str]],
+                    self._client.scan(cursor, match=pattern, count=100),
+                )
                 if keys:
                     self._client.delete(*keys)
                 if cursor == 0:

--- a/fmp_data/company/models.py
+++ b/fmp_data/company/models.py
@@ -517,7 +517,7 @@ class IntradayPrice(BaseModel):
     low: float = Field(description="Low price")
     high: float = Field(description="High price")
     close: float = Field(description="Closing price")
-    volume: int = Field(description="Trading volume")
+    volume: float = Field(description="Trading volume")
 
 
 class ExecutiveCompensation(BaseModel):

--- a/fmp_data/lc/embedding.py
+++ b/fmp_data/lc/embedding.py
@@ -64,7 +64,7 @@ class EmbeddingConfig(BaseModel):
                 from langchain_openai import OpenAIEmbeddings
 
                 return OpenAIEmbeddings(
-                    api_key=self.api_key,
+                    openai_api_key=self.api_key,
                     model=self.model_name or "text-embedding-ada-002",
                     **self.additional_kwargs,
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-    "hatchling>=1.22.0",
-    "hatch-vcs>=0.4.0",
+    "hatchling>=1.29.0",
+    "hatch-vcs>=0.5.0",
 ]
 build-backend = "hatchling.build"
 
@@ -48,7 +48,7 @@ classifiers = [
 dependencies = [
     "httpx>=0.28.1",
     "pydantic>=2.12.5",
-    "tenacity>=9.1.2",
+    "tenacity>=9.1.4",
 ]
 
 [project.license]
@@ -64,84 +64,84 @@ fmp-mcp = "fmp_data.mcp.cli:main"
 
 [project.optional-dependencies]
 mcp = [
-    "mcp[cli]>=1.25.0",
+    "mcp[cli]>=1.27.0",
     "pyyaml>=6.0.3",
 ]
 cache-redis = [
-    "redis>=5.0.0",
+    "redis>=7.4.0",
 ]
 langchain = [
     "faiss-cpu>=1.13.2",
-    "langchain-core>=1.2.8",
+    "langchain-core>=1.2.26",
     "langchain-community>=0.4.1",
-    "langchain-openai>=1.1.7",
-    "langgraph>=1.0.6",
-    "openai>=2.15.0",
+    "langchain-openai>=1.1.12",
+    "langgraph>=1.1.6",
+    "openai>=2.30.0",
     "tiktoken>=0.12.0",
 ]
 dev = [
-    "ruff>=0.14.13",
-    "mypy>=1.19.1",
-    "bandit[toml]>=1.9.3",
+    "ruff>=0.15.9",
+    "mypy>=1.20.0",
+    "bandit[toml]>=1.9.4",
     "pip-audit>=2.10.0",
-    "python-dotenv>=1.1.1",
+    "python-dotenv>=1.2.2",
     "pytest>=9.0.2",
     "pytest-asyncio>=1.3.0",
-    "pytest-cov>=7.0.0",
+    "pytest-cov>=7.1.0",
     "pytest-mock>=3.15.1",
     "pytest-xdist>=3.6.1",
     "freezegun>=1.5.5",
-    "responses>=0.25.8",
+    "responses>=0.26.0",
     "vcrpy>=8.1.1",
-    "coverage>=7.13.1",
+    "coverage>=7.13.5",
     "pre-commit>=4.5.1",
-    "rich>=14.3.2",
+    "rich>=14.3.3",
     "twine>=6.2.0",
-    "nox>=2025.11.12",
+    "nox>=2026.2.9",
 ]
 docs = [
     "mkdocs>=1.6.1",
-    "mkdocs-material>=9.7.1",
-    "mkdocstrings-python>=2.0.1",
+    "mkdocs-material>=9.7.6",
+    "mkdocstrings-python>=2.0.3",
 ]
 
 [dependency-groups]
 dev = [
-    "ruff>=0.14.13",
-    "mypy>=1.19.1",
-    "bandit[toml]>=1.9.3",
+    "ruff>=0.15.9",
+    "mypy>=1.20.0",
+    "bandit[toml]>=1.9.4",
     "pip-audit>=2.10.0",
-    "python-dotenv>=1.1.1",
+    "python-dotenv>=1.2.2",
     "pytest>=9.0.2",
     "pytest-asyncio>=1.3.0",
-    "pytest-cov>=7.0.0",
+    "pytest-cov>=7.1.0",
     "pytest-mock>=3.15.1",
     "pytest-xdist>=3.6.1",
     "freezegun>=1.5.5",
-    "responses>=0.25.8",
+    "responses>=0.26.0",
     "vcrpy>=8.1.1",
-    "coverage>=7.13.1",
+    "coverage>=7.13.5",
     "pre-commit>=4.5.1",
-    "rich>=14.3.2",
+    "rich>=14.3.3",
     "twine>=6.2.0",
-    "nox>=2025.11.12",
+    "nox>=2026.2.9",
 ]
 docs = [
     "mkdocs>=1.6.1",
-    "mkdocs-material>=9.7.1",
-    "mkdocstrings-python>=2.0.1",
+    "mkdocs-material>=9.7.6",
+    "mkdocstrings-python>=2.0.3",
 ]
 langchain = [
     "faiss-cpu>=1.13.2",
-    "langchain-core>=1.2.8",
+    "langchain-core>=1.2.26",
     "langchain-community>=0.4.1",
-    "langchain-openai>=1.1.7",
-    "langgraph>=1.0.6",
-    "openai>=2.15.0",
+    "langchain-openai>=1.1.12",
+    "langgraph>=1.1.6",
+    "openai>=2.30.0",
     "tiktoken>=0.12.0",
 ]
 mcp = [
-    "mcp[cli]>=1.25.0",
+    "mcp[cli]>=1.27.0",
     "pyyaml>=6.0.3",
 ]
 

--- a/tests/integration/test_company.py
+++ b/tests/integration/test_company.py
@@ -130,7 +130,7 @@ class TestCompanyEndpoints(BaseTestCase):
                 assert isinstance(price.high, float)
                 assert isinstance(price.low, float)
                 assert isinstance(price.close, float)
-                assert isinstance(price.volume, int)
+                assert isinstance(price.volume, float)
 
     def test_get_market_cap(self, fmp_client: FMPDataClient, vcr_instance):
         """Test getting market capitalization data"""

--- a/tests/unit/lc/test_embedding.py
+++ b/tests/unit/lc/test_embedding.py
@@ -54,7 +54,7 @@ def test_get_embeddings_openai(mock_openai):
 
     config.get_embeddings()
     mock_openai.assert_called_once_with(
-        api_key="test-key", model="text-embedding-ada-002"
+        openai_api_key="test-key", model="text-embedding-ada-002"
     )
 
 

--- a/tests/unit/test_alternative.py
+++ b/tests/unit/test_alternative.py
@@ -158,7 +158,8 @@ def test_crypto_historical_price_model(mock_crypto_historical):
     assert price.low == 43500.00
     assert price.close == 45000.00
     assert price.adj_close == 45000.00
-    assert price.volume == 25000000000
+    assert price.volume == pytest.approx(25000000000.0)
+    assert isinstance(price.volume, float)
     assert price.change == 1250.00
     assert price.change_percent == 2.85
     assert price.vwap == 44500.00
@@ -174,3 +175,19 @@ def test_alternative_historical_price_accepts_float_volume(mock_crypto_historica
 
     assert price.volume == pytest.approx(25000000000.75)
     assert price.unadjusted_volume == pytest.approx(24999999999.25)
+
+
+def test_alternative_historical_price_normalizes_integer_volume_to_float(
+    mock_crypto_historical,
+):
+    """Test integer volume payloads normalize to float for a single API shape."""
+    historical_data = dict(mock_crypto_historical["historical"][0])
+    historical_data["volume"] = 123456789
+    historical_data["unadjustedVolume"] = 123456700
+
+    price = AlternativeHistoricalPrice.model_validate(historical_data)
+
+    assert price.volume == pytest.approx(123456789.0)
+    assert isinstance(price.volume, float)
+    assert price.unadjusted_volume == pytest.approx(123456700.0)
+    assert isinstance(price.unadjusted_volume, float)

--- a/tests/unit/test_alternative.py
+++ b/tests/unit/test_alternative.py
@@ -9,6 +9,9 @@ from fmp_data.alternative.models import (
     CryptoQuote,
     ForexQuote,
 )
+from fmp_data.alternative.models import (
+    HistoricalPrice as AlternativeHistoricalPrice,
+)
 
 
 @pytest.fixture
@@ -159,3 +162,15 @@ def test_crypto_historical_price_model(mock_crypto_historical):
     assert price.change == 1250.00
     assert price.change_percent == 2.85
     assert price.vwap == 44500.00
+
+
+def test_alternative_historical_price_accepts_float_volume(mock_crypto_historical):
+    """Test alternative historical price models accept float volume values."""
+    historical_data = dict(mock_crypto_historical["historical"][0])
+    historical_data["volume"] = 25000000000.75
+    historical_data["unadjustedVolume"] = 24999999999.25
+
+    price = AlternativeHistoricalPrice.model_validate(historical_data)
+
+    assert price.volume == pytest.approx(25000000000.75)
+    assert price.unadjusted_volume == pytest.approx(24999999999.25)

--- a/tests/unit/test_company.py
+++ b/tests/unit/test_company.py
@@ -11,6 +11,7 @@ from fmp_data.company.models import (
     ExecutiveCompensationBenchmark,
     HistoricalData,
     HistoricalPrice,
+    IntradayPrice,
     MergerAcquisition,
     PriceTarget,
     PriceTargetSummary,
@@ -443,6 +444,26 @@ class TestSimpleQuoteModel:
     def test_simple_quote_volume_validator_none(self):
         """Test SimpleQuote volume validator handles None."""
         assert SimpleQuote.coerce_volume_to_int(None) is None
+
+
+class TestIntradayPriceModel:
+    """Tests for intraday price model validation"""
+
+    def test_intraday_price_accepts_float_volume(self):
+        """Test intraday prices accept float volume values from the API."""
+        data = {
+            "date": "2024-01-05T16:00:00",
+            "open": 149.00,
+            "low": 148.50,
+            "high": 151.00,
+            "close": 150.25,
+            "volume": 28541.004200000316,
+        }
+
+        price = IntradayPrice.model_validate(data)
+
+        assert price.volume == pytest.approx(28541.004200000316)
+        assert isinstance(price.volume, float)
 
     def test_simple_quote_volume_validator_string(self):
         """Test SimpleQuote volume validator passes non-numeric values."""

--- a/tests/unit/test_company.py
+++ b/tests/unit/test_company.py
@@ -465,6 +465,22 @@ class TestIntradayPriceModel:
         assert price.volume == pytest.approx(28541.004200000316)
         assert isinstance(price.volume, float)
 
+    def test_intraday_price_normalizes_integer_volume_to_float(self):
+        """Test integer intraday volume payloads normalize to float."""
+        data = {
+            "date": "2024-01-05T16:00:00",
+            "open": 149.00,
+            "low": 148.50,
+            "high": 151.00,
+            "close": 150.25,
+            "volume": 28541,
+        }
+
+        price = IntradayPrice.model_validate(data)
+
+        assert price.volume == pytest.approx(28541.0)
+        assert isinstance(price.volume, float)
+
     def test_simple_quote_volume_validator_string(self):
         """Test SimpleQuote volume validator passes non-numeric values."""
         assert SimpleQuote.coerce_volume_to_int("abc") == "abc"

--- a/tests/unit/test_intelligence.py
+++ b/tests/unit/test_intelligence.py
@@ -188,7 +188,7 @@ class TestMarketIntelligenceClientCalendar:
         result = fmp_client.intelligence.get_earnings_calendar()
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert len(kwargs) == 0  # No date parameters when None
         assert isinstance(result, list)
         assert len(result) == 1
@@ -207,8 +207,7 @@ class TestMarketIntelligenceClientCalendar:
         )
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
-        print(kwargs)
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["start_date"] == "2024-01-01"
         assert kwargs["end_date"] == "2024-01-31"
         assert isinstance(result, list)
@@ -222,7 +221,7 @@ class TestMarketIntelligenceClientCalendar:
         result = fmp_client.intelligence.get_historical_earnings("AAPL")
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["symbol"] == "AAPL"
         assert isinstance(result, list)
 
@@ -237,7 +236,7 @@ class TestMarketIntelligenceClientCalendar:
         )
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["start_date"] == "2024-01-01"
         assert kwargs["end_date"] == "2024-01-31"
         assert isinstance(result, list)
@@ -255,7 +254,7 @@ class TestMarketIntelligenceClientCalendar:
         result = fmp_client.intelligence.get_earnings_surprises("AAPL")
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["symbol"] == "AAPL"
         assert isinstance(result, list)
 
@@ -270,7 +269,7 @@ class TestMarketIntelligenceClientCalendar:
         )
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["start_date"] == "2024-01-01"
         assert kwargs["end_date"] == "2024-01-31"
         assert isinstance(result, list)
@@ -292,7 +291,7 @@ class TestMarketIntelligenceClientCalendar:
         )
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["start_date"] == "2024-01-01"
         assert kwargs["end_date"] == "2024-01-31"
         assert isinstance(result, list)
@@ -306,7 +305,7 @@ class TestMarketIntelligenceClientCalendar:
         )
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["start_date"] == "2024-01-01"
         assert kwargs["end_date"] == "2024-01-31"
         assert isinstance(result, list)
@@ -349,7 +348,7 @@ class TestMarketIntelligenceClientNews:
         result = fmp_client.intelligence.get_fmp_articles()
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["page"] == 0
         assert kwargs["limit"] == 20
         assert isinstance(result, list)
@@ -362,7 +361,7 @@ class TestMarketIntelligenceClientNews:
         _ = fmp_client.intelligence.get_fmp_articles(page=1, limit=10)
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["page"] == 1
         assert kwargs["limit"] == 10
 
@@ -401,7 +400,7 @@ class TestMarketIntelligenceClientNews:
         result = fmp_client.intelligence.get_general_news(page=0)
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["page"] == 0
         assert kwargs["limit"] == 20
         assert isinstance(result, list)
@@ -426,7 +425,7 @@ class TestMarketIntelligenceClientNews:
         )
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["page"] == 1
         assert kwargs["start_date"] == "2024-01-01"
         assert kwargs["end_date"] == "2024-01-31"
@@ -444,7 +443,7 @@ class TestMarketIntelligenceClientNews:
         )
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["page"] == 1
         assert kwargs["start_date"] == "2024-01-01"
         assert kwargs["end_date"] == "2024-01-31"
@@ -457,7 +456,7 @@ class TestMarketIntelligenceClientNews:
         _ = fmp_client.intelligence.get_stock_news("AAPL")
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["start_date"] is None
         assert kwargs["end_date"] is None
 
@@ -506,7 +505,7 @@ class TestMarketIntelligenceClientNews:
         )
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["start_date"] == "2024-01-01"
         assert kwargs["end_date"] == "2024-01-31"
         assert kwargs["limit"] == 25
@@ -533,7 +532,7 @@ class TestMarketIntelligenceClientNews:
         )
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["symbol"] == "EURUSD"
         assert kwargs["start_date"] == "2024-01-01"
         assert kwargs["end_date"] == "2024-01-31"
@@ -560,7 +559,7 @@ class TestMarketIntelligenceClientNews:
         )
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["start_date"] == "2024-01-01"
         assert kwargs["end_date"] == "2024-01-31"
         assert kwargs["limit"] == 20
@@ -587,7 +586,7 @@ class TestMarketIntelligenceClientNews:
         )
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["symbol"] == "BTCUSD"
         assert kwargs["start_date"] == "2024-01-01"
         assert kwargs["end_date"] == "2024-01-31"
@@ -615,7 +614,7 @@ class TestMarketIntelligenceClientPressReleases:
         )
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["page"] == 0
         assert kwargs["start_date"] == "2024-01-01"
         assert kwargs["end_date"] == "2024-01-31"
@@ -640,7 +639,7 @@ class TestMarketIntelligenceClientPressReleases:
         )
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["symbol"] == "AAPL"
         assert kwargs["page"] == 1
         assert kwargs["start_date"] == "2024-01-01"
@@ -690,7 +689,7 @@ class TestMarketIntelligenceClientSocialSentiment:
         result = fmp_client.intelligence.get_esg_benchmark()
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert "year" not in kwargs
         assert isinstance(result, list)
         assert len(result) == 1
@@ -709,7 +708,7 @@ class TestMarketIntelligenceClientESG:
         result = fmp_client.intelligence.get_esg_data("AAPL")
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["symbol"] == "AAPL"
         assert isinstance(result, ESGData)
         assert result.symbol == "AAPL"
@@ -732,7 +731,7 @@ class TestMarketIntelligenceClientESG:
         result = fmp_client.intelligence.get_esg_ratings("AAPL")
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["symbol"] == "AAPL"
         assert isinstance(result, ESGRating)
 
@@ -752,7 +751,7 @@ class TestMarketIntelligenceClientESG:
         _ = fmp_client.intelligence.get_esg_benchmark()
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert "year" not in kwargs
 
 
@@ -783,7 +782,7 @@ class TestMarketIntelligenceClientGovernment:
         _ = fmp_client.intelligence.get_senate_latest(page=0, limit=100)
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["page"] == 0
         assert kwargs["limit"] == 100
 
@@ -809,7 +808,7 @@ class TestMarketIntelligenceClientGovernment:
         _ = fmp_client.intelligence.get_senate_trading("AAPL")
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["symbol"] == "AAPL"
 
     def test_get_senate_trades_by_name(self, fmp_client, mock_client):
@@ -819,7 +818,7 @@ class TestMarketIntelligenceClientGovernment:
         _ = fmp_client.intelligence.get_senate_trades_by_name("Jerry")
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["name"] == "Jerry"
 
     def test_get_senate_trading_rss(self, fmp_client, mock_client):
@@ -829,7 +828,7 @@ class TestMarketIntelligenceClientGovernment:
         _ = fmp_client.intelligence.get_senate_trading_rss(page=0)
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["page"] == 0
 
     def test_get_house_latest(self, fmp_client, mock_client):
@@ -856,7 +855,7 @@ class TestMarketIntelligenceClientGovernment:
         _ = fmp_client.intelligence.get_house_latest(page=0, limit=100)
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["page"] == 0
         assert kwargs["limit"] == 100
 
@@ -882,7 +881,7 @@ class TestMarketIntelligenceClientGovernment:
         _ = fmp_client.intelligence.get_house_disclosure("AAPL")
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["symbol"] == "AAPL"
 
     def test_get_house_trades_by_name(self, fmp_client, mock_client):
@@ -892,7 +891,7 @@ class TestMarketIntelligenceClientGovernment:
         _ = fmp_client.intelligence.get_house_trades_by_name("James")
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["name"] == "James"
 
 
@@ -943,7 +942,7 @@ class TestMarketIntelligenceClientFundraising:
         result = fmp_client.intelligence.get_crowdfunding_rss(page=0, limit=100)
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["page"] == 0
         assert kwargs["limit"] == 100
         assert isinstance(result, list)
@@ -961,7 +960,7 @@ class TestMarketIntelligenceClientFundraising:
         result = fmp_client.intelligence.search_crowdfunding("startup")
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["name"] == "startup"
         assert isinstance(result, list)
         assert isinstance(result[0], CrowdfundingOfferingSearchItem)
@@ -973,7 +972,7 @@ class TestMarketIntelligenceClientFundraising:
         _ = fmp_client.intelligence.get_crowdfunding_by_cik("0001234567")
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["cik"] == "0001234567"
 
     def test_get_equity_offering_rss(self, fmp_client, mock_client):
@@ -1024,7 +1023,7 @@ class TestMarketIntelligenceClientFundraising:
         result = fmp_client.intelligence.get_equity_offering_rss(page=0, limit=10)
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["page"] == 0
         assert kwargs["limit"] == 10
         assert isinstance(result, list)
@@ -1043,7 +1042,7 @@ class TestMarketIntelligenceClientFundraising:
         result = fmp_client.intelligence.search_equity_offering("company")
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["name"] == "company"
         assert isinstance(result, list)
         assert isinstance(result[0], EquityOfferingSearchItem)
@@ -1055,7 +1054,7 @@ class TestMarketIntelligenceClientFundraising:
         _ = fmp_client.intelligence.get_equity_offering_by_cik("0001234567")
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["cik"] == "0001234567"
 
 
@@ -1080,7 +1079,7 @@ class TestMarketIntelligenceClientEdgeCases:
         fmp_client.intelligence.get_stock_news("AAPL", from_date=None, to_date=None)
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["start_date"] is None
         assert kwargs["end_date"] is None
 
@@ -1107,7 +1106,7 @@ class TestMarketIntelligenceClientEdgeCases:
         )
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["start_date"] == "2024-12-31"
         assert kwargs["end_date"] == "2024-01-01"
 
@@ -1133,7 +1132,7 @@ class TestMarketIntelligenceClientEdgeCases:
         )
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["page"] is None
         assert kwargs["start_date"] is None
         assert kwargs["end_date"] is None
@@ -1170,7 +1169,7 @@ class TestMarketIntelligenceClientAnalyst:
         result = fmp_client.intelligence.get_ratings_snapshot("AAPL")
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["symbol"] == "AAPL"
         assert isinstance(result, RatingsSnapshot)
         assert result.symbol == "AAPL"
@@ -1231,7 +1230,7 @@ class TestMarketIntelligenceClientAnalyst:
         result = fmp_client.intelligence.get_ratings_historical("AAPL", limit=50)
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["symbol"] == "AAPL"
         assert kwargs["limit"] == 50
         assert isinstance(result, list)
@@ -1258,7 +1257,7 @@ class TestMarketIntelligenceClientAnalyst:
         result = fmp_client.intelligence.get_price_target_news("AAPL", page=1)
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["symbol"] == "AAPL"
         assert kwargs["page"] == 1
         assert isinstance(result, list)
@@ -1284,7 +1283,7 @@ class TestMarketIntelligenceClientAnalyst:
         result = fmp_client.intelligence.get_price_target_latest_news(page=0)
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["page"] == 0
         assert isinstance(result, list)
 
@@ -1308,7 +1307,7 @@ class TestMarketIntelligenceClientAnalyst:
         result = fmp_client.intelligence.get_grades("AAPL", page=2)
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["symbol"] == "AAPL"
         assert kwargs["page"] == 2
         assert isinstance(result, list)
@@ -1334,7 +1333,7 @@ class TestMarketIntelligenceClientAnalyst:
         result = fmp_client.intelligence.get_grades_historical("AAPL", limit=200)
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["symbol"] == "AAPL"
         assert kwargs["limit"] == 200
         assert isinstance(result, list)
@@ -1356,7 +1355,7 @@ class TestMarketIntelligenceClientAnalyst:
         result = fmp_client.intelligence.get_grades_consensus("AAPL")
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["symbol"] == "AAPL"
         assert isinstance(result, StockGradesConsensus)
         assert result.consensus == "Buy"
@@ -1400,7 +1399,7 @@ class TestMarketIntelligenceClientAnalyst:
         result = fmp_client.intelligence.get_grades_news("AAPL", page=1)
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["symbol"] == "AAPL"
         assert kwargs["page"] == 1
         assert isinstance(result, list)
@@ -1426,7 +1425,7 @@ class TestMarketIntelligenceClientAnalyst:
         result = fmp_client.intelligence.get_grades_latest_news(page=0)
 
         mock_client.request.assert_called_once()
-        args, kwargs = mock_client.request.call_args
+        _args, kwargs = mock_client.request.call_args
         assert kwargs["page"] == 0
         assert isinstance(result, list)
         assert result[0].symbol == "MSFT"

--- a/tests/unit/test_mcp.py
+++ b/tests/unit/test_mcp.py
@@ -100,7 +100,7 @@ class TestToolLoader:
         # Ensure the attribute really doesn't exist
         del test_obj.client.missing_method
 
-        with pytest.raises(RuntimeError, match="Attribute chain .* failed"):
+        with pytest.raises(RuntimeError, match=r"Attribute chain .* failed"):
             _resolve_attr(test_obj, "client.missing_method")
 
     def test_resolve_attr_not_callable(self):
@@ -110,7 +110,7 @@ class TestToolLoader:
         mock_obj = Mock()
         mock_obj.client.data = "not_callable"
 
-        with pytest.raises(RuntimeError, match=".* is not callable"):
+        with pytest.raises(RuntimeError, match=r".* is not callable"):
             _resolve_attr(mock_obj, "client.data")
 
     @patch("fmp_data.mcp.tool_loader.importlib.import_module")
@@ -132,7 +132,7 @@ class TestToolLoader:
         mock_module = Mock(spec=[])  # Empty spec means no attributes
         mock_import.return_value = mock_module
 
-        with pytest.raises(RuntimeError, match="lacks.*ENDPOINTS_SEMANTICS"):
+        with pytest.raises(RuntimeError, match=r"lacks.*ENDPOINTS_SEMANTICS"):
             _load_semantics("company", "profile")
 
     def test_register_from_manifest_duplicate_keys_raises(self):


### PR DESCRIPTION
## Summary
- sync `main` back into `dev` so release workflow changes stay aligned
- pull in PRs #88 and #89 to update `actions/deploy-pages` to `v5.0.0` and `codecov/codecov-action` to `v6.0.0`
- pull in PR #90 to accept fractional volume values in `alternative.HistoricalPrice` and `company.IntradayPrice`
- add unit and integration regression coverage for the float-volume paths
- update `CHANGELOG.md` for the pending patch release

## Validation
- `uv run pytest tests/unit/test_alternative.py tests/unit/test_company.py`
- `uv run pytest tests/integration/test_company.py -k intraday`
- `uv run mypy fmp_data`
- `uv run pytest -q`
- git hooks passed during commit (`black`, `ruff`, `detect-secrets`, `mypy: core package`)

## Notes
- verified upstream action releases before merging: `actions/deploy-pages@v5.0.0`, `codecov/codecov-action@v6.0.0`
- full-project `ruff check .` / `ruff format --check .` still report unrelated pre-existing issues outside this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Volume fields in pricing models now consistently use float to normalize API responses.

* **Bug Fixes**
  * Quote volume fields accept null values.
  * Volume validation now handles fractional inputs without errors.

* **Chores**
  * Updated CI workflow action pins and raised dependency minimums.

* **Documentation**
  * New “Launch Notes” and updated contributing docs describing the versioning labels and volume behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->