### PR TITLE
release: minor HTTP redaction, bulk volume fix, and dependency refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,17 +25,17 @@ jobs:
 
     steps:
       - name: 🛎️  Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
 
       - name: 🐍  Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: ${{ matrix.python }}
 
       - name: ⚡  Install uv (with cache)
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           enable-cache: true
 
@@ -70,15 +70,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛎️  Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: 🐍  Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.14"
 
       - name: ⚡  Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@v8.3.2
 
       - name: 📊 Run all tests with coverage
         env:
@@ -88,7 +88,7 @@ jobs:
           uv tool run nox -s coverage_local
 
       - name: 📈 Coverage upload
-        uses: codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
@@ -100,10 +100,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛎️  Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: 🐍  Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.14"
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 1
 

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -19,18 +19,18 @@ jobs:
 
     steps:
       - name: 🛎️  Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0  # Needed for version calculation
           fetch-tags: true
 
       - name: 🐍  Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: ⚡  Install uv (with cache)
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           enable-cache: true
 

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -39,21 +39,21 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/setup-python@v6.3.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           enable-cache: true
 
       - name: Cache uv dependencies
-        uses: actions/cache@v5.0.4
+        uses: actions/cache@v6.1.0
         with:
           path: |
             ~/.cache/uv
@@ -94,7 +94,7 @@ jobs:
           PACKAGE_VERSION="${{ steps.version.outputs.VERSION }}" uv run mkdocs build --strict
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4.0.0
+        uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: site
 

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -36,18 +36,18 @@ jobs:
 
     steps:
       - name: 🛎️  Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0  # Needed for version calculation
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: 🐍  Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: ⚡  Install uv (with cache)
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           enable-cache: true
 
@@ -117,7 +117,7 @@ jobs:
           print-hash: true
 
       - name: 📝  Comment on PR
-        uses: actions/github-script@v9
+        uses: actions/github-script@v9.0.0
         with:
           script: |
             const version = '${{ steps.version.outputs.TEST_VERSION }}';
@@ -179,17 +179,17 @@ jobs:
 
     steps:
       - name: 🛎️  Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0  # Needed for hatch-vcs versioning
 
       - name: 🐍  Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: ⚡  Install uv (with cache)
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           enable-cache: true
 

--- a/.github/workflows/rebase-reminder.yml
+++ b/.github/workflows/rebase-reminder.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR head
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
           ref: dev
 
       - name: Create or Update Release PR
-        uses: peter-evans/create-pull-request@v8.1.0
+        uses: peter-evans/create-pull-request@v8.1.1
         with:
           branch: release/dev-to-main
           base: main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,18 +26,18 @@ jobs:
 
     steps:
       - name: 🛎️ Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0  # Fetch all history for proper versioning
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🐍 Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: ⚡ Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           enable-cache: true
 

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           ref: main
           fetch-depth: 0
@@ -37,7 +37,7 @@ jobs:
 
       - name: Create Sync PR
         if: steps.diff.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@v8.1.0
+        uses: peter-evans/create-pull-request@v8.1.1
         with:
           branch: sync/main-to-dev
           base: dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Release impact: treat this as a minor release because the runtime type and generated schema change from integer to number for these fields
 
 ### Fixed
+- **Bulk CSV Volume String Coercion** (#104) - Fixed silent bulk row drops when FMP sends volume as a fractional numeric string:
+  - `coerce_volume_value` now coerces numeric strings such as `"475.9"` via `int(float(...))` for `CompanyProfile` / `Quote` volume fields
+  - Empty/whitespace volume cells become `None`; non-numeric strings still surface as validation errors
+  - Addresses ~9.7% row loss on `profile-bulk` (and other bulk CSV endpoints that use the same helper). Refs #70
 - **Cache Payload Isolation** - Prevented mutable cached payloads from being shared by reference:
   - `BaseClient` now deep-copies cache payloads on both cache read and write paths
   - Added sync and async regression coverage to prevent future cache aliasing regressions
@@ -99,6 +103,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **HTTP Error Traceback Redaction** - Suppressed exception chaining for HTTP status errors so formatted tracebacks do not expose API key query parameters:
   - Updated rate limit, authentication, validation, and fallback HTTP error paths to raise sanitized package exceptions without chaining the raw `httpx.HTTPStatusError`
   - Added regression coverage for API key redaction in formatted tracebacks and exception messages
+- **HTTP Error Payload & Binary Path Redaction** (#97) - Expanded API-key redaction beyond traceback cause suppression:
+  - Redact reflected keys in HTTP error detail payloads (query-string, percent-encoded, nested JSON, and known key names)
+  - Route binary (`response_model is bytes`) status failures through the same typed FMP error mapper
+  - Safely decode non-UTF-8 error bodies, redact 429 bodies before rate-limiter logging, and keep mapped 5xx `FMPError`s retryable
+  - Added regression coverage for sync/async binary paths, non-UTF-8 bodies, and message embedding of error details
 - **VCR Cassette Leak Guard** - Added unit tests that scan all committed VCR cassettes for leaked API keys:
   - `test_vcr_sanitization.py` verifies the VCR `scrub_api_key` / `scrub_response_secrets` hooks and scans every YAML cassette for real API key values
   - `test_cassette_contracts.py` validates every cassette response against its declared Pydantic endpoint model, catching schema drift and stale cassettes
@@ -111,6 +120,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Bumped `codecov/codecov-action` from `v5` to `v6` in CI coverage uploads
   - Bumped `actions/github-script` from `v8` to `v9` in the TestPyPI publishing workflow
   - Bumped `pypa/gh-action-pypi-publish` from `v1.13.0` to `v1.14.0` in publishing workflows
+- **Dependency Refresh** (#105) - Raised GitHub Actions and Python package floors to current stable releases:
+  - Actions: `checkout` 7, `setup-python` 6.3, `setup-uv` 8.3.2, `cache` 6.1, `codecov-action` 7, and related workflow pins
+  - Python: pydantic 2.13, redis 8 (cache-redis extra), mypy 2.x, rich 15, langchain/openai/mcp stack bumps, ruff/pytest/nox updates
+  - Set mypy `python_version` to 3.12 for numpy 2.x stubs while keeping runtime support on 3.10+
 - **VCR Cassettes Excluded from Git** - Cassettes are now gitignored (`tests/integration/vcr_cassettes/`) because they are too large for GitHub (130 MB+ individual files). Developers must record cassettes locally with `FMP_TEST_API_KEY`.
 - **CI Secret Scan** - The `secret-scan` job now gracefully skips when no cassette YAML files are present instead of failing.
 - **Cassette Contract Test** - `test_vcr_cassettes_match_endpoint_models` now skips with a clear message when no cassettes are found, instead of silently passing.

--- a/fmp_data/base.py
+++ b/fmp_data/base.py
@@ -6,8 +6,9 @@ from contextvars import ContextVar
 import copy
 import json
 import logging
+import re
 import time
-from typing import Any, Literal, TypeGuard, TypeVar, cast, overload
+from typing import Any, Literal, NoReturn, TypeGuard, TypeVar, cast, overload
 import warnings
 
 import httpx
@@ -46,10 +47,55 @@ _rate_limit_retry_count: ContextVar[int] = ContextVar(
     "rate_limit_retry_count", default=0
 )
 _extra_field_warnings_seen: set[tuple[str, tuple[str, ...]]] = set()
+_API_KEY_ASSIGNMENT_RE = re.compile(
+    r"([\"']?api_?key[\"']?\s*[=:]\s*[\"']?)([^&\s\"'<>]+)([\"']?)",
+    re.IGNORECASE,
+)
+_API_KEY_ENCODED_RE = re.compile(r"(apikey%3[Dd])([^&\s\"'<>]+)", re.IGNORECASE)
 
 
 def _is_pydantic_model(model: type[Any]) -> TypeGuard[type[BaseModel]]:
     return isinstance(model, type) and issubclass(model, BaseModel)
+
+
+def _redact_api_keys(text: str) -> str:
+    """Redact apikey/api_key values embedded in free-form strings.
+
+    Handles common query-string, percent-encoded (``apikey%3D``), and
+    assignment/JSON-text patterns. For structured dict payloads, use
+    :func:`_sanitize_error_details` (also redacts ``api-key`` keys by name).
+    """
+    redacted = _API_KEY_ASSIGNMENT_RE.sub(r"\1[REDACTED]\3", text)
+    return _API_KEY_ENCODED_RE.sub(r"\1[REDACTED]", redacted)
+
+
+def _sanitize_error_details(
+    value: dict[str, Any] | list[Any] | str,
+) -> dict[str, Any] | list[Any] | str:
+    """Recursively redact API keys from error payloads that may reflect them."""
+    if isinstance(value, str):
+        return _redact_api_keys(value)
+    if isinstance(value, list):
+        return [_sanitize_error_value(item) for item in value]
+    return {
+        key: (
+            "[REDACTED]"
+            if key.lower() in {"apikey", "api_key", "api-key"}
+            else _sanitize_error_value(item)
+        )
+        for key, item in value.items()
+    }
+
+
+def _sanitize_error_value(value: Any) -> Any:
+    """Sanitize a single error-payload value (dict, list, string, or other)."""
+    if isinstance(value, dict):
+        return _sanitize_error_details(value)
+    if isinstance(value, list):
+        return [_sanitize_error_value(item) for item in value]
+    if isinstance(value, str):
+        return _redact_api_keys(value)
+    return value
 
 
 class BaseClient:
@@ -276,6 +322,13 @@ class BaseClient:
             return True
         if isinstance(exc, RateLimitError):
             return True
+        # Mapped FMP errors from status conversion (incl. binary endpoints).
+        if (
+            isinstance(exc, FMPError)
+            and exc.status_code is not None
+            and exc.status_code >= 500
+        ):
+            return True
         if isinstance(exc, httpx.HTTPStatusError):
             return exc.response.status_code >= 500
         return False
@@ -387,7 +440,7 @@ class BaseClient:
             try:
                 data: bytes | dict[str, Any] | list[Any]
                 if endpoint.response_model is bytes:
-                    response.raise_for_status()
+                    self._raise_response_for_status(response)
                     data = response.content
                 else:
                     data = self.handle_response(endpoint, response)
@@ -498,17 +551,45 @@ class BaseClient:
             )
         return cast(dict[str, Any] | list[Any], data)
 
+    def _raise_response_for_status(self, response: httpx.Response) -> None:
+        """Raise typed FMP errors for non-success binary responses.
+
+        Binary endpoints must not re-raise raw ``httpx.HTTPStatusError``:
+        that type stringifies the request URL, which often includes ``apikey``.
+        """
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            self._raise_fmp_http_error(
+                exc,
+                self._safe_error_details(exc.response),
+                exc.response.status_code,
+            )
+
     @staticmethod
     def _get_error_details(
         response: httpx.Response,
     ) -> dict[str, Any] | list[Any]:
+        """Return response body for error reporting with API keys redacted."""
         try:
             data = response.json()
-        except json.JSONDecodeError:
-            return {"raw_content": response.content.decode()}
+        except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
+            raw = response.content.decode("utf-8", errors="replace")
+            return {"raw_content": _redact_api_keys(raw)}
         if isinstance(data, dict | list):
-            return data
-        return {"raw_content": str(data)}
+            return cast(dict[str, Any] | list[Any], _sanitize_error_details(data))
+        return {"raw_content": _redact_api_keys(str(data))}
+
+    @classmethod
+    def _safe_error_details(
+        cls,
+        response: httpx.Response,
+    ) -> dict[str, Any] | list[Any]:
+        """Best-effort error details; never fail open to unreadable bodies."""
+        try:
+            return cls._get_error_details(response)
+        except Exception:
+            return {"raw_content": "[unreadable error body]"}
 
     def _handle_http_status_error(
         self,
@@ -524,7 +605,7 @@ class BaseClient:
                     "_handle_http_status_error() missing required error argument"
                 )
 
-        error_details = self._get_error_details(error.response)
+        error_details = self._safe_error_details(error.response)
         status_code = error.response.status_code
 
         if status_code == 404:
@@ -551,8 +632,24 @@ class BaseClient:
                 )
                 return {}
 
+        self._raise_fmp_http_error(error, error_details, status_code)
+
+    def _raise_fmp_http_error(
+        self,
+        error: httpx.HTTPStatusError,
+        error_details: dict[str, Any] | list[Any],
+        status_code: int,
+    ) -> NoReturn:
+        """Map HTTP status errors to FMP exceptions without chaining httpx.
+
+        ``from None`` is intentional: ``httpx.HTTPStatusError`` stringifies the
+        request URL (often including ``apikey``), so chaining would leak keys
+        into formatted tracebacks.
+        """
         if status_code == 429:
-            self._rate_limiter.handle_response(status_code, error.response.text)
+            self._rate_limiter.handle_response(
+                status_code, _redact_api_keys(error.response.text)
+            )
             retry_after = self._rate_limiter.get_retry_after(error.response.headers)
             wait_time = (
                 retry_after
@@ -902,7 +999,7 @@ class BaseClient:
             try:
                 data: bytes | dict[str, Any] | list[Any]
                 if endpoint.response_model is bytes:
-                    response.raise_for_status()
+                    self._raise_response_for_status(response)
                     data = response.content
                 else:
                     data = self.handle_response(endpoint, response)

--- a/fmp_data/base.py
+++ b/fmp_data/base.py
@@ -313,8 +313,9 @@ class BaseClient:
         if outcome is not None and outcome.failed:
             exc = outcome.exception()
             if isinstance(exc, RateLimitError) and exc.retry_after is not None:
-                return exc.retry_after
-        return wait_exponential(multiplier=1, min=4, max=10)(retry_state)
+                return float(exc.retry_after)
+        wait = wait_exponential(multiplier=1, min=4, max=10)(retry_state)
+        return float(wait)
 
     @staticmethod
     def _is_retryable_error(exc: BaseException) -> bool:

--- a/fmp_data/company/models.py
+++ b/fmp_data/company/models.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import date, datetime
 from decimal import Decimal
 import json
+import math
 from typing import Any
 from urllib.parse import urlparse
 from zoneinfo import ZoneInfo
@@ -25,14 +26,38 @@ from fmp_data.models import ShareFloat
 
 
 def coerce_volume_value(value: Any) -> Any:
-    """Coerce volume values to int (FMP API may return floats).
+    """Coerce volume values to int (FMP may return floats or numeric strings).
+
+    JSON endpoints return volume as a number, but the bulk CSV endpoints (e.g.
+    ``profile-bulk``) return a possibly-fractional string such as ``"475.9"``.
+    Both must land as ``int`` (truncating toward zero) so a fractional value
+    doesn't fail the ``int`` field and silently drop the whole parsed row.
+    Empty strings become ``None``; non-numeric and non-finite values (``nan``,
+    ``inf``) are passed through unchanged so they surface as a validation error
+    instead of raising ``OverflowError`` or masking bad data.
 
     See: https://github.com/MehdiZare/fmp-data/issues/70
     """
     if value is None:
         return None
     if isinstance(value, int | float):
+        # bool is a subclass of int; int(True)==1 would mask bad payloads.
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, float) and not math.isfinite(value):
+            return value
         return int(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        try:
+            number = float(stripped)
+        except ValueError:
+            return value
+        if not math.isfinite(number):
+            return value
+        return int(number)
     return value
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "hatchling>=1.29.0",
+    "hatchling>=1.31.0",
     "hatch-vcs>=0.5.0",
 ]
 build-backend = "hatchling.build"
@@ -47,7 +47,7 @@ classifiers = [
 ]
 dependencies = [
     "httpx>=0.28.1",
-    "pydantic>=2.12.5",
+    "pydantic>=2.13.4",
     "tenacity>=9.1.4",
 ]
 
@@ -64,84 +64,84 @@ fmp-mcp = "fmp_data.mcp.cli:main"
 
 [project.optional-dependencies]
 mcp = [
-    "mcp[cli]>=1.27.0",
+    "mcp[cli]>=1.28.1",
     "pyyaml>=6.0.3",
 ]
 cache-redis = [
-    "redis>=7.4.0",
+    "redis>=8.0.1",
 ]
 langchain = [
-    "faiss-cpu>=1.13.2",
-    "langchain-core>=1.2.26",
-    "langchain-community>=0.4.1",
-    "langchain-openai>=1.1.12",
-    "langgraph>=1.1.6",
-    "openai>=2.30.0",
-    "tiktoken>=0.12.0",
+    "faiss-cpu>=1.14.3",
+    "langchain-core>=1.4.9",
+    "langchain-community>=0.4.2",
+    "langchain-openai>=1.3.5",
+    "langgraph>=1.2.9",
+    "openai>=2.45.0",
+    "tiktoken>=0.13.0",
 ]
 dev = [
-    "ruff>=0.15.9",
-    "mypy>=1.20.0",
+    "ruff>=0.15.21",
+    "mypy>=2.2.0",
     "bandit[toml]>=1.9.4",
-    "pip-audit>=2.10.0",
+    "pip-audit>=2.10.1",
     "python-dotenv>=1.2.2",
-    "pytest>=9.0.2",
-    "pytest-asyncio>=1.3.0",
+    "pytest>=9.1.1",
+    "pytest-asyncio>=1.4.0",
     "pytest-cov>=7.1.0",
     "pytest-mock>=3.15.1",
-    "pytest-xdist>=3.6.1",
+    "pytest-xdist>=3.8.0",
     "freezegun>=1.5.5",
-    "responses>=0.26.0",
-    "vcrpy>=8.1.1",
-    "coverage>=7.13.5",
-    "pre-commit>=4.5.1",
-    "rich>=14.3.3",
+    "responses>=0.26.2",
+    "vcrpy>=8.3.0",
+    "coverage>=7.15.1",
+    "pre-commit>=4.6.0",
+    "rich>=15.0.0",
     "twine>=6.2.0",
-    "nox>=2026.2.9",
+    "nox>=2026.7.11",
 ]
 docs = [
     "mkdocs>=1.6.1",
     "mkdocs-material>=9.7.6",
-    "mkdocstrings-python>=2.0.3",
+    "mkdocstrings-python>=2.0.5",
 ]
 
 [dependency-groups]
 dev = [
-    "ruff>=0.15.9",
-    "mypy>=1.20.0",
+    "ruff>=0.15.21",
+    "mypy>=2.2.0",
     "bandit[toml]>=1.9.4",
-    "pip-audit>=2.10.0",
+    "pip-audit>=2.10.1",
     "python-dotenv>=1.2.2",
-    "pytest>=9.0.2",
-    "pytest-asyncio>=1.3.0",
+    "pytest>=9.1.1",
+    "pytest-asyncio>=1.4.0",
     "pytest-cov>=7.1.0",
     "pytest-mock>=3.15.1",
-    "pytest-xdist>=3.6.1",
+    "pytest-xdist>=3.8.0",
     "freezegun>=1.5.5",
-    "responses>=0.26.0",
-    "vcrpy>=8.1.1",
-    "coverage>=7.13.5",
-    "pre-commit>=4.5.1",
-    "rich>=14.3.3",
+    "responses>=0.26.2",
+    "vcrpy>=8.3.0",
+    "coverage>=7.15.1",
+    "pre-commit>=4.6.0",
+    "rich>=15.0.0",
     "twine>=6.2.0",
-    "nox>=2026.2.9",
+    "nox>=2026.7.11",
 ]
 docs = [
     "mkdocs>=1.6.1",
     "mkdocs-material>=9.7.6",
-    "mkdocstrings-python>=2.0.3",
+    "mkdocstrings-python>=2.0.5",
 ]
 langchain = [
-    "faiss-cpu>=1.13.2",
-    "langchain-core>=1.2.26",
-    "langchain-community>=0.4.1",
-    "langchain-openai>=1.1.12",
-    "langgraph>=1.1.6",
-    "openai>=2.30.0",
-    "tiktoken>=0.12.0",
+    "faiss-cpu>=1.14.3",
+    "langchain-core>=1.4.9",
+    "langchain-community>=0.4.2",
+    "langchain-openai>=1.3.5",
+    "langgraph>=1.2.9",
+    "openai>=2.45.0",
+    "tiktoken>=0.13.0",
 ]
 mcp = [
-    "mcp[cli]>=1.27.0",
+    "mcp[cli]>=1.28.1",
     "pyyaml>=6.0.3",
 ]
 
@@ -223,7 +223,9 @@ known-first-party = [
 force-sort-within-sections = true
 
 [tool.mypy]
-python_version = "3.10"
+# Analyze against 3.12 so third-party stubs (numpy 2.x PEP 695 `type` statements)
+# parse correctly. Runtime still supports Python 3.10+.
+python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -6,7 +6,12 @@ import httpx
 from pydantic import BaseModel, ConfigDict
 import pytest
 
-from fmp_data.base import BaseClient, EndpointGroup
+from fmp_data.base import (
+    BaseClient,
+    EndpointGroup,
+    _sanitize_error_details,
+    _sanitize_error_value,
+)
 from fmp_data.config import ClientConfig
 from fmp_data.exceptions import (
     AuthenticationError,
@@ -239,6 +244,106 @@ def test_get_error_details_json_decode_error():
     assert details == {"raw_content": "not json"}
 
 
+def test_get_error_details_redacts_api_keys():
+    """Error details should not preserve reflected API keys."""
+    fake_key_value = "SECRET_FMP_KEY"
+    response = Mock()
+    response.json.return_value = {
+        "url": f"https://example.test/path?apikey={fake_key_value}&symbol=AAPL",
+        "encoded": f"apikey%3D{fake_key_value}%26symbol%3DAAPL",
+        "apikey": fake_key_value,
+        "nested": [{"message": f'apikey="{fake_key_value}"'}],
+    }
+
+    details = BaseClient._get_error_details(response)
+
+    rendered = repr(details)
+    assert fake_key_value not in rendered
+    assert "[REDACTED]" in rendered
+
+
+def test_get_error_details_redacts_api_keys_in_raw_content():
+    """Non-JSON error bodies should still redact reflected API keys."""
+    fake_key_value = "SECRET_FMP_KEY"
+    response = Mock()
+    response.json.side_effect = json.JSONDecodeError("bad", "doc", 0)
+    response.content = (
+        f"Error at https://api.example/path?apikey={fake_key_value}".encode()
+    )
+
+    details = BaseClient._get_error_details(response)
+
+    assert fake_key_value not in repr(details)
+    assert details["raw_content"].count("[REDACTED]") >= 1
+
+
+def test_get_error_details_redacts_api_keys_in_scalar_json():
+    """Scalar JSON error bodies should redact embedded API keys."""
+    fake_key_value = "SECRET_FMP_KEY"
+    response = Mock()
+    response.json.return_value = f"apikey={fake_key_value}"
+
+    details = BaseClient._get_error_details(response)
+
+    assert fake_key_value not in repr(details)
+    assert "[REDACTED]" in details["raw_content"]
+
+
+def test_get_error_details_handles_non_utf8_body():
+    """Non-UTF-8 error bodies should not raise while extracting details."""
+    request = httpx.Request("GET", "https://example.com")
+    response = httpx.Response(401, request=request, content=b"\xff\xfe binary body")
+
+    details = BaseClient._get_error_details(response)
+
+    assert "raw_content" in details
+    assert isinstance(details["raw_content"], str)
+
+
+def test_sanitize_error_details_top_level_string_and_list():
+    """Sanitize helpers should handle top-level string and list payloads."""
+    fake_key_value = "SECRET_FMP_KEY"
+    redacted_str = _sanitize_error_details(f"apikey={fake_key_value}")
+    assert fake_key_value not in redacted_str
+    assert "[REDACTED]" in redacted_str
+
+    redacted_list = _sanitize_error_details(
+        [f"apikey={fake_key_value}", {"count": 1, "api-key": fake_key_value}]
+    )
+    assert fake_key_value not in repr(redacted_list)
+    assert redacted_list[1]["count"] == 1
+    assert redacted_list[1]["api-key"] == "[REDACTED]"
+
+
+def test_sanitize_error_value_preserves_non_string_scalars():
+    """Non-string scalar values should pass through sanitization unchanged."""
+    assert _sanitize_error_value(42) == 42
+    assert _sanitize_error_value(None) is None
+    assert _sanitize_error_value(True) is True
+    assert _sanitize_error_value(3.14) == 3.14
+
+    nested = _sanitize_error_details(
+        {"code": 401, "ok": False, "retries": None, "items": [1, True, None]}
+    )
+    assert nested == {
+        "code": 401,
+        "ok": False,
+        "retries": None,
+        "items": [1, True, None],
+    }
+
+
+def test_safe_error_details_fallback_when_extraction_raises():
+    """Unreadable bodies should fall back without propagating extraction errors."""
+    response = Mock()
+    with patch.object(
+        BaseClient, "_get_error_details", side_effect=RuntimeError("boom")
+    ):
+        details = BaseClient._safe_error_details(response)
+
+    assert details == {"raw_content": "[unreadable error body]"}
+
+
 def test_handle_http_status_error_404_empty_payloads(base_client):
     """Test 404 errors return empty payloads without raising."""
     request = httpx.Request("GET", "https://example.com")
@@ -253,6 +358,38 @@ def test_handle_http_status_error_404_empty_payloads(base_client):
         "Not found", request=request, response=dict_response
     )
     assert base_client._handle_http_status_error(dict_error) == {}
+
+
+def test_handle_http_status_error_allow_empty_on_404(base_client, mock_endpoint):
+    """Endpoints with allow_empty_on_404 should return [] on 404."""
+    request = httpx.Request("GET", "https://example.com")
+    response = httpx.Response(404, request=request, json={"message": "missing"})
+    error = httpx.HTTPStatusError("Not found", request=request, response=response)
+    mock_endpoint.allow_empty_on_404 = True
+    mock_endpoint.name = "sample-endpoint"
+
+    result = base_client._handle_http_status_error(mock_endpoint, error)
+
+    assert result == []
+
+
+def test_handle_http_status_error_404_non_empty_raises(base_client):
+    """404 with a non-empty payload should raise a typed FMP error."""
+    request = httpx.Request("GET", "https://example.com")
+    response = httpx.Response(404, request=request, json={"message": "missing"})
+    error = httpx.HTTPStatusError("Not found", request=request, response=response)
+
+    with pytest.raises(FMPError) as exc_info:
+        base_client._handle_http_status_error(error)
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.__cause__ is None
+
+
+def test_handle_http_status_error_requires_error_argument(base_client):
+    """Missing error argument should raise TypeError."""
+    with pytest.raises(TypeError, match="missing required error argument"):
+        base_client._handle_http_status_error(None)
 
 
 def test_handle_http_status_error_uses_retry_after_header(base_client):
@@ -272,6 +409,205 @@ def test_handle_http_status_error_uses_retry_after_header(base_client):
         base_client._handle_http_status_error(error)
 
     assert exc_info.value.retry_after == 12.0
+
+
+def test_rate_limit_handler_receives_redacted_response_body(base_client):
+    """429 handling should not pass raw API keys into the rate limiter."""
+    fake_key_value = "SECRET_FMP_KEY"
+    request = httpx.Request("GET", "https://example.com")
+    response = httpx.Response(
+        429,
+        request=request,
+        headers={"Retry-After": "5"},
+        text=f"Rate limited for https://api.example/?apikey={fake_key_value}",
+    )
+    error = httpx.HTTPStatusError(
+        "Too many requests", request=request, response=response
+    )
+
+    with (
+        patch.object(base_client._rate_limiter, "handle_response") as handle_response,
+        patch.object(base_client._rate_limiter, "get_retry_after", return_value=5.0),
+        pytest.raises(RateLimitError),
+    ):
+        base_client._handle_http_status_error(error)
+
+    handle_response.assert_called_once()
+    body = handle_response.call_args.args[1]
+    assert fake_key_value not in body
+    assert "[REDACTED]" in body
+
+
+def test_handle_response_error_traceback_suppresses_httpx_request_url(base_client):
+    """HTTP error handling should not chain tracebacks that expose API keys."""
+    fake_key_value = "SECRET_FMP_KEY"
+    request = httpx.Request(
+        "GET",
+        f"https://financialmodelingprep.com/stable/profile?apikey={fake_key_value}&symbol=AAPL",
+    )
+    response = httpx.Response(
+        401,
+        request=request,
+        json={"message": "Invalid API key"},
+    )
+
+    with pytest.raises(AuthenticationError) as exc_info:
+        base_client.handle_response(response)
+
+    exc = exc_info.value
+    rendered = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+    assert exc.__cause__ is None
+    assert exc.__suppress_context__ is True
+    assert fake_key_value not in rendered
+    assert "HTTPStatusError" not in rendered
+    assert fake_key_value not in repr(exc.response)
+
+
+def test_bytes_response_http_error_uses_typed_fmp_exception(base_client, mock_endpoint):
+    """Binary endpoints map httpx status errors to FMP exceptions without chaining."""
+    fake_key_value = "SECRET_FMP_KEY"
+    request = httpx.Request(
+        "GET",
+        f"https://financialmodelingprep.com/stable/download?apikey={fake_key_value}",
+    )
+    response = httpx.Response(
+        401,
+        request=request,
+        json={"message": "Invalid API key"},
+    )
+    mock_endpoint.method.value = "GET"
+    mock_endpoint.build_url.return_value = (
+        "https://financialmodelingprep.com/stable/download"
+    )
+    mock_endpoint.response_model = bytes
+
+    with (
+        patch.object(base_client.client, "request", return_value=response),
+        pytest.raises(AuthenticationError) as exc_info,
+    ):
+        base_client._execute_request(mock_endpoint)
+
+    exc = exc_info.value
+    rendered = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+    assert exc.__cause__ is None
+    assert exc.__suppress_context__ is True
+    assert fake_key_value not in rendered
+    assert "HTTPStatusError" not in rendered
+    assert fake_key_value not in repr(exc.response)
+
+
+def test_bytes_response_non_utf8_error_body_uses_typed_fmp_exception(
+    base_client, mock_endpoint
+):
+    """Binary non-UTF-8 error bodies still raise typed FMP exceptions safely."""
+    fake_key_value = "SECRET_FMP_KEY"
+    request = httpx.Request(
+        "GET",
+        f"https://financialmodelingprep.com/stable/download?apikey={fake_key_value}",
+    )
+    response = httpx.Response(
+        401,
+        request=request,
+        content=b"\xff\xfe binary error body",
+    )
+    mock_endpoint.method.value = "GET"
+    mock_endpoint.build_url.return_value = (
+        "https://financialmodelingprep.com/stable/download"
+    )
+    mock_endpoint.response_model = bytes
+
+    with (
+        patch.object(base_client.client, "request", return_value=response),
+        pytest.raises(AuthenticationError) as exc_info,
+    ):
+        base_client._execute_request(mock_endpoint)
+
+    exc = exc_info.value
+    rendered = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+    assert exc.__cause__ is None
+    assert exc.__suppress_context__ is True
+    assert fake_key_value not in rendered
+    assert "HTTPStatusError" not in rendered
+    assert fake_key_value not in repr(exc.response)
+
+
+@pytest.mark.asyncio
+async def test_async_bytes_response_http_error_uses_typed_fmp_exception(
+    base_client, mock_endpoint
+):
+    """Async binary endpoints map status errors without chaining httpx."""
+    from unittest.mock import AsyncMock
+
+    fake_key_value = "SECRET_FMP_KEY"
+    request = httpx.Request(
+        "GET",
+        f"https://financialmodelingprep.com/stable/download?apikey={fake_key_value}",
+    )
+    response = httpx.Response(
+        401,
+        request=request,
+        json={"message": "Invalid API key"},
+    )
+    mock_endpoint.method = MagicMock()
+    mock_endpoint.method.value = "GET"
+    mock_endpoint.validate_params.return_value = {}
+    mock_endpoint.build_url.return_value = (
+        "https://financialmodelingprep.com/stable/download"
+    )
+    mock_endpoint.get_query_params.return_value = {}
+    mock_endpoint.response_model = bytes
+
+    mock_async_client = AsyncMock()
+    mock_async_client.request = AsyncMock(return_value=response)
+
+    with (
+        patch.object(
+            base_client, "_setup_async_client", return_value=mock_async_client
+        ),
+        pytest.raises(AuthenticationError) as exc_info,
+    ):
+        await base_client._execute_request_async(mock_endpoint)
+
+    exc = exc_info.value
+    rendered = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+    assert exc.__cause__ is None
+    assert exc.__suppress_context__ is True
+    assert fake_key_value not in rendered
+    assert "HTTPStatusError" not in rendered
+    assert fake_key_value not in repr(exc.response)
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected_exception"),
+    [
+        (400, ValidationError),
+        (500, FMPError),
+    ],
+)
+def test_handle_http_status_error_redacts_key_in_exception_message(
+    base_client: BaseClient,
+    status_code: int,
+    expected_exception: type[FMPError],
+) -> None:
+    """400/500 messages embed error details and must redact reflected keys."""
+    fake_key_value = "SECRET_FMP_KEY"
+    request = httpx.Request("GET", "https://example.com")
+    response = httpx.Response(
+        status_code,
+        request=request,
+        json={
+            "message": f"Failed for https://api.example/?apikey={fake_key_value}",
+            "apikey": fake_key_value,
+        },
+    )
+
+    with pytest.raises(expected_exception) as exc_info:
+        base_client.handle_response(response)
+
+    exc = exc_info.value
+    assert fake_key_value not in str(exc)
+    assert fake_key_value not in repr(exc.response)
+    assert "[REDACTED]" in str(exc)
 
 
 @pytest.mark.parametrize(
@@ -313,6 +649,29 @@ def test_handle_http_status_error_redacts_chained_apikey_traceback(
         assert exc.__suppress_context__ is True
     else:
         pytest.fail(f"Expected {expected_exception.__name__}")
+
+
+def test_is_retryable_error_includes_mapped_5xx_fmp_errors():
+    """Mapped FMP 5xx errors from status conversion should still be retried."""
+    assert BaseClient._is_retryable_error(FMPError("server", status_code=500)) is True
+    assert BaseClient._is_retryable_error(FMPError("server", status_code=503)) is True
+    assert (
+        BaseClient._is_retryable_error(AuthenticationError("auth", status_code=401))
+        is False
+    )
+    assert BaseClient._is_retryable_error(FMPError("client", status_code=400)) is False
+    assert BaseClient._is_retryable_error(FMPError("no status")) is False
+    assert BaseClient._is_retryable_error(RateLimitError("limited", retry_after=1.0))
+    request = httpx.Request("GET", "https://example.com")
+    response_5xx = httpx.Response(503, request=request)
+    response_4xx = httpx.Response(404, request=request)
+    assert BaseClient._is_retryable_error(
+        httpx.HTTPStatusError("server", request=request, response=response_5xx)
+    )
+    assert not BaseClient._is_retryable_error(
+        httpx.HTTPStatusError("not found", request=request, response=response_4xx)
+    )
+    assert not BaseClient._is_retryable_error(ValueError("other"))
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -267,6 +267,53 @@ class TestBatchClient:
         assert results == []
         assert "Skipping invalid SimpleRow row" in caplog.text
 
+    def test_parse_csv_models_keeps_fractional_string_volume(self):
+        """profile-bulk CSV volumes are fractional strings; rows must not drop.
+
+        Regression for Issue #70 / PR #104: coerce_volume_value used to pass
+        strings through, so ``"475.9"`` failed the strict ``int`` field and
+        ``parse_csv_models`` silently skipped the whole row.
+        """
+        csv_text = (
+            "symbol,companyName,currency,exchange,exchangeFullName,"
+            "industry,sector,country,isEtf,isActivelyTrading,isAdr,isFund,"
+            "volume,averageVolume\n"
+            "AAPL,Apple Inc.,USD,NASDAQ,NASDAQ Global Select,"
+            "Consumer Electronics,Technology,US,false,true,false,false,"
+            "475.9,7155681.59509\n"
+        )
+        results = parse_csv_models(csv_text.encode("utf-8"), CompanyProfile)
+
+        assert len(results) == 1
+        assert results[0].symbol == "AAPL"
+        assert results[0].volume == 475
+        assert results[0].vol_avg == 7155681
+        assert isinstance(results[0].volume, int)
+        assert isinstance(results[0].vol_avg, int)
+
+    def test_parse_csv_models_non_finite_volume_skips_row_not_abort(self, caplog):
+        """A single non-finite volume must skip that row, not crash the bulk parse."""
+        import logging
+
+        csv_text = (
+            "symbol,companyName,currency,exchange,exchangeFullName,"
+            "industry,sector,country,isEtf,isActivelyTrading,isAdr,isFund,"
+            "volume,averageVolume\n"
+            "BAD,Bad Co,USD,NASDAQ,NASDAQ,"
+            "Tech,Technology,US,false,true,false,false,"
+            "inf,100\n"
+            "GOOD,Good Co,USD,NASDAQ,NASDAQ,"
+            "Tech,Technology,US,false,true,false,false,"
+            "1000,2000\n"
+        )
+        with caplog.at_level(logging.WARNING, logger="fmp_data.batch._csv_utils"):
+            results = parse_csv_models(csv_text.encode("utf-8"), CompanyProfile)
+
+        assert len(results) == 1
+        assert results[0].symbol == "GOOD"
+        assert results[0].volume == 1000
+        assert "Skipping invalid CompanyProfile row" in caplog.text
+
     @patch("httpx.Client.request")
     def test_get_quotes(
         self, mock_request, fmp_client, mock_response, batch_quote_data

--- a/tests/unit/test_company.py
+++ b/tests/unit/test_company.py
@@ -257,6 +257,56 @@ class TestCompanyProfile:
         assert profile.vol_avg == 50000000
         assert profile.volume == 25000000
 
+    def test_model_validation_fractional_string_volume(self, profile_data):
+        """Bulk CSV endpoints (e.g. profile-bulk) return volume as a fractional
+        STRING such as "475.9"; it must coerce to int instead of failing the
+        ``int`` field and silently dropping the whole parsed row (Issue #70)."""
+        profile_data["volAvg"] = "7155681.59509"
+        profile_data["volume"] = "475.9"
+        profile = CompanyProfile.model_validate(profile_data)
+        assert profile.vol_avg == 7155681
+        assert profile.volume == 475
+        assert isinstance(profile.vol_avg, int)
+        assert isinstance(profile.volume, int)
+
+    def test_model_validation_empty_string_volume(self, profile_data):
+        """An empty/whitespace volume cell (common in CSV rows) coerces to None,
+        not a validation error."""
+        profile_data["volAvg"] = ""
+        profile_data["volume"] = "   "
+        profile = CompanyProfile.model_validate(profile_data)
+        assert profile.vol_avg is None
+        assert profile.volume is None
+
+    def test_model_validation_non_finite_volume_raises(self, profile_data):
+        """Non-finite volume must not raise OverflowError; it surfaces as
+        ValidationError so bulk parsers can skip a single row safely."""
+        from pydantic import ValidationError
+
+        from fmp_data.company.models import coerce_volume_value
+
+        for bad in ("inf", "-inf", "nan", "NaN", float("inf"), float("nan")):
+            # Pass-through (no OverflowError); Pydantic then rejects the value.
+            assert coerce_volume_value(bad) is bad
+            profile_data["volume"] = bad
+            with pytest.raises(ValidationError):
+                CompanyProfile.model_validate(profile_data)
+
+    def test_coerce_volume_value_passthrough_edges(self):
+        """Cover defensive pass-through arms Codecov flags on the patch.
+
+        - bool is a subclass of int; must not become 0/1
+        - non-numeric strings pass through for later ValidationError
+        - unknown types fall through unchanged
+        """
+        from fmp_data.company.models import coerce_volume_value
+
+        assert coerce_volume_value(True) is True
+        assert coerce_volume_value(False) is False
+        assert coerce_volume_value("not_a_number") == "not_a_number"
+        assert coerce_volume_value([1]) == [1]
+        assert coerce_volume_value({"v": 1}) == {"v": 1}
+
     def test_model_validation_invalid_website(self, profile_data):
         """Test CompanyProfile model with invalid website URL"""
         # Use a URL with protocol but invalid hostname (no TLD) to trigger validation


### PR DESCRIPTION
## Release v2.4.0 (minor)

Merge `dev` → `main`. On merge, `release.yml` (label `release:minor`) tags **v2.4.0**, builds, and publishes to PyPI via OIDC.

### Included PRs
| PR | Title | Notes |
|----|-------|-------|
| **#97** | `fix(client): redact FMP http status errors` | Redact API keys from error payloads/tracebacks; binary path typed errors; non-UTF-8 safe decode; 5xx retry restore. Closes #94. |
| **#104** | `fix(company): coerce fractional numeric-string volume to int` | Fix ~9.7% silent `profile-bulk` row drop when volume is a CSV string. Refs #70. |
| **#105** | `chore(deps): bump GitHub Actions and Python deps to latest` | Actions + Python package floor refresh (pydantic, redis 8, mypy 2, langchain stack, etc.). Supersedes #99–#103. |

### Why minor
Security and data-correctness fixes plus a broad dependency refresh (including major floor bumps such as redis 8 / mypy 2). Cut as **minor** so the next tag is **v2.4.0** (latest tag is `v2.3.1`).

### Validation
- #97, #104, #105 CI green on `dev` (tests 3.10–3.14, coverage, CodeQL, codecov)
- CHANGELOG updated under Unreleased for these three items

### After merge
Release workflow will:
1. Create git tag `v2.4.0`
2. Build and publish to PyPI
3. Create GitHub Release