### PR TITLE
[codex] Redact FMP http status errors

### DIFF
--- a/fmp_data/base.py
+++ b/fmp_data/base.py
@@ -6,8 +6,9 @@ from contextvars import ContextVar
 import copy
 import json
 import logging
+import re
 import time
-from typing import Any, Literal, TypeGuard, TypeVar, cast, overload
+from typing import Any, Literal, NoReturn, TypeGuard, TypeVar, cast, overload
 import warnings
 
 import httpx
@@ -46,10 +47,48 @@ _rate_limit_retry_count: ContextVar[int] = ContextVar(
     "rate_limit_retry_count", default=0
 )
 _extra_field_warnings_seen: set[tuple[str, tuple[str, ...]]] = set()
+_API_KEY_ASSIGNMENT_RE = re.compile(
+    r"([\"']?api_?key[\"']?\s*[=:]\s*[\"']?)([^&\s\"'<>]+)([\"']?)",
+    re.IGNORECASE,
+)
+_API_KEY_ENCODED_RE = re.compile(r"(apikey%3[Dd])([^&\s\"'<>]+)", re.IGNORECASE)
 
 
 def _is_pydantic_model(model: type[Any]) -> TypeGuard[type[BaseModel]]:
     return isinstance(model, type) and issubclass(model, BaseModel)
+
+
+def _redact_api_keys(text: str) -> str:
+    """Redact API key values in common URL, encoded URL, and JSON forms."""
+    redacted = _API_KEY_ASSIGNMENT_RE.sub(r"\1[REDACTED]\3", text)
+    return _API_KEY_ENCODED_RE.sub(r"\1[REDACTED]", redacted)
+
+
+def _sanitize_error_details(
+    value: dict[str, Any] | list[Any] | str,
+) -> dict[str, Any] | list[Any] | str:
+    if isinstance(value, str):
+        return _redact_api_keys(value)
+    if isinstance(value, list):
+        return [_sanitize_error_value(item) for item in value]
+    return {
+        key: (
+            "[REDACTED]"
+            if key.lower() in {"apikey", "api_key", "api-key"}
+            else _sanitize_error_value(item)
+        )
+        for key, item in value.items()
+    }
+
+
+def _sanitize_error_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return _sanitize_error_details(value)
+    if isinstance(value, list):
+        return [_sanitize_error_value(item) for item in value]
+    if isinstance(value, str):
+        return _redact_api_keys(value)
+    return value
 
 
 class BaseClient:
@@ -387,7 +426,7 @@ class BaseClient:
             try:
                 data: bytes | dict[str, Any] | list[Any]
                 if endpoint.response_model is bytes:
-                    response.raise_for_status()
+                    self._raise_response_for_status(response)
                     data = response.content
                 else:
                     data = self.handle_response(endpoint, response)
@@ -498,6 +537,16 @@ class BaseClient:
             )
         return cast(dict[str, Any] | list[Any], data)
 
+    def _raise_response_for_status(self, response: httpx.Response) -> None:
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            self._raise_fmp_http_error(
+                exc,
+                self._get_error_details(exc.response),
+                exc.response.status_code,
+            )
+
     @staticmethod
     def _get_error_details(
         response: httpx.Response,
@@ -505,10 +554,10 @@ class BaseClient:
         try:
             data = response.json()
         except json.JSONDecodeError:
-            return {"raw_content": response.content.decode()}
+            return {"raw_content": _redact_api_keys(response.content.decode())}
         if isinstance(data, dict | list):
-            return data
-        return {"raw_content": str(data)}
+            return cast(dict[str, Any] | list[Any], _sanitize_error_details(data))
+        return {"raw_content": _redact_api_keys(str(data))}
 
     def _handle_http_status_error(
         self,
@@ -551,6 +600,14 @@ class BaseClient:
                 )
                 return {}
 
+        self._raise_fmp_http_error(error, error_details, status_code)
+
+    def _raise_fmp_http_error(
+        self,
+        error: httpx.HTTPStatusError,
+        error_details: dict[str, Any] | list[Any],
+        status_code: int,
+    ) -> NoReturn:
         if status_code == 429:
             self._rate_limiter.handle_response(status_code, error.response.text)
             retry_after = self._rate_limiter.get_retry_after(error.response.headers)
@@ -564,27 +621,27 @@ class BaseClient:
                 status_code=429,
                 response=error_details,
                 retry_after=wait_time,
-            ) from error
+            ) from None
 
         if status_code == 401:
             raise AuthenticationError(
                 "Invalid API key or authentication failed",
                 status_code=401,
                 response=error_details,
-            ) from error
+            ) from None
 
         if status_code == 400:
             raise ValidationError(
                 f"Invalid request parameters: {error_details}",
                 status_code=400,
                 response=error_details,
-            ) from error
+            ) from None
 
         raise FMPError(
             f"HTTP {status_code} error occurred: {error_details}",
             status_code=status_code,
             response=error_details,
-        ) from error
+        ) from None
 
     @staticmethod
     def _check_error_response(data: dict[str, Any]) -> None:
@@ -902,7 +959,7 @@ class BaseClient:
             try:
                 data: bytes | dict[str, Any] | list[Any]
                 if endpoint.response_model is bytes:
-                    response.raise_for_status()
+                    self._raise_response_for_status(response)
                     data = response.content
                 else:
                     data = self.handle_response(endpoint, response)

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -1,4 +1,5 @@
 import json
+import traceback
 from unittest.mock import MagicMock, Mock, patch
 
 import httpx
@@ -238,6 +239,24 @@ def test_get_error_details_json_decode_error():
     assert details == {"raw_content": "not json"}
 
 
+def test_get_error_details_redacts_api_keys():
+    """Error details should not preserve reflected API keys."""
+    fake_key_value = "SECRET_FMP_KEY"
+    response = Mock()
+    response.json.return_value = {
+        "url": f"https://example.test/path?apikey={fake_key_value}&symbol=AAPL",
+        "encoded": f"apikey%3D{fake_key_value}%26symbol%3DAAPL",
+        "apikey": fake_key_value,
+        "nested": [{"message": f'apikey="{fake_key_value}"'}],
+    }
+
+    details = BaseClient._get_error_details(response)
+
+    rendered = repr(details)
+    assert fake_key_value not in rendered
+    assert "[REDACTED]" in rendered
+
+
 def test_handle_http_status_error_404_empty_payloads(base_client):
     """Test 404 errors return empty payloads without raising."""
     request = httpx.Request("GET", "https://example.com")
@@ -271,6 +290,64 @@ def test_handle_http_status_error_uses_retry_after_header(base_client):
         base_client._handle_http_status_error(error)
 
     assert exc_info.value.retry_after == 12.0
+
+
+def test_handle_response_error_traceback_redacts_httpx_request_url(base_client):
+    """HTTP error handling should not chain tracebacks that expose API keys."""
+    fake_key_value = "SECRET_FMP_KEY"
+    request = httpx.Request(
+        "GET",
+        f"https://financialmodelingprep.com/stable/profile?apikey={fake_key_value}&symbol=AAPL",
+    )
+    response = httpx.Response(
+        401,
+        request=request,
+        json={"message": "Invalid API key"},
+    )
+
+    with pytest.raises(AuthenticationError) as exc_info:
+        base_client.handle_response(response)
+
+    exc = exc_info.value
+    rendered = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+    assert exc.__cause__ is None
+    assert exc.__suppress_context__ is True
+    assert fake_key_value not in rendered
+    assert "HTTPStatusError" not in rendered
+
+
+def test_bytes_response_http_error_uses_redacted_fmp_exception(
+    base_client, mock_endpoint
+):
+    """Binary endpoints should not re-raise raw httpx status errors."""
+    fake_key_value = "SECRET_FMP_KEY"
+    request = httpx.Request(
+        "GET",
+        f"https://financialmodelingprep.com/stable/download?apikey={fake_key_value}",
+    )
+    response = httpx.Response(
+        401,
+        request=request,
+        json={"message": "Invalid API key"},
+    )
+    mock_endpoint.method.value = "GET"
+    mock_endpoint.build_url.return_value = (
+        "https://financialmodelingprep.com/stable/download"
+    )
+    mock_endpoint.response_model = bytes
+
+    with (
+        patch.object(base_client.client, "request", return_value=response),
+        pytest.raises(AuthenticationError) as exc_info,
+    ):
+        base_client._execute_request(mock_endpoint)
+
+    exc = exc_info.value
+    rendered = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+    assert exc.__cause__ is None
+    assert exc.__suppress_context__ is True
+    assert fake_key_value not in rendered
+    assert "HTTPStatusError" not in rendered
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- redact FMP API keys from reflected HTTP error detail payloads
- stop chaining typed FMP status exceptions from raw httpx.HTTPStatusError objects
- route binary response status failures through the same typed FMP error handler
- add regression coverage for traceback redaction across JSON and binary response paths

## Root Cause

httpx.HTTPStatusError includes the full request URL in its string representation. The client raised typed FMP exceptions with the original HTTPStatusError as the cause, so tracebacks could include URLs with the apikey query parameter.

## Validation

- uv run pytest tests/unit/test_base.py
- uv run ruff format --check fmp_data/base.py tests/unit/test_base.py
- uv run ruff check fmp_data/base.py tests/unit/test_base.py
- uv run mypy fmp_data
- .venv/bin/pre-commit run --files fmp_data/base.py tests/unit/test_base.py
- make check

Fixes #94


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API keys and sensitive credentials are now automatically redacted from all error messages and exception traces to prevent accidental exposure.
  * Improved error sanitization to remove sensitive data from HTTP error responses.

* **Tests**
  * Added comprehensive tests to ensure sensitive information is properly redacted and not exposed during error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->