### PR TITLE
release: patch security and workflow dependency updates

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -124,7 +124,7 @@ jobs:
           fi
 
       - name: 🧪  Upload to Test PyPI
-        uses: pypa/gh-action-pypi-publish@v1.13.0
+        uses: pypa/gh-action-pypi-publish@v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: dist

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -108,7 +108,7 @@ jobs:
           fi
 
       - name: 🧪  Upload to Test PyPI
-        uses: pypa/gh-action-pypi-publish@v1.13.0
+        uses: pypa/gh-action-pypi-publish@v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: dist
@@ -199,7 +199,7 @@ jobs:
           python -m build --wheel --sdist
 
       - name: 🚀  Upload to Test PyPI
-        uses: pypa/gh-action-pypi-publish@v1.13.0
+        uses: pypa/gh-action-pypi-publish@v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: dist

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -117,7 +117,7 @@ jobs:
           print-hash: true
 
       - name: 📝  Comment on PR
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const version = '${{ steps.version.outputs.TEST_VERSION }}';

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,7 +180,7 @@ jobs:
           fi
 
       - name: 🚀 Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.13.0
+        uses: pypa/gh-action-pypi-publish@v1.14.0
         with:
           packages-dir: dist/
           skip-existing: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Will be removed in a future major version
 
 ### Security
+- **HTTP Error Traceback Redaction** - Suppressed exception chaining for HTTP status errors so formatted tracebacks do not expose API key query parameters:
+  - Updated rate limit, authentication, validation, and fallback HTTP error paths to raise sanitized package exceptions without chaining the raw `httpx.HTTPStatusError`
+  - Added regression coverage for API key redaction in formatted tracebacks and exception messages
 - **VCR Cassette Leak Guard** - Added unit tests that scan all committed VCR cassettes for leaked API keys:
   - `test_vcr_sanitization.py` verifies the VCR `scrub_api_key` / `scrub_response_secrets` hooks and scans every YAML cassette for real API key values
   - `test_cassette_contracts.py` validates every cassette response against its declared Pydantic endpoint model, catching schema drift and stale cassettes
@@ -106,6 +109,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **GitHub Actions Maintenance** - Updated workflow actions to current upstream releases:
   - Bumped `actions/deploy-pages` from `v4` to `v5` in the documentation workflow
   - Bumped `codecov/codecov-action` from `v5` to `v6` in CI coverage uploads
+  - Bumped `actions/github-script` from `v8` to `v9` in the TestPyPI publishing workflow
+  - Bumped `pypa/gh-action-pypi-publish` from `v1.13.0` to `v1.14.0` in publishing workflows
 - **VCR Cassettes Excluded from Git** - Cassettes are now gitignored (`tests/integration/vcr_cassettes/`) because they are too large for GitHub (130 MB+ individual files). Developers must record cassettes locally with `FMP_TEST_API_KEY`.
 - **CI Secret Scan** - The `secret-scan` job now gracefully skips when no cassette YAML files are present instead of failing.
 - **Cassette Contract Test** - `test_vcr_cassettes_match_endpoint_models` now skips with a clear message when no cassettes are found, instead of silently passing.

--- a/fmp_data/base.py
+++ b/fmp_data/base.py
@@ -564,27 +564,27 @@ class BaseClient:
                 status_code=429,
                 response=error_details,
                 retry_after=wait_time,
-            ) from error
+            ) from None
 
         if status_code == 401:
             raise AuthenticationError(
                 "Invalid API key or authentication failed",
                 status_code=401,
                 response=error_details,
-            ) from error
+            ) from None
 
         if status_code == 400:
             raise ValidationError(
                 f"Invalid request parameters: {error_details}",
                 status_code=400,
                 response=error_details,
-            ) from error
+            ) from None
 
         raise FMPError(
             f"HTTP {status_code} error occurred: {error_details}",
             status_code=status_code,
             response=error_details,
-        ) from error
+        ) from None
 
     @staticmethod
     def _check_error_response(data: dict[str, Any]) -> None:

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -1,4 +1,5 @@
 import json
+import traceback
 from unittest.mock import MagicMock, Mock, patch
 
 import httpx
@@ -271,6 +272,33 @@ def test_handle_http_status_error_uses_retry_after_header(base_client):
         base_client._handle_http_status_error(error)
 
     assert exc_info.value.retry_after == 12.0
+
+
+def test_handle_http_status_error_redacts_chained_apikey_traceback(base_client):
+    """Test 429 tracebacks do not expose the API key query parameter."""
+    marker = "TRACEBACK_REDACTION_SENTINEL"
+    request = httpx.Request(
+        "GET",
+        f"https://financialmodelingprep.com/stable/quote?symbol=AAPL&apikey={marker}",
+    )
+    response = httpx.Response(
+        429,
+        request=request,
+        json={"message": "Rate limit exceeded"},
+    )
+
+    try:
+        base_client.handle_response(response)
+    except RateLimitError as exc:
+        formatted_traceback = traceback.format_exc()
+        assert "apikey=" not in formatted_traceback
+        assert marker not in formatted_traceback
+        assert "apikey=" not in str(exc)
+        assert marker not in str(exc)
+        assert exc.__cause__ is None
+        assert exc.__suppress_context__ is True
+    else:
+        pytest.fail("Expected RateLimitError")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -274,7 +274,7 @@ def test_handle_http_status_error_uses_retry_after_header(base_client):
     assert exc_info.value.retry_after == 12.0
 
 
-def test_handle_http_status_error_redacts_chained_apikey_traceback(base_client):
+def test_handle_http_status_error_redacts_chained_apikey_traceback(base_client) -> None:
     """Test 429 tracebacks do not expose the API key query parameter."""
     marker = "TRACEBACK_REDACTION_SENTINEL"
     request = httpx.Request(

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -284,7 +284,7 @@ def test_handle_http_status_error_uses_retry_after_header(base_client):
     ],
 )
 def test_handle_http_status_error_redacts_chained_apikey_traceback(
-    base_client,
+    base_client: BaseClient,
     status_code: int,
     expected_exception: type[FMPError],
 ) -> None:

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -274,22 +274,36 @@ def test_handle_http_status_error_uses_retry_after_header(base_client):
     assert exc_info.value.retry_after == 12.0
 
 
-def test_handle_http_status_error_redacts_chained_apikey_traceback(base_client) -> None:
-    """Test 429 tracebacks do not expose the API key query parameter."""
+@pytest.mark.parametrize(
+    ("status_code", "expected_exception"),
+    [
+        (429, RateLimitError),
+        (401, AuthenticationError),
+        (400, ValidationError),
+        (500, FMPError),
+    ],
+)
+def test_handle_http_status_error_redacts_chained_apikey_traceback(
+    base_client,
+    status_code: int,
+    expected_exception: type[FMPError],
+) -> None:
+    """Test HTTP error tracebacks do not expose the API key query parameter."""
     marker = "TRACEBACK_REDACTION_SENTINEL"
     request = httpx.Request(
         "GET",
         f"https://financialmodelingprep.com/stable/quote?symbol=AAPL&apikey={marker}",
     )
     response = httpx.Response(
-        429,
+        status_code,
         request=request,
         json={"message": "Rate limit exceeded"},
     )
 
     try:
         base_client.handle_response(response)
-    except RateLimitError as exc:
+    except FMPError as exc:
+        assert isinstance(exc, expected_exception)
         formatted_traceback = traceback.format_exc()
         assert "apikey=" not in formatted_traceback
         assert marker not in formatted_traceback
@@ -298,7 +312,7 @@ def test_handle_http_status_error_redacts_chained_apikey_traceback(base_client) 
         assert exc.__cause__ is None
         assert exc.__suppress_context__ is True
     else:
-        pytest.fail("Expected RateLimitError")
+        pytest.fail(f"Expected {expected_exception.__name__}")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Include #95 to suppress raw httpx HTTPStatusError chaining from typed FMP HTTP errors, preventing apikey query params from appearing in tracebacks.
- Include #92 to update actions/github-script from 8 to 9.
- Include #93 to update pypa/gh-action-pypi-publish from 1.13.0 to 1.14.0.

## Patch Release
This is marked as a patch release because it contains a security traceback redaction fix and workflow dependency maintenance without API changes.

## Dependency Refresh
- Ran `uv lock --upgrade`; no lockfile changes were needed.
- Ran `uv tree --depth 1 --all-groups --outdated`; no outdated direct resolved Python dependencies were reported.

## Validation
- #92 refreshed checks passed before merge.
- #93 refreshed checks passed before merge.
- #95 passed local validation before merge: `uv run pytest tests/unit/test_base.py`, direct ruff checks, and `make check`.

## Note
#97 is still open separately as a direct hotfix PR to main with a broader HTTP redaction change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Exception tracebacks no longer reveal API keys or sensitive query parameters; chained internal errors are suppressed for cleaner, safer messages.

* **Tests**
  * Added regression tests to ensure sensitive data is not exposed in formatted tracebacks or exception messages.

* **Chores**
  * Updated CI publishing workflow tooling.

* **Documentation**
  * Changelog updated with security and CI maintenance notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->