### PR TITLE
chore(deps): bump GitHub Actions and Python deps to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,17 +25,17 @@ jobs:
 
     steps:
       - name: 🛎️  Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
 
       - name: 🐍  Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: ${{ matrix.python }}
 
       - name: ⚡  Install uv (with cache)
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           enable-cache: true
 
@@ -70,15 +70,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛎️  Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: 🐍  Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.14"
 
       - name: ⚡  Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@v8.3.2
 
       - name: 📊 Run all tests with coverage
         env:
@@ -88,7 +88,7 @@ jobs:
           uv tool run nox -s coverage_local
 
       - name: 📈 Coverage upload
-        uses: codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
@@ -100,10 +100,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛎️  Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: 🐍  Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.14"
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 1
 

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -19,18 +19,18 @@ jobs:
 
     steps:
       - name: 🛎️  Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0  # Needed for version calculation
           fetch-tags: true
 
       - name: 🐍  Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: ⚡  Install uv (with cache)
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           enable-cache: true
 

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -39,21 +39,21 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/setup-python@v6.3.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           enable-cache: true
 
       - name: Cache uv dependencies
-        uses: actions/cache@v5.0.4
+        uses: actions/cache@v6.1.0
         with:
           path: |
             ~/.cache/uv
@@ -94,7 +94,7 @@ jobs:
           PACKAGE_VERSION="${{ steps.version.outputs.VERSION }}" uv run mkdocs build --strict
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4.0.0
+        uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: site
 

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -36,18 +36,18 @@ jobs:
 
     steps:
       - name: 🛎️  Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0  # Needed for version calculation
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: 🐍  Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: ⚡  Install uv (with cache)
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           enable-cache: true
 
@@ -117,7 +117,7 @@ jobs:
           print-hash: true
 
       - name: 📝  Comment on PR
-        uses: actions/github-script@v9
+        uses: actions/github-script@v9.0.0
         with:
           script: |
             const version = '${{ steps.version.outputs.TEST_VERSION }}';
@@ -179,17 +179,17 @@ jobs:
 
     steps:
       - name: 🛎️  Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0  # Needed for hatch-vcs versioning
 
       - name: 🐍  Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: ⚡  Install uv (with cache)
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           enable-cache: true
 

--- a/.github/workflows/rebase-reminder.yml
+++ b/.github/workflows/rebase-reminder.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR head
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
           ref: dev
 
       - name: Create or Update Release PR
-        uses: peter-evans/create-pull-request@v8.1.0
+        uses: peter-evans/create-pull-request@v8.1.1
         with:
           branch: release/dev-to-main
           base: main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,18 +26,18 @@ jobs:
 
     steps:
       - name: 🛎️ Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0  # Fetch all history for proper versioning
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🐍 Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: ⚡ Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           enable-cache: true
 

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           ref: main
           fetch-depth: 0
@@ -37,7 +37,7 @@ jobs:
 
       - name: Create Sync PR
         if: steps.diff.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@v8.1.0
+        uses: peter-evans/create-pull-request@v8.1.1
         with:
           branch: sync/main-to-dev
           base: dev

--- a/fmp_data/base.py
+++ b/fmp_data/base.py
@@ -267,8 +267,9 @@ class BaseClient:
         if outcome is not None and outcome.failed:
             exc = outcome.exception()
             if isinstance(exc, RateLimitError) and exc.retry_after is not None:
-                return exc.retry_after
-        return wait_exponential(multiplier=1, min=4, max=10)(retry_state)
+                return float(exc.retry_after)
+        wait = wait_exponential(multiplier=1, min=4, max=10)(retry_state)
+        return float(wait)
 
     @staticmethod
     def _is_retryable_error(exc: BaseException) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "hatchling>=1.29.0",
+    "hatchling>=1.31.0",
     "hatch-vcs>=0.5.0",
 ]
 build-backend = "hatchling.build"
@@ -47,7 +47,7 @@ classifiers = [
 ]
 dependencies = [
     "httpx>=0.28.1",
-    "pydantic>=2.12.5",
+    "pydantic>=2.13.4",
     "tenacity>=9.1.4",
 ]
 
@@ -64,84 +64,84 @@ fmp-mcp = "fmp_data.mcp.cli:main"
 
 [project.optional-dependencies]
 mcp = [
-    "mcp[cli]>=1.27.0",
+    "mcp[cli]>=1.28.1",
     "pyyaml>=6.0.3",
 ]
 cache-redis = [
-    "redis>=7.4.0",
+    "redis>=8.0.1",
 ]
 langchain = [
-    "faiss-cpu>=1.13.2",
-    "langchain-core>=1.2.26",
-    "langchain-community>=0.4.1",
-    "langchain-openai>=1.1.12",
-    "langgraph>=1.1.6",
-    "openai>=2.30.0",
-    "tiktoken>=0.12.0",
+    "faiss-cpu>=1.14.3",
+    "langchain-core>=1.4.9",
+    "langchain-community>=0.4.2",
+    "langchain-openai>=1.3.5",
+    "langgraph>=1.2.9",
+    "openai>=2.45.0",
+    "tiktoken>=0.13.0",
 ]
 dev = [
-    "ruff>=0.15.9",
-    "mypy>=1.20.0",
+    "ruff>=0.15.21",
+    "mypy>=2.2.0",
     "bandit[toml]>=1.9.4",
-    "pip-audit>=2.10.0",
+    "pip-audit>=2.10.1",
     "python-dotenv>=1.2.2",
-    "pytest>=9.0.2",
-    "pytest-asyncio>=1.3.0",
+    "pytest>=9.1.1",
+    "pytest-asyncio>=1.4.0",
     "pytest-cov>=7.1.0",
     "pytest-mock>=3.15.1",
-    "pytest-xdist>=3.6.1",
+    "pytest-xdist>=3.8.0",
     "freezegun>=1.5.5",
-    "responses>=0.26.0",
-    "vcrpy>=8.1.1",
-    "coverage>=7.13.5",
-    "pre-commit>=4.5.1",
-    "rich>=14.3.3",
+    "responses>=0.26.2",
+    "vcrpy>=8.3.0",
+    "coverage>=7.15.1",
+    "pre-commit>=4.6.0",
+    "rich>=15.0.0",
     "twine>=6.2.0",
-    "nox>=2026.2.9",
+    "nox>=2026.7.11",
 ]
 docs = [
     "mkdocs>=1.6.1",
     "mkdocs-material>=9.7.6",
-    "mkdocstrings-python>=2.0.3",
+    "mkdocstrings-python>=2.0.5",
 ]
 
 [dependency-groups]
 dev = [
-    "ruff>=0.15.9",
-    "mypy>=1.20.0",
+    "ruff>=0.15.21",
+    "mypy>=2.2.0",
     "bandit[toml]>=1.9.4",
-    "pip-audit>=2.10.0",
+    "pip-audit>=2.10.1",
     "python-dotenv>=1.2.2",
-    "pytest>=9.0.2",
-    "pytest-asyncio>=1.3.0",
+    "pytest>=9.1.1",
+    "pytest-asyncio>=1.4.0",
     "pytest-cov>=7.1.0",
     "pytest-mock>=3.15.1",
-    "pytest-xdist>=3.6.1",
+    "pytest-xdist>=3.8.0",
     "freezegun>=1.5.5",
-    "responses>=0.26.0",
-    "vcrpy>=8.1.1",
-    "coverage>=7.13.5",
-    "pre-commit>=4.5.1",
-    "rich>=14.3.3",
+    "responses>=0.26.2",
+    "vcrpy>=8.3.0",
+    "coverage>=7.15.1",
+    "pre-commit>=4.6.0",
+    "rich>=15.0.0",
     "twine>=6.2.0",
-    "nox>=2026.2.9",
+    "nox>=2026.7.11",
 ]
 docs = [
     "mkdocs>=1.6.1",
     "mkdocs-material>=9.7.6",
-    "mkdocstrings-python>=2.0.3",
+    "mkdocstrings-python>=2.0.5",
 ]
 langchain = [
-    "faiss-cpu>=1.13.2",
-    "langchain-core>=1.2.26",
-    "langchain-community>=0.4.1",
-    "langchain-openai>=1.1.12",
-    "langgraph>=1.1.6",
-    "openai>=2.30.0",
-    "tiktoken>=0.12.0",
+    "faiss-cpu>=1.14.3",
+    "langchain-core>=1.4.9",
+    "langchain-community>=0.4.2",
+    "langchain-openai>=1.3.5",
+    "langgraph>=1.2.9",
+    "openai>=2.45.0",
+    "tiktoken>=0.13.0",
 ]
 mcp = [
-    "mcp[cli]>=1.27.0",
+    "mcp[cli]>=1.28.1",
     "pyyaml>=6.0.3",
 ]
 
@@ -223,7 +223,9 @@ known-first-party = [
 force-sort-within-sections = true
 
 [tool.mypy]
-python_version = "3.10"
+# Analyze against 3.12 so third-party stubs (numpy 2.x PEP 695 `type` statements)
+# parse correctly. Runtime still supports Python 3.10+.
+python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true


### PR DESCRIPTION
## Summary
Full dependency refresh: consolidates Dependabot PRs #99–#103 (GitHub Actions) and raises all Python package floors to current stable releases on PyPI.

### GitHub Actions
| Action | Was | Dependabot | Now |
|--------|-----|------------|-----|
| `astral-sh/setup-uv` | 8.0.0 | 8.1.0 (#99) | **8.3.2** |
| `actions/upload-pages-artifact` | 4.0.0 | 5.0.0 (#100) | **5.0.0** |
| `peter-evans/create-pull-request` | 8.1.0 | 8.1.1 (#101) | **8.1.1** |
| `actions/cache` | 5.0.4 | 5.0.5 (#102) | **6.1.0** |
| `codecov/codecov-action` | 6.0.0 | 6.0.1 (#103) | **7.0.0** |
| `actions/checkout` | 6.x | — | **7.0.0** |
| `actions/setup-python` | 6.2.0 | — | **6.3.0** |
| `actions/github-script` | v9 | — | **9.0.0** |

### Python (selected)
| Package | Was | Now | Notes |
|---------|-----|-----|-------|
| pydantic | 2.12.5 | **2.13.4** | core |
| redis | 7.4.0 | **8.0.1** | major (cache-redis extra) |
| mypy | 1.20.0 | **2.2.0** | major (dev) |
| rich | 14.3.3 | **15.0.0** | major (dev) |
| mcp | 1.27.0 | **1.28.1** | |
| langchain-core | 1.2.26 | **1.4.9** | |
| langchain-openai | 1.1.12 | **1.3.5** | |
| langgraph | 1.1.6 | **1.2.9** | |
| openai | 2.30.0 | **2.45.0** | |
| faiss-cpu | 1.13.2 | **1.14.3** | |
| ruff | 0.15.9 | **0.15.21** | |
| pytest | 9.0.2 | **9.1.1** | |
| nox | 2026.2.9 | **2026.7.11** | |

Plus matching bumps for pip-audit, pytest-asyncio, vcrpy, coverage, pre-commit, mkdocstrings-python, hatchling, etc. Unchanged at already-latest: httpx, tenacity, pyyaml, bandit, pytest-cov, freezegun, twine, mkdocs, mkdocs-material.

### Related code / config
- `mypy` `python_version` set to **3.12** so numpy 2.x stubs (PEP 695 `type` statements) parse when optional extras are installed. Runtime support remains 3.10+.
- Cast tenacity wait / `retry_after` values to `float` for `no-any-return` under mypy 2.

Supersedes #99, #100, #101, #102, #103 (already closed).

## Test plan
- [x] `uv run mypy fmp_data` (all extras) — clean
- [x] `uv run nox -s typecheck --no-install` — clean
- [x] `uv run pytest tests/unit` — 1023 passed, 1 skipped
- [ ] CI green on this PR