### PR TITLE
fix(company): coerce fractional numeric-string volume to int (profile-bulk 9.7% row drop)

### DIFF
--- a/fmp_data/company/models.py
+++ b/fmp_data/company/models.py
@@ -25,7 +25,14 @@ from fmp_data.models import ShareFloat
 
 
 def coerce_volume_value(value: Any) -> Any:
-    """Coerce volume values to int (FMP API may return floats).
+    """Coerce volume values to int (FMP may return floats or numeric strings).
+
+    JSON endpoints return volume as a number, but the bulk CSV endpoints (e.g.
+    ``profile-bulk``) return a possibly-fractional string such as ``"475.9"``.
+    Both must land as ``int`` so a fractional value doesn't fail the ``int``
+    field and silently drop the whole parsed row. Empty strings become ``None``;
+    genuinely non-numeric strings are passed through unchanged so they surface as
+    a validation error instead of being masked.
 
     See: https://github.com/MehdiZare/fmp-data/issues/70
     """
@@ -33,6 +40,14 @@ def coerce_volume_value(value: Any) -> Any:
         return None
     if isinstance(value, int | float):
         return int(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        try:
+            return int(float(stripped))
+        except ValueError:
+            return value
     return value
 
 

--- a/fmp_data/company/models.py
+++ b/fmp_data/company/models.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import date, datetime
 from decimal import Decimal
 import json
+import math
 from typing import Any
 from urllib.parse import urlparse
 from zoneinfo import ZoneInfo
@@ -29,25 +30,34 @@ def coerce_volume_value(value: Any) -> Any:
 
     JSON endpoints return volume as a number, but the bulk CSV endpoints (e.g.
     ``profile-bulk``) return a possibly-fractional string such as ``"475.9"``.
-    Both must land as ``int`` so a fractional value doesn't fail the ``int``
-    field and silently drop the whole parsed row. Empty strings become ``None``;
-    genuinely non-numeric strings are passed through unchanged so they surface as
-    a validation error instead of being masked.
+    Both must land as ``int`` (truncating toward zero) so a fractional value
+    doesn't fail the ``int`` field and silently drop the whole parsed row.
+    Empty strings become ``None``; non-numeric and non-finite values (``nan``,
+    ``inf``) are passed through unchanged so they surface as a validation error
+    instead of raising ``OverflowError`` or masking bad data.
 
     See: https://github.com/MehdiZare/fmp-data/issues/70
     """
     if value is None:
         return None
     if isinstance(value, int | float):
+        # bool is a subclass of int; int(True)==1 would mask bad payloads.
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, float) and not math.isfinite(value):
+            return value
         return int(value)
     if isinstance(value, str):
         stripped = value.strip()
         if not stripped:
             return None
         try:
-            return int(float(stripped))
+            number = float(stripped)
         except ValueError:
             return value
+        if not math.isfinite(number):
+            return value
+        return int(number)
     return value
 
 

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -267,6 +267,53 @@ class TestBatchClient:
         assert results == []
         assert "Skipping invalid SimpleRow row" in caplog.text
 
+    def test_parse_csv_models_keeps_fractional_string_volume(self):
+        """profile-bulk CSV volumes are fractional strings; rows must not drop.
+
+        Regression for Issue #70 / PR #104: coerce_volume_value used to pass
+        strings through, so ``"475.9"`` failed the strict ``int`` field and
+        ``parse_csv_models`` silently skipped the whole row.
+        """
+        csv_text = (
+            "symbol,companyName,currency,exchange,exchangeFullName,"
+            "industry,sector,country,isEtf,isActivelyTrading,isAdr,isFund,"
+            "volume,averageVolume\n"
+            "AAPL,Apple Inc.,USD,NASDAQ,NASDAQ Global Select,"
+            "Consumer Electronics,Technology,US,false,true,false,false,"
+            "475.9,7155681.59509\n"
+        )
+        results = parse_csv_models(csv_text.encode("utf-8"), CompanyProfile)
+
+        assert len(results) == 1
+        assert results[0].symbol == "AAPL"
+        assert results[0].volume == 475
+        assert results[0].vol_avg == 7155681
+        assert isinstance(results[0].volume, int)
+        assert isinstance(results[0].vol_avg, int)
+
+    def test_parse_csv_models_non_finite_volume_skips_row_not_abort(self, caplog):
+        """A single non-finite volume must skip that row, not crash the bulk parse."""
+        import logging
+
+        csv_text = (
+            "symbol,companyName,currency,exchange,exchangeFullName,"
+            "industry,sector,country,isEtf,isActivelyTrading,isAdr,isFund,"
+            "volume,averageVolume\n"
+            "BAD,Bad Co,USD,NASDAQ,NASDAQ,"
+            "Tech,Technology,US,false,true,false,false,"
+            "inf,100\n"
+            "GOOD,Good Co,USD,NASDAQ,NASDAQ,"
+            "Tech,Technology,US,false,true,false,false,"
+            "1000,2000\n"
+        )
+        with caplog.at_level(logging.WARNING, logger="fmp_data.batch._csv_utils"):
+            results = parse_csv_models(csv_text.encode("utf-8"), CompanyProfile)
+
+        assert len(results) == 1
+        assert results[0].symbol == "GOOD"
+        assert results[0].volume == 1000
+        assert "Skipping invalid CompanyProfile row" in caplog.text
+
     @patch("httpx.Client.request")
     def test_get_quotes(
         self, mock_request, fmp_client, mock_response, batch_quote_data

--- a/tests/unit/test_company.py
+++ b/tests/unit/test_company.py
@@ -292,6 +292,21 @@ class TestCompanyProfile:
             with pytest.raises(ValidationError):
                 CompanyProfile.model_validate(profile_data)
 
+    def test_coerce_volume_value_passthrough_edges(self):
+        """Cover defensive pass-through arms Codecov flags on the patch.
+
+        - bool is a subclass of int; must not become 0/1
+        - non-numeric strings pass through for later ValidationError
+        - unknown types fall through unchanged
+        """
+        from fmp_data.company.models import coerce_volume_value
+
+        assert coerce_volume_value(True) is True
+        assert coerce_volume_value(False) is False
+        assert coerce_volume_value("not_a_number") == "not_a_number"
+        assert coerce_volume_value([1]) == [1]
+        assert coerce_volume_value({"v": 1}) == {"v": 1}
+
     def test_model_validation_invalid_website(self, profile_data):
         """Test CompanyProfile model with invalid website URL"""
         # Use a URL with protocol but invalid hostname (no TLD) to trigger validation

--- a/tests/unit/test_company.py
+++ b/tests/unit/test_company.py
@@ -278,6 +278,20 @@ class TestCompanyProfile:
         assert profile.vol_avg is None
         assert profile.volume is None
 
+    def test_model_validation_non_finite_volume_raises(self, profile_data):
+        """Non-finite volume must not raise OverflowError; it surfaces as
+        ValidationError so bulk parsers can skip a single row safely."""
+        from pydantic import ValidationError
+
+        from fmp_data.company.models import coerce_volume_value
+
+        for bad in ("inf", "-inf", "nan", "NaN", float("inf"), float("nan")):
+            # Pass-through (no OverflowError); Pydantic then rejects the value.
+            assert coerce_volume_value(bad) is bad
+            profile_data["volume"] = bad
+            with pytest.raises(ValidationError):
+                CompanyProfile.model_validate(profile_data)
+
     def test_model_validation_invalid_website(self, profile_data):
         """Test CompanyProfile model with invalid website URL"""
         # Use a URL with protocol but invalid hostname (no TLD) to trigger validation

--- a/tests/unit/test_company.py
+++ b/tests/unit/test_company.py
@@ -257,6 +257,27 @@ class TestCompanyProfile:
         assert profile.vol_avg == 50000000
         assert profile.volume == 25000000
 
+    def test_model_validation_fractional_string_volume(self, profile_data):
+        """Bulk CSV endpoints (e.g. profile-bulk) return volume as a fractional
+        STRING such as "475.9"; it must coerce to int instead of failing the
+        ``int`` field and silently dropping the whole parsed row (Issue #70)."""
+        profile_data["volAvg"] = "7155681.59509"
+        profile_data["volume"] = "475.9"
+        profile = CompanyProfile.model_validate(profile_data)
+        assert profile.vol_avg == 7155681
+        assert profile.volume == 475
+        assert isinstance(profile.vol_avg, int)
+        assert isinstance(profile.volume, int)
+
+    def test_model_validation_empty_string_volume(self, profile_data):
+        """An empty/whitespace volume cell (common in CSV rows) coerces to None,
+        not a validation error."""
+        profile_data["volAvg"] = ""
+        profile_data["volume"] = "   "
+        profile = CompanyProfile.model_validate(profile_data)
+        assert profile.vol_avg is None
+        assert profile.volume is None
+
     def test_model_validation_invalid_website(self, profile_data):
         """Test CompanyProfile model with invalid website URL"""
         # Use a URL with protocol but invalid hostname (no TLD) to trigger validation


### PR DESCRIPTION
## Summary

`coerce_volume_value` coerces `int`/`float` volume to `int` but **passes strings through unchanged**. FMP's JSON endpoints send volume as a number, but the **bulk CSV endpoints** (`profile-bulk`, and the other `*-bulk` routes) send it as a possibly-fractional **string** like `"475.9"`. That string reaches the strict `int` field, raises `int_parsing`, and `parse_csv_models` **silently drops the whole row**.

Measured against `get_profile_bulk("0")` on a live key: **22,588 rows → 2,202 dropped (9.7%)**, of which **2,178 are volume-typed** (`averageVolume` 2,167 + `volume` 11). The per-symbol `get_profile` path is unaffected because JSON sends a float.

## Fix

Extend `coerce_volume_value` to coerce numeric strings via `int(float(...))`; empty/whitespace → `None`; genuinely non-numeric strings still pass through so they surface as a validation error rather than being masked. `CompanyProfile.vol_avg` / `.volume` and `Quote.volume` share this helper, so all are fixed with one change.

```python
# "475.9" (fractional CSV string)  -> 475      (was: dropped row)
# "7155681.59509"                  -> 7155681  (was: dropped row)
# "50000000" / 50000000 / 4.7e7    -> int       (unchanged)
# "" / "   "                       -> None       (was: dropped row)
# "not_a_number"                   -> unchanged  (surfaces as validation error)
```

## Tests

- `test_model_validation_fractional_string_volume` — the CSV/bulk case.
- `test_model_validation_empty_string_volume` — empty cell → `None`.
- Existing integer-string / float / int / None / non-numeric-passthrough tests unchanged.
- Full unit suite: **936 passed, 5 skipped**; ruff + mypy clean.

Refs #70.
