### PR TITLE
fix(base): redact API key from error tracebacks

### DIFF
--- a/fmp_data/base.py
+++ b/fmp_data/base.py
@@ -564,27 +564,27 @@ class BaseClient:
                 status_code=429,
                 response=error_details,
                 retry_after=wait_time,
-            ) from error
+            ) from None
 
         if status_code == 401:
             raise AuthenticationError(
                 "Invalid API key or authentication failed",
                 status_code=401,
                 response=error_details,
-            ) from error
+            ) from None
 
         if status_code == 400:
             raise ValidationError(
                 f"Invalid request parameters: {error_details}",
                 status_code=400,
                 response=error_details,
-            ) from error
+            ) from None
 
         raise FMPError(
             f"HTTP {status_code} error occurred: {error_details}",
             status_code=status_code,
             response=error_details,
-        ) from error
+        ) from None
 
     @staticmethod
     def _check_error_response(data: dict[str, Any]) -> None:

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -1,4 +1,5 @@
 import json
+import traceback
 from unittest.mock import MagicMock, Mock, patch
 
 import httpx
@@ -271,6 +272,33 @@ def test_handle_http_status_error_uses_retry_after_header(base_client):
         base_client._handle_http_status_error(error)
 
     assert exc_info.value.retry_after == 12.0
+
+
+def test_handle_http_status_error_redacts_chained_apikey_traceback(base_client):
+    """Test 429 tracebacks do not expose the API key query parameter."""
+    marker = "TRACEBACK_REDACTION_SENTINEL"
+    request = httpx.Request(
+        "GET",
+        f"https://financialmodelingprep.com/stable/quote?symbol=AAPL&apikey={marker}",
+    )
+    response = httpx.Response(
+        429,
+        request=request,
+        json={"message": "Rate limit exceeded"},
+    )
+
+    try:
+        base_client.handle_response(response)
+    except RateLimitError as exc:
+        formatted_traceback = traceback.format_exc()
+        assert "apikey=" not in formatted_traceback
+        assert marker not in formatted_traceback
+        assert "apikey=" not in str(exc)
+        assert marker not in str(exc)
+        assert exc.__cause__ is None
+        assert exc.__suppress_context__ is True
+    else:
+        pytest.fail("Expected RateLimitError")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Suppress raw httpx HTTPStatusError context when raising typed fmp_data HTTP errors so tracebacks do not expose apikey query params.
- Add a 429 regression test covering formatted traceback and str(exc) redaction.

## Validation
- uv run pytest tests/unit/test_base.py
- uv run ruff check tests/unit/test_base.py
- uv run ruff format --check tests/unit/test_base.py
- make check

Closes #94