### PR TITLE
fix(client): redact FMP http status errors

### DIFF
--- a/fmp_data/base.py
+++ b/fmp_data/base.py
@@ -6,8 +6,9 @@ from contextvars import ContextVar
 import copy
 import json
 import logging
+import re
 import time
-from typing import Any, Literal, TypeGuard, TypeVar, cast, overload
+from typing import Any, Literal, NoReturn, TypeGuard, TypeVar, cast, overload
 import warnings
 
 import httpx
@@ -46,10 +47,48 @@ _rate_limit_retry_count: ContextVar[int] = ContextVar(
     "rate_limit_retry_count", default=0
 )
 _extra_field_warnings_seen: set[tuple[str, tuple[str, ...]]] = set()
+_API_KEY_ASSIGNMENT_RE = re.compile(
+    r"([\"']?api_?key[\"']?\s*[=:]\s*[\"']?)([^&\s\"'<>]+)([\"']?)",
+    re.IGNORECASE,
+)
+_API_KEY_ENCODED_RE = re.compile(r"(apikey%3[Dd])([^&\s\"'<>]+)", re.IGNORECASE)
 
 
 def _is_pydantic_model(model: type[Any]) -> TypeGuard[type[BaseModel]]:
     return isinstance(model, type) and issubclass(model, BaseModel)
+
+
+def _redact_api_keys(text: str) -> str:
+    """Redact API key values in common URL, encoded URL, and JSON forms."""
+    redacted = _API_KEY_ASSIGNMENT_RE.sub(r"\1[REDACTED]\3", text)
+    return _API_KEY_ENCODED_RE.sub(r"\1[REDACTED]", redacted)
+
+
+def _sanitize_error_details(
+    value: dict[str, Any] | list[Any] | str,
+) -> dict[str, Any] | list[Any] | str:
+    if isinstance(value, str):
+        return _redact_api_keys(value)
+    if isinstance(value, list):
+        return [_sanitize_error_value(item) for item in value]
+    return {
+        key: (
+            "[REDACTED]"
+            if key.lower() in {"apikey", "api_key", "api-key"}
+            else _sanitize_error_value(item)
+        )
+        for key, item in value.items()
+    }
+
+
+def _sanitize_error_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return _sanitize_error_details(value)
+    if isinstance(value, list):
+        return [_sanitize_error_value(item) for item in value]
+    if isinstance(value, str):
+        return _redact_api_keys(value)
+    return value
 
 
 class BaseClient:
@@ -387,7 +426,7 @@ class BaseClient:
             try:
                 data: bytes | dict[str, Any] | list[Any]
                 if endpoint.response_model is bytes:
-                    response.raise_for_status()
+                    self._raise_response_for_status(response)
                     data = response.content
                 else:
                     data = self.handle_response(endpoint, response)
@@ -498,6 +537,16 @@ class BaseClient:
             )
         return cast(dict[str, Any] | list[Any], data)
 
+    def _raise_response_for_status(self, response: httpx.Response) -> None:
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            self._raise_fmp_http_error(
+                exc,
+                self._get_error_details(exc.response),
+                exc.response.status_code,
+            )
+
     @staticmethod
     def _get_error_details(
         response: httpx.Response,
@@ -505,10 +554,10 @@ class BaseClient:
         try:
             data = response.json()
         except json.JSONDecodeError:
-            return {"raw_content": response.content.decode()}
+            return {"raw_content": _redact_api_keys(response.content.decode())}
         if isinstance(data, dict | list):
-            return data
-        return {"raw_content": str(data)}
+            return cast(dict[str, Any] | list[Any], _sanitize_error_details(data))
+        return {"raw_content": _redact_api_keys(str(data))}
 
     def _handle_http_status_error(
         self,
@@ -551,6 +600,14 @@ class BaseClient:
                 )
                 return {}
 
+        self._raise_fmp_http_error(error, error_details, status_code)
+
+    def _raise_fmp_http_error(
+        self,
+        error: httpx.HTTPStatusError,
+        error_details: dict[str, Any] | list[Any],
+        status_code: int,
+    ) -> NoReturn:
         if status_code == 429:
             self._rate_limiter.handle_response(status_code, error.response.text)
             retry_after = self._rate_limiter.get_retry_after(error.response.headers)
@@ -564,27 +621,27 @@ class BaseClient:
                 status_code=429,
                 response=error_details,
                 retry_after=wait_time,
-            ) from error
+            ) from None
 
         if status_code == 401:
             raise AuthenticationError(
                 "Invalid API key or authentication failed",
                 status_code=401,
                 response=error_details,
-            ) from error
+            ) from None
 
         if status_code == 400:
             raise ValidationError(
                 f"Invalid request parameters: {error_details}",
                 status_code=400,
                 response=error_details,
-            ) from error
+            ) from None
 
         raise FMPError(
             f"HTTP {status_code} error occurred: {error_details}",
             status_code=status_code,
             response=error_details,
-        ) from error
+        ) from None
 
     @staticmethod
     def _check_error_response(data: dict[str, Any]) -> None:
@@ -902,7 +959,7 @@ class BaseClient:
             try:
                 data: bytes | dict[str, Any] | list[Any]
                 if endpoint.response_model is bytes:
-                    response.raise_for_status()
+                    self._raise_response_for_status(response)
                     data = response.content
                 else:
                     data = self.handle_response(endpoint, response)

--- a/fmp_data/base.py
+++ b/fmp_data/base.py
@@ -59,7 +59,12 @@ def _is_pydantic_model(model: type[Any]) -> TypeGuard[type[BaseModel]]:
 
 
 def _redact_api_keys(text: str) -> str:
-    """Redact API key values in common URL, encoded URL, and JSON forms."""
+    """Redact apikey/api_key values embedded in free-form strings.
+
+    Handles common query-string, percent-encoded (``apikey%3D``), and
+    assignment/JSON-text patterns. For structured dict payloads, use
+    :func:`_sanitize_error_details` (also redacts ``api-key`` keys by name).
+    """
     redacted = _API_KEY_ASSIGNMENT_RE.sub(r"\1[REDACTED]\3", text)
     return _API_KEY_ENCODED_RE.sub(r"\1[REDACTED]", redacted)
 
@@ -67,6 +72,7 @@ def _redact_api_keys(text: str) -> str:
 def _sanitize_error_details(
     value: dict[str, Any] | list[Any] | str,
 ) -> dict[str, Any] | list[Any] | str:
+    """Recursively redact API keys from error payloads that may reflect them."""
     if isinstance(value, str):
         return _redact_api_keys(value)
     if isinstance(value, list):
@@ -82,6 +88,7 @@ def _sanitize_error_details(
 
 
 def _sanitize_error_value(value: Any) -> Any:
+    """Sanitize a single error-payload value (dict, list, string, or other)."""
     if isinstance(value, dict):
         return _sanitize_error_details(value)
     if isinstance(value, list):
@@ -315,6 +322,13 @@ class BaseClient:
             return True
         if isinstance(exc, RateLimitError):
             return True
+        # Mapped FMP errors from status conversion (incl. binary endpoints).
+        if (
+            isinstance(exc, FMPError)
+            and exc.status_code is not None
+            and exc.status_code >= 500
+        ):
+            return True
         if isinstance(exc, httpx.HTTPStatusError):
             return exc.response.status_code >= 500
         return False
@@ -538,12 +552,17 @@ class BaseClient:
         return cast(dict[str, Any] | list[Any], data)
 
     def _raise_response_for_status(self, response: httpx.Response) -> None:
+        """Raise typed FMP errors for non-success binary responses.
+
+        Binary endpoints must not re-raise raw ``httpx.HTTPStatusError``:
+        that type stringifies the request URL, which often includes ``apikey``.
+        """
         try:
             response.raise_for_status()
         except httpx.HTTPStatusError as exc:
             self._raise_fmp_http_error(
                 exc,
-                self._get_error_details(exc.response),
+                self._safe_error_details(exc.response),
                 exc.response.status_code,
             )
 
@@ -551,13 +570,26 @@ class BaseClient:
     def _get_error_details(
         response: httpx.Response,
     ) -> dict[str, Any] | list[Any]:
+        """Return response body for error reporting with API keys redacted."""
         try:
             data = response.json()
-        except json.JSONDecodeError:
-            return {"raw_content": _redact_api_keys(response.content.decode())}
+        except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
+            raw = response.content.decode("utf-8", errors="replace")
+            return {"raw_content": _redact_api_keys(raw)}
         if isinstance(data, dict | list):
             return cast(dict[str, Any] | list[Any], _sanitize_error_details(data))
         return {"raw_content": _redact_api_keys(str(data))}
+
+    @classmethod
+    def _safe_error_details(
+        cls,
+        response: httpx.Response,
+    ) -> dict[str, Any] | list[Any]:
+        """Best-effort error details; never fail open to unreadable bodies."""
+        try:
+            return cls._get_error_details(response)
+        except Exception:
+            return {"raw_content": "[unreadable error body]"}
 
     def _handle_http_status_error(
         self,
@@ -573,7 +605,7 @@ class BaseClient:
                     "_handle_http_status_error() missing required error argument"
                 )
 
-        error_details = self._get_error_details(error.response)
+        error_details = self._safe_error_details(error.response)
         status_code = error.response.status_code
 
         if status_code == 404:
@@ -608,8 +640,16 @@ class BaseClient:
         error_details: dict[str, Any] | list[Any],
         status_code: int,
     ) -> NoReturn:
+        """Map HTTP status errors to FMP exceptions without chaining httpx.
+
+        ``from None`` is intentional: ``httpx.HTTPStatusError`` stringifies the
+        request URL (often including ``apikey``), so chaining would leak keys
+        into formatted tracebacks.
+        """
         if status_code == 429:
-            self._rate_limiter.handle_response(status_code, error.response.text)
+            self._rate_limiter.handle_response(
+                status_code, _redact_api_keys(error.response.text)
+            )
             retry_after = self._rate_limiter.get_retry_after(error.response.headers)
             wait_time = (
                 retry_after

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -6,7 +6,12 @@ import httpx
 from pydantic import BaseModel, ConfigDict
 import pytest
 
-from fmp_data.base import BaseClient, EndpointGroup
+from fmp_data.base import (
+    BaseClient,
+    EndpointGroup,
+    _sanitize_error_details,
+    _sanitize_error_value,
+)
 from fmp_data.config import ClientConfig
 from fmp_data.exceptions import (
     AuthenticationError,
@@ -295,6 +300,50 @@ def test_get_error_details_handles_non_utf8_body():
     assert isinstance(details["raw_content"], str)
 
 
+def test_sanitize_error_details_top_level_string_and_list():
+    """Sanitize helpers should handle top-level string and list payloads."""
+    fake_key_value = "SECRET_FMP_KEY"
+    redacted_str = _sanitize_error_details(f"apikey={fake_key_value}")
+    assert fake_key_value not in redacted_str
+    assert "[REDACTED]" in redacted_str
+
+    redacted_list = _sanitize_error_details(
+        [f"apikey={fake_key_value}", {"count": 1, "api-key": fake_key_value}]
+    )
+    assert fake_key_value not in repr(redacted_list)
+    assert redacted_list[1]["count"] == 1
+    assert redacted_list[1]["api-key"] == "[REDACTED]"
+
+
+def test_sanitize_error_value_preserves_non_string_scalars():
+    """Non-string scalar values should pass through sanitization unchanged."""
+    assert _sanitize_error_value(42) == 42
+    assert _sanitize_error_value(None) is None
+    assert _sanitize_error_value(True) is True
+    assert _sanitize_error_value(3.14) == 3.14
+
+    nested = _sanitize_error_details(
+        {"code": 401, "ok": False, "retries": None, "items": [1, True, None]}
+    )
+    assert nested == {
+        "code": 401,
+        "ok": False,
+        "retries": None,
+        "items": [1, True, None],
+    }
+
+
+def test_safe_error_details_fallback_when_extraction_raises():
+    """Unreadable bodies should fall back without propagating extraction errors."""
+    response = Mock()
+    with patch.object(
+        BaseClient, "_get_error_details", side_effect=RuntimeError("boom")
+    ):
+        details = BaseClient._safe_error_details(response)
+
+    assert details == {"raw_content": "[unreadable error body]"}
+
+
 def test_handle_http_status_error_404_empty_payloads(base_client):
     """Test 404 errors return empty payloads without raising."""
     request = httpx.Request("GET", "https://example.com")
@@ -309,6 +358,38 @@ def test_handle_http_status_error_404_empty_payloads(base_client):
         "Not found", request=request, response=dict_response
     )
     assert base_client._handle_http_status_error(dict_error) == {}
+
+
+def test_handle_http_status_error_allow_empty_on_404(base_client, mock_endpoint):
+    """Endpoints with allow_empty_on_404 should return [] on 404."""
+    request = httpx.Request("GET", "https://example.com")
+    response = httpx.Response(404, request=request, json={"message": "missing"})
+    error = httpx.HTTPStatusError("Not found", request=request, response=response)
+    mock_endpoint.allow_empty_on_404 = True
+    mock_endpoint.name = "sample-endpoint"
+
+    result = base_client._handle_http_status_error(mock_endpoint, error)
+
+    assert result == []
+
+
+def test_handle_http_status_error_404_non_empty_raises(base_client):
+    """404 with a non-empty payload should raise a typed FMP error."""
+    request = httpx.Request("GET", "https://example.com")
+    response = httpx.Response(404, request=request, json={"message": "missing"})
+    error = httpx.HTTPStatusError("Not found", request=request, response=response)
+
+    with pytest.raises(FMPError) as exc_info:
+        base_client._handle_http_status_error(error)
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.__cause__ is None
+
+
+def test_handle_http_status_error_requires_error_argument(base_client):
+    """Missing error argument should raise TypeError."""
+    with pytest.raises(TypeError, match="missing required error argument"):
+        base_client._handle_http_status_error(None)
 
 
 def test_handle_http_status_error_uses_retry_after_header(base_client):
@@ -579,6 +660,18 @@ def test_is_retryable_error_includes_mapped_5xx_fmp_errors():
         is False
     )
     assert BaseClient._is_retryable_error(FMPError("client", status_code=400)) is False
+    assert BaseClient._is_retryable_error(FMPError("no status")) is False
+    assert BaseClient._is_retryable_error(RateLimitError("limited", retry_after=1.0))
+    request = httpx.Request("GET", "https://example.com")
+    response_5xx = httpx.Response(503, request=request)
+    response_4xx = httpx.Response(404, request=request)
+    assert BaseClient._is_retryable_error(
+        httpx.HTTPStatusError("server", request=request, response=response_5xx)
+    )
+    assert not BaseClient._is_retryable_error(
+        httpx.HTTPStatusError("not found", request=request, response=response_4xx)
+    )
+    assert not BaseClient._is_retryable_error(ValueError("other"))
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -257,6 +257,44 @@ def test_get_error_details_redacts_api_keys():
     assert "[REDACTED]" in rendered
 
 
+def test_get_error_details_redacts_api_keys_in_raw_content():
+    """Non-JSON error bodies should still redact reflected API keys."""
+    fake_key_value = "SECRET_FMP_KEY"
+    response = Mock()
+    response.json.side_effect = json.JSONDecodeError("bad", "doc", 0)
+    response.content = (
+        f"Error at https://api.example/path?apikey={fake_key_value}".encode()
+    )
+
+    details = BaseClient._get_error_details(response)
+
+    assert fake_key_value not in repr(details)
+    assert details["raw_content"].count("[REDACTED]") >= 1
+
+
+def test_get_error_details_redacts_api_keys_in_scalar_json():
+    """Scalar JSON error bodies should redact embedded API keys."""
+    fake_key_value = "SECRET_FMP_KEY"
+    response = Mock()
+    response.json.return_value = f"apikey={fake_key_value}"
+
+    details = BaseClient._get_error_details(response)
+
+    assert fake_key_value not in repr(details)
+    assert "[REDACTED]" in details["raw_content"]
+
+
+def test_get_error_details_handles_non_utf8_body():
+    """Non-UTF-8 error bodies should not raise while extracting details."""
+    request = httpx.Request("GET", "https://example.com")
+    response = httpx.Response(401, request=request, content=b"\xff\xfe binary body")
+
+    details = BaseClient._get_error_details(response)
+
+    assert "raw_content" in details
+    assert isinstance(details["raw_content"], str)
+
+
 def test_handle_http_status_error_404_empty_payloads(base_client):
     """Test 404 errors return empty payloads without raising."""
     request = httpx.Request("GET", "https://example.com")
@@ -292,7 +330,34 @@ def test_handle_http_status_error_uses_retry_after_header(base_client):
     assert exc_info.value.retry_after == 12.0
 
 
-def test_handle_response_error_traceback_redacts_httpx_request_url(base_client):
+def test_rate_limit_handler_receives_redacted_response_body(base_client):
+    """429 handling should not pass raw API keys into the rate limiter."""
+    fake_key_value = "SECRET_FMP_KEY"
+    request = httpx.Request("GET", "https://example.com")
+    response = httpx.Response(
+        429,
+        request=request,
+        headers={"Retry-After": "5"},
+        text=f"Rate limited for https://api.example/?apikey={fake_key_value}",
+    )
+    error = httpx.HTTPStatusError(
+        "Too many requests", request=request, response=response
+    )
+
+    with (
+        patch.object(base_client._rate_limiter, "handle_response") as handle_response,
+        patch.object(base_client._rate_limiter, "get_retry_after", return_value=5.0),
+        pytest.raises(RateLimitError),
+    ):
+        base_client._handle_http_status_error(error)
+
+    handle_response.assert_called_once()
+    body = handle_response.call_args.args[1]
+    assert fake_key_value not in body
+    assert "[REDACTED]" in body
+
+
+def test_handle_response_error_traceback_suppresses_httpx_request_url(base_client):
     """HTTP error handling should not chain tracebacks that expose API keys."""
     fake_key_value = "SECRET_FMP_KEY"
     request = httpx.Request(
@@ -314,12 +379,11 @@ def test_handle_response_error_traceback_redacts_httpx_request_url(base_client):
     assert exc.__suppress_context__ is True
     assert fake_key_value not in rendered
     assert "HTTPStatusError" not in rendered
+    assert fake_key_value not in repr(exc.response)
 
 
-def test_bytes_response_http_error_uses_redacted_fmp_exception(
-    base_client, mock_endpoint
-):
-    """Binary endpoints should not re-raise raw httpx status errors."""
+def test_bytes_response_http_error_uses_typed_fmp_exception(base_client, mock_endpoint):
+    """Binary endpoints map httpx status errors to FMP exceptions without chaining."""
     fake_key_value = "SECRET_FMP_KEY"
     request = httpx.Request(
         "GET",
@@ -348,6 +412,121 @@ def test_bytes_response_http_error_uses_redacted_fmp_exception(
     assert exc.__suppress_context__ is True
     assert fake_key_value not in rendered
     assert "HTTPStatusError" not in rendered
+    assert fake_key_value not in repr(exc.response)
+
+
+def test_bytes_response_non_utf8_error_body_uses_typed_fmp_exception(
+    base_client, mock_endpoint
+):
+    """Binary non-UTF-8 error bodies still raise typed FMP exceptions safely."""
+    fake_key_value = "SECRET_FMP_KEY"
+    request = httpx.Request(
+        "GET",
+        f"https://financialmodelingprep.com/stable/download?apikey={fake_key_value}",
+    )
+    response = httpx.Response(
+        401,
+        request=request,
+        content=b"\xff\xfe binary error body",
+    )
+    mock_endpoint.method.value = "GET"
+    mock_endpoint.build_url.return_value = (
+        "https://financialmodelingprep.com/stable/download"
+    )
+    mock_endpoint.response_model = bytes
+
+    with (
+        patch.object(base_client.client, "request", return_value=response),
+        pytest.raises(AuthenticationError) as exc_info,
+    ):
+        base_client._execute_request(mock_endpoint)
+
+    exc = exc_info.value
+    rendered = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+    assert exc.__cause__ is None
+    assert exc.__suppress_context__ is True
+    assert fake_key_value not in rendered
+    assert "HTTPStatusError" not in rendered
+    assert fake_key_value not in repr(exc.response)
+
+
+@pytest.mark.asyncio
+async def test_async_bytes_response_http_error_uses_typed_fmp_exception(
+    base_client, mock_endpoint
+):
+    """Async binary endpoints map status errors without chaining httpx."""
+    from unittest.mock import AsyncMock
+
+    fake_key_value = "SECRET_FMP_KEY"
+    request = httpx.Request(
+        "GET",
+        f"https://financialmodelingprep.com/stable/download?apikey={fake_key_value}",
+    )
+    response = httpx.Response(
+        401,
+        request=request,
+        json={"message": "Invalid API key"},
+    )
+    mock_endpoint.method = MagicMock()
+    mock_endpoint.method.value = "GET"
+    mock_endpoint.validate_params.return_value = {}
+    mock_endpoint.build_url.return_value = (
+        "https://financialmodelingprep.com/stable/download"
+    )
+    mock_endpoint.get_query_params.return_value = {}
+    mock_endpoint.response_model = bytes
+
+    mock_async_client = AsyncMock()
+    mock_async_client.request = AsyncMock(return_value=response)
+
+    with (
+        patch.object(
+            base_client, "_setup_async_client", return_value=mock_async_client
+        ),
+        pytest.raises(AuthenticationError) as exc_info,
+    ):
+        await base_client._execute_request_async(mock_endpoint)
+
+    exc = exc_info.value
+    rendered = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+    assert exc.__cause__ is None
+    assert exc.__suppress_context__ is True
+    assert fake_key_value not in rendered
+    assert "HTTPStatusError" not in rendered
+    assert fake_key_value not in repr(exc.response)
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected_exception"),
+    [
+        (400, ValidationError),
+        (500, FMPError),
+    ],
+)
+def test_handle_http_status_error_redacts_key_in_exception_message(
+    base_client: BaseClient,
+    status_code: int,
+    expected_exception: type[FMPError],
+) -> None:
+    """400/500 messages embed error details and must redact reflected keys."""
+    fake_key_value = "SECRET_FMP_KEY"
+    request = httpx.Request("GET", "https://example.com")
+    response = httpx.Response(
+        status_code,
+        request=request,
+        json={
+            "message": f"Failed for https://api.example/?apikey={fake_key_value}",
+            "apikey": fake_key_value,
+        },
+    )
+
+    with pytest.raises(expected_exception) as exc_info:
+        base_client.handle_response(response)
+
+    exc = exc_info.value
+    assert fake_key_value not in str(exc)
+    assert fake_key_value not in repr(exc.response)
+    assert "[REDACTED]" in str(exc)
 
 
 @pytest.mark.parametrize(
@@ -389,6 +568,17 @@ def test_handle_http_status_error_redacts_chained_apikey_traceback(
         assert exc.__suppress_context__ is True
     else:
         pytest.fail(f"Expected {expected_exception.__name__}")
+
+
+def test_is_retryable_error_includes_mapped_5xx_fmp_errors():
+    """Mapped FMP 5xx errors from status conversion should still be retried."""
+    assert BaseClient._is_retryable_error(FMPError("server", status_code=500)) is True
+    assert BaseClient._is_retryable_error(FMPError("server", status_code=503)) is True
+    assert (
+        BaseClient._is_retryable_error(AuthenticationError("auth", status_code=401))
+        is False
+    )
+    assert BaseClient._is_retryable_error(FMPError("client", status_code=400)) is False
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -1,4 +1,5 @@
 import json
+import traceback
 from unittest.mock import MagicMock, Mock, patch
 
 import httpx
@@ -238,6 +239,24 @@ def test_get_error_details_json_decode_error():
     assert details == {"raw_content": "not json"}
 
 
+def test_get_error_details_redacts_api_keys():
+    """Error details should not preserve reflected API keys."""
+    fake_key_value = "SECRET_FMP_KEY"
+    response = Mock()
+    response.json.return_value = {
+        "url": f"https://example.test/path?apikey={fake_key_value}&symbol=AAPL",
+        "encoded": f"apikey%3D{fake_key_value}%26symbol%3DAAPL",
+        "apikey": fake_key_value,
+        "nested": [{"message": f'apikey="{fake_key_value}"'}],
+    }
+
+    details = BaseClient._get_error_details(response)
+
+    rendered = repr(details)
+    assert fake_key_value not in rendered
+    assert "[REDACTED]" in rendered
+
+
 def test_handle_http_status_error_404_empty_payloads(base_client):
     """Test 404 errors return empty payloads without raising."""
     request = httpx.Request("GET", "https://example.com")
@@ -271,6 +290,64 @@ def test_handle_http_status_error_uses_retry_after_header(base_client):
         base_client._handle_http_status_error(error)
 
     assert exc_info.value.retry_after == 12.0
+
+
+def test_handle_response_error_traceback_redacts_httpx_request_url(base_client):
+    """HTTP error handling should not chain tracebacks that expose API keys."""
+    fake_key_value = "SECRET_FMP_KEY"
+    request = httpx.Request(
+        "GET",
+        f"https://financialmodelingprep.com/stable/profile?apikey={fake_key_value}&symbol=AAPL",
+    )
+    response = httpx.Response(
+        401,
+        request=request,
+        json={"message": "Invalid API key"},
+    )
+
+    with pytest.raises(AuthenticationError) as exc_info:
+        base_client.handle_response(response)
+
+    exc = exc_info.value
+    rendered = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+    assert exc.__cause__ is None
+    assert exc.__suppress_context__ is True
+    assert fake_key_value not in rendered
+    assert "HTTPStatusError" not in rendered
+
+
+def test_bytes_response_http_error_uses_redacted_fmp_exception(
+    base_client, mock_endpoint
+):
+    """Binary endpoints should not re-raise raw httpx status errors."""
+    fake_key_value = "SECRET_FMP_KEY"
+    request = httpx.Request(
+        "GET",
+        f"https://financialmodelingprep.com/stable/download?apikey={fake_key_value}",
+    )
+    response = httpx.Response(
+        401,
+        request=request,
+        json={"message": "Invalid API key"},
+    )
+    mock_endpoint.method.value = "GET"
+    mock_endpoint.build_url.return_value = (
+        "https://financialmodelingprep.com/stable/download"
+    )
+    mock_endpoint.response_model = bytes
+
+    with (
+        patch.object(base_client.client, "request", return_value=response),
+        pytest.raises(AuthenticationError) as exc_info,
+    ):
+        base_client._execute_request(mock_endpoint)
+
+    exc = exc_info.value
+    rendered = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+    assert exc.__cause__ is None
+    assert exc.__suppress_context__ is True
+    assert fake_key_value not in rendered
+    assert "HTTPStatusError" not in rendered
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- redact FMP API keys from reflected HTTP error detail payloads
- stop chaining typed FMP status exceptions from raw httpx.HTTPStatusError objects
- route binary response status failures through the same typed FMP error handler
- add regression coverage for traceback redaction across JSON and binary response paths

## Root Cause

httpx.HTTPStatusError includes the full request URL in its string representation. The client raised typed FMP exceptions with the original HTTPStatusError as the cause, so tracebacks could include URLs with the apikey query parameter.

## Notes

- Targets **dev** (not main). Complements #95, which landed the minimal traceback-cause fix on dev.
- Supersedes #96, which used a codex/* branch and was blocked by Guard-Main-Origin when aimed at main.
- Follow-up hardening: non-UTF-8 safe decode, mapped 5xx retries for binary endpoints, redacted 429 bodies, and broader regression tests.

## Validation

- uv run pytest tests/unit/test_base.py
- uv run ruff format --check fmp_data/base.py tests/unit/test_base.py
- uv run ruff check fmp_data/base.py tests/unit/test_base.py
- uv run mypy fmp_data
- make check

Closes #94