### PR TITLE
feat(intelligence): add includeReportTimes to earnings endpoints (#111) + dependency refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,17 +25,17 @@ jobs:
 
     steps:
       - name: 🛎️  Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
 
       - name: 🐍  Set up Python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@v7.0.0
         with:
           python-version: ${{ matrix.python }}
 
       - name: ⚡  Install uv (with cache)
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
 
@@ -70,15 +70,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛎️  Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: 🐍  Set up Python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@v7.0.0
         with:
           python-version: "3.14"
 
       - name: ⚡  Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@v9.0.0
 
       - name: 📊 Run all tests with coverage
         env:
@@ -100,10 +100,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛎️  Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: 🐍  Set up Python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@v7.0.0
         with:
           python-version: "3.14"
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 1
 

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -19,18 +19,18 @@ jobs:
 
     steps:
       - name: 🛎️  Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0  # Needed for version calculation
           fetch-tags: true
 
       - name: 🐍  Set up Python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@v7.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: ⚡  Install uv (with cache)
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
 
@@ -124,7 +124,7 @@ jobs:
           fi
 
       - name: 🧪  Upload to Test PyPI
-        uses: pypa/gh-action-pypi-publish@v1.14.0
+        uses: pypa/gh-action-pypi-publish@v1.14.1
         with:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: dist

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -39,16 +39,16 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6.3.0
+      - uses: actions/setup-python@v7.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
 

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -36,18 +36,18 @@ jobs:
 
     steps:
       - name: 🛎️  Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0  # Needed for version calculation
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: 🐍  Set up Python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@v7.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: ⚡  Install uv (with cache)
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
 
@@ -108,7 +108,7 @@ jobs:
           fi
 
       - name: 🧪  Upload to Test PyPI
-        uses: pypa/gh-action-pypi-publish@v1.14.0
+        uses: pypa/gh-action-pypi-publish@v1.14.1
         with:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: dist
@@ -179,17 +179,17 @@ jobs:
 
     steps:
       - name: 🛎️  Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0  # Needed for hatch-vcs versioning
 
       - name: 🐍  Set up Python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@v7.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: ⚡  Install uv (with cache)
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
 
@@ -199,7 +199,7 @@ jobs:
           python -m build --wheel --sdist
 
       - name: 🚀  Upload to Test PyPI
-        uses: pypa/gh-action-pypi-publish@v1.14.0
+        uses: pypa/gh-action-pypi-publish@v1.14.1
         with:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: dist

--- a/.github/workflows/rebase-reminder.yml
+++ b/.github/workflows/rebase-reminder.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR head
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
           ref: dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,18 +26,18 @@ jobs:
 
     steps:
       - name: 🛎️ Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0  # Fetch all history for proper versioning
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🐍 Set up Python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@v7.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: ⚡ Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
 
@@ -180,7 +180,7 @@ jobs:
           fi
 
       - name: 🚀 Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.14.0
+        uses: pypa/gh-action-pypi-publish@v1.14.1
         with:
           packages-dir: dist/
           skip-existing: true

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         with:
           ref: main
           fetch-depth: 0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   # ───────── Core utility hooks ───────────────────────────────────────────
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -15,23 +15,20 @@ repos:
       - id: check-merge-conflict
       - id: check-docstring-first
 
-  # ───────── Black code formatter ─────────────────────────────────────────
-  - repo: https://github.com/psf/black
-    rev: 24.10.0
-    hooks:
-      - id: black
-        language_version: python3
-
-  # ───────── Ruff (lint / fix) ─────────────────────────────────────────────
+  # ───────── Ruff (lint / fix / format) ────────────────────────────────────
+  # Ruff replaces black here: black 24.x and ruff's formatter disagree on
+  # assert-with-message wrapping, so running both fights over the same lines.
+  # Keep this rev in sync with the ruff pin in uv.lock.
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.2
+    rev: v0.16.1
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
 
   # ───────── Bandit security scanner ──────────────────────────────────────
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.8.5
+    rev: 1.9.4
     hooks:
       - id: bandit
         name: bandit

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -155,14 +155,14 @@
         "filename": "docs/mcp/troubleshooting.md",
         "hashed_secret": "f4bd37ba60c10958ceda8e9c77b44404035e07a0",
         "is_verified": false,
-        "line_number": 126
+        "line_number": 127
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/mcp/troubleshooting.md",
         "hashed_secret": "a3e14ca24483c78554c083bc907c7194c7846ef1",
         "is_verified": false,
-        "line_number": 223
+        "line_number": 225
       }
     ],
     "examples/mcp/claude_desktop/README.md": [
@@ -171,7 +171,7 @@
         "filename": "examples/mcp/claude_desktop/README.md",
         "hashed_secret": "cf4a956e75901c220c0f5fbaec41987fc6177345",
         "is_verified": false,
-        "line_number": 138
+        "line_number": 137
       }
     ],
     "examples/mcp/claude_desktop/claude_desktop_config.json": [
@@ -214,14 +214,14 @@
         "filename": "examples/mcp/claude_desktop/troubleshooting.md",
         "hashed_secret": "f4bd37ba60c10958ceda8e9c77b44404035e07a0",
         "is_verified": false,
-        "line_number": 126
+        "line_number": 127
       },
       {
         "type": "Secret Keyword",
         "filename": "examples/mcp/claude_desktop/troubleshooting.md",
         "hashed_secret": "a3e14ca24483c78554c083bc907c7194c7846ef1",
         "is_verified": false,
-        "line_number": 223
+        "line_number": 225
       }
     ],
     "examples/mcp/setup_guide.md": [
@@ -234,5 +234,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-09T00:55:58Z"
+  "generated_at": "2026-08-06T12:26:27Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Notable bumps: `mcp` 1.28.1 → 2.0.0, `ruff` 0.15.21 → 0.16.1, `mypy` 2.2.0 → 2.3.0, `cryptography` 49 → 50, `twine` 6.2.0 → 7.0.0
   - Actions: `checkout` v7.0.1, `setup-python` v7.0.0, `setup-uv` v9.0.0, `gh-action-pypi-publish` v1.14.1 (closes #107, #108, #109, #110)
   - Dropped the `black` pre-commit hook: black 24.x and ruff 0.16's formatter disagree on assert-message wrapping, and ruff already formats this project
-  - Reformatted the tree with ruff 0.16 (formatting only, no behavior change)
+  - Reformatted the tree with ruff 0.16 (formatting only, no behavior change); 0.16 also formats Python blocks inside Markdown, hence the docs churn
+  - The `nox -s security` session now upgrades pip before auditing instead of suppressing `CVE-2026-1703`, so the report covers project dependencies rather than the virtualenv's bundled pip
 - **Volume Type Normalization** - Normalized price-model volume fields to always deserialize as `float`:
   - `alternative.HistoricalPrice.volume` and `alternative.HistoricalPrice.unadjusted_volume` now normalize whole-number payloads such as `123` to `123.0`
   - `company.IntradayPrice.volume` now normalizes whole-number payloads to `float` as well

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+- **Earnings Report Times** (#111) - Added the `includeReportTimes` parameter to the earnings endpoints:
+  - `get_earnings_calendar(include_report_times=True)` and `get_historical_earnings(include_report_times=True)` on both sync and async clients
+  - When set, `EarningEvent` carries `time` (`"bmo"` / `"amc"`), `period_ending`, `fiscal_period`, `fiscal_year` and `confirmed`
+  - These five fields are `None` when the flag is omitted, so existing calls are unaffected
+  - `get_historical_earnings()` also accepts `limit` now
+  - Thanks to @joshuatz for the report
 - **New Company Endpoint** - Added `get_profile_cik()` method to retrieve company profile using CIK (Central Index Key) number
   - Available in both sync (`CompanyClient`) and async (`AsyncCompanyClient`) clients
   - Endpoint: `/stable/profile-cik`
@@ -21,6 +27,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added optional `cache-redis` extra for Redis-backed caching
 
 ### Changed
+- **MCP SDK 2.x Support** - The MCP server now works against both MCP SDK 1.x and 2.x:
+  - MCP SDK 2.0 renamed `mcp.server.fastmcp.FastMCP` to `mcp.server.MCPServer`
+  - Added `fmp_data.mcp._compat` to resolve whichever class the installed SDK provides
+  - The `mcp` extra floor stays at `>=1.28.1`, so no forced SDK upgrade for existing installs
+- **Dependency Refresh** - Upgraded all locked dependencies and GitHub Actions to their latest releases:
+  - Notable bumps: `mcp` 1.28.1 → 2.0.0, `ruff` 0.15.21 → 0.16.1, `mypy` 2.2.0 → 2.3.0, `cryptography` 49 → 50, `twine` 6.2.0 → 7.0.0
+  - Actions: `checkout` v7.0.1, `setup-python` v7.0.0, `setup-uv` v9.0.0, `gh-action-pypi-publish` v1.14.1 (closes #107, #108, #109, #110)
+  - Dropped the `black` pre-commit hook: black 24.x and ruff 0.16's formatter disagree on assert-message wrapping, and ruff already formats this project
+  - Reformatted the tree with ruff 0.16 (formatting only, no behavior change)
 - **Volume Type Normalization** - Normalized price-model volume fields to always deserialize as `float`:
   - `alternative.HistoricalPrice.volume` and `alternative.HistoricalPrice.unadjusted_volume` now normalize whole-number payloads such as `123` to `123.0`
   - `company.IntradayPrice.volume` now normalizes whole-number payloads to `float` as well
@@ -28,6 +43,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Release impact: treat this as a minor release because the runtime type and generated schema change from integer to number for these fields
 
 ### Fixed
+- **Historical Earnings 404** (#111) - Fixed `get_historical_earnings()` returning nothing:
+  - The endpoint pointed at the legacy `historical/earning-calendar` path, which 404s on `/stable`
+  - Now uses the stable `/earnings` path; the VCR cassette records a 200 with real data
+  - Integration test now asserts a non-empty response so a future path break fails loudly
 - **Bulk CSV Volume String Coercion** (#104) - Fixed silent bulk row drops when FMP sends volume as a fractional numeric string:
   - `coerce_volume_value` now coerces numeric strings such as `"475.9"` via `int(float(...))` for `CompanyProfile` / `Quote` volume fields
   - Empty/whitespace volume cells become `None`; non-numeric strings still surface as validation errors
@@ -93,6 +112,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Cassette Contract Test** - Enhanced to run in `warn` mode and assert zero uncaptured fields (excluding dynamic SEC XBRL taxonomy keys in AsReported models)
 
 ### Deprecated
+- **Confirmed Earnings & Earnings Surprises Endpoints** (#111) - Marked `get_earnings_confirmed()` and `get_earnings_surprises()` as deprecated:
+  - FMP no longer serves `earning-calendar-confirmed` or `earnings-surprises` on `/stable` (both return 404)
+  - Both sync and async methods now emit `DeprecationWarning` naming the replacement
+  - Replace `get_earnings_confirmed()` with `get_earnings_calendar(include_report_times=True)` and read `confirmed` / `time`
+  - Replace `get_earnings_surprises()` with `get_historical_earnings()` and compare `eps` against `eps_estimated`
+  - The `EarningConfirmed` and `EarningSurprise` models are retained for now; removal is planned for the next major version
 - **Stock News Sentiments Endpoint** - Marked `get_stock_news_sentiments()` as deprecated:
   - FMP API no longer supports the `stock-news-sentiments-rss-feed` endpoint (returns 404)
   - Both sync and async methods now emit `DeprecationWarning` with clear migration message
@@ -246,7 +271,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   # New (2.0.0+)
   vector_store = EndpointVectorStore.load(
       cache_dir,
-      allow_dangerous_deserialization=True  # Only if you trust the cache source
+      allow_dangerous_deserialization=True,  # Only if you trust the cache source
   )
   ```
 

--- a/LLM.md
+++ b/LLM.md
@@ -40,11 +40,13 @@ with FMPDataClient.from_env() as client:
 import asyncio
 from fmp_data import AsyncFMPDataClient
 
+
 async def main():
     async with AsyncFMPDataClient.from_env() as client:
         quote = await client.company.get_quote("AAPL")
         rsi = await client.technical.get_rsi("AAPL", period_length=14)
         return quote, rsi
+
 
 asyncio.run(main())
 ```

--- a/README.md
+++ b/README.md
@@ -227,15 +227,15 @@ from fmp_data import create_vector_store
 
 # Initialize the vector store
 vector_store = create_vector_store(
-    fmp_api_key="YOUR_FMP_API_KEY",       # pragma: allowlist secret
-    openai_api_key="YOUR_OPENAI_API_KEY"  # pragma: allowlist secret
+    fmp_api_key="YOUR_FMP_API_KEY",  # pragma: allowlist secret
+    openai_api_key="YOUR_OPENAI_API_KEY",  # pragma: allowlist secret
 )
 
 # Example queries
 queries = [
     "what is the price of Apple stock?",
     "what was the revenue of Tesla last year?",
-    "what's new in the market?"
+    "what's new in the market?",
 ]
 
 # Search for relevant endpoints and tools
@@ -249,7 +249,7 @@ for query in queries:
     for tool in tools:
         print(f"Name: {tool.get('name')}")
         print(f"Description: {tool.get('description')}")
-        print("Parameters:", tool.get('parameters'))
+        print("Parameters:", tool.get("parameters"))
         print()
 
     # You can also search endpoints directly
@@ -276,10 +276,10 @@ from fmp_data.lc.embedding import EmbeddingProvider
 
 # Configure with LangChain support
 config = LangChainConfig(
-    api_key="YOUR_FMP_API_KEY",           # pragma: allowlist secret
+    api_key="YOUR_FMP_API_KEY",  # pragma: allowlist secret
     embedding_provider=EmbeddingProvider.OPENAI,
-    embedding_api_key="YOUR_OPENAI_API_KEY", # pragma: allowlist secret
-    embedding_model="text-embedding-3-small"
+    embedding_api_key="YOUR_OPENAI_API_KEY",  # pragma: allowlist secret
+    embedding_model="text-embedding-3-small",
 )
 
 # Create client with LangChain config
@@ -328,23 +328,23 @@ from fmp_data import FMPDataClient, ClientConfig, LoggingConfig
 from fmp_data.exceptions import FMPError, RateLimitError, AuthenticationError
 
 # Method 1: Initialize with direct API key
-client = FMPDataClient(api_key="your_api_key_here") # pragma: allowlist secret
+client = FMPDataClient(api_key="your_api_key_here")  # pragma: allowlist secret
 
 # Method 2: Initialize from environment variable (FMP_API_KEY)
 client = FMPDataClient.from_env()
 
 # Method 3: Initialize with custom configuration
 config = ClientConfig(
-    api_key="your_api_key_here", #pragma: allowlist secret
+    api_key="your_api_key_here",  # pragma: allowlist secret
     timeout=30,
     max_retries=3,
     base_url="https://financialmodelingprep.com",
-    logging=LoggingConfig(level="INFO")
+    logging=LoggingConfig(level="INFO"),
 )
 client = FMPDataClient(config=config)
 
 # Using with context manager (recommended)
-with FMPDataClient(api_key="your_api_key_here") as client: # pragma: allowlist secret
+with FMPDataClient(api_key="your_api_key_here") as client:  # pragma: allowlist secret
     try:
         # Get company profile
         profile = client.company.get_profile("AAPL")
@@ -422,14 +422,11 @@ with FMPDataClient.from_env() as client:
     income_stmt = client.fundamental.get_income_statement(
         "AAPL",
         period="quarter",  # or "annual"
-        limit=4
+        limit=4,
     )
 
     # Get balance sheets
-    balance_sheet = client.fundamental.get_balance_sheet(
-        "AAPL",
-        period="annual"
-    )
+    balance_sheet = client.fundamental.get_balance_sheet("AAPL", period="annual")
 
     # Get cash flow statements
     cash_flow = client.fundamental.get_cash_flow("AAPL")
@@ -445,16 +442,11 @@ with FMPDataClient.from_env() as client:
 
     # Get historical prices
     history = client.company.get_historical_prices(
-        symbol="TSLA",
-        from_date=date(2023, 1, 1),
-        to_date=date(2023, 12, 31)
+        symbol="TSLA", from_date=date(2023, 1, 1), to_date=date(2023, 12, 31)
     )
 
     # Get intraday prices
-    intraday = client.company.get_intraday_prices(
-        "TSLA",
-        interval="5min"
-    )
+    intraday = client.company.get_intraday_prices("TSLA", interval="5min")
 ```
 
 ### 4. Technical Indicators
@@ -464,25 +456,14 @@ from datetime import date
 
 with FMPDataClient.from_env() as client:
     # Simple Moving Average
-    sma = client.technical.get_sma(
-        "AAPL",
-        period_length=20,
-        timeframe="1day"
-    )
+    sma = client.technical.get_sma("AAPL", period_length=20, timeframe="1day")
 
     # RSI (Relative Strength Index)
-    rsi = client.technical.get_rsi(
-        "AAPL",
-        period_length=14,
-        timeframe="1day"
-    )
+    rsi = client.technical.get_rsi("AAPL", period_length=14, timeframe="1day")
 
     # MACD
     macd = client.technical.get_macd(
-        "AAPL",
-        fast_period=12,
-        slow_period=26,
-        signal_period=9
+        "AAPL", fast_period=12, slow_period=26, signal_period=9
     )
 ```
 
@@ -598,6 +579,7 @@ API reference in `docs/api/reference.md#async-client-usage`.
 from fmp_data import AsyncFMPDataClient
 import asyncio
 
+
 async def main():
     async with AsyncFMPDataClient.from_env() as client:
         # All endpoint methods are async
@@ -612,6 +594,7 @@ async def main():
         )
         for p in profiles:
             print(f"{p.symbol}: {p.company_name}")
+
 
 asyncio.run(main())
 ```
@@ -645,7 +628,13 @@ FMP_MCP_MANIFEST=/path/to/custom/manifest.py
 
 ### Custom Configuration
 ```python
-from fmp_data import FMPDataClient, ClientConfig, LoggingConfig, RateLimitConfig, LogHandlerConfig
+from fmp_data import (
+    FMPDataClient,
+    ClientConfig,
+    LoggingConfig,
+    RateLimitConfig,
+    LogHandlerConfig,
+)
 
 config = ClientConfig(
     api_key="your_api_key_here",  # pragma: allowlist secret
@@ -653,9 +642,7 @@ config = ClientConfig(
     max_retries=3,
     base_url="https://financialmodelingprep.com",
     rate_limit=RateLimitConfig(
-        daily_limit=250,
-        requests_per_second=10,
-        requests_per_minute=300
+        daily_limit=250, requests_per_second=10, requests_per_minute=300
     ),
     logging=LoggingConfig(
         level="DEBUG",
@@ -663,7 +650,7 @@ config = ClientConfig(
             "console": LogHandlerConfig(
                 class_name="StreamHandler",
                 level="INFO",
-                format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+                format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
             ),
             "file": LogHandlerConfig(
                 class_name="RotatingFileHandler",
@@ -672,11 +659,11 @@ config = ClientConfig(
                 handler_kwargs={
                     "filename": "fmp.log",
                     "maxBytes": 10485760,
-                    "backupCount": 5
-                }
-            )
-        }
-    )
+                    "backupCount": 5,
+                },
+            ),
+        },
+    ),
 )
 
 client = FMPDataClient(config=config)
@@ -689,15 +676,15 @@ The library provides a comprehensive exception hierarchy for robust error handli
 ```python
 from fmp_data import FMPDataClient
 from fmp_data.exceptions import (
-    FMPError,              # Base exception for all FMP errors
-    RateLimitError,        # API rate limit exceeded
-    AuthenticationError,   # Invalid or missing API key
-    ValidationError,       # Invalid request parameters
-    ConfigError,           # Configuration errors
-    InvalidSymbolError,    # Missing or blank required symbol
+    FMPError,  # Base exception for all FMP errors
+    RateLimitError,  # API rate limit exceeded
+    AuthenticationError,  # Invalid or missing API key
+    ValidationError,  # Invalid request parameters
+    ConfigError,  # Configuration errors
+    InvalidSymbolError,  # Missing or blank required symbol
     InvalidResponseTypeError,  # Unexpected API response type
-    DependencyError,       # Missing optional dependency
-    FMPNotFound,          # Symbol or resource not found
+    DependencyError,  # Missing optional dependency
+    FMPNotFound,  # Symbol or resource not found
 )
 
 try:

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -383,10 +383,10 @@ with FMPDataClient.from_env() as client:
 
 # Manual initialization
 client = FMPDataClient(
-    api_key="your_api_key", # pragma: allowlist secret
+    api_key="your_api_key",  # pragma: allowlist secret
     timeout=30,
     max_retries=3,
-    debug=True
+    debug=True,
 )
 ```
 
@@ -396,6 +396,7 @@ client = FMPDataClient(
 import asyncio
 from fmp_data import AsyncFMPDataClient
 
+
 async def main():
     # Initialize from environment
     async with AsyncFMPDataClient.from_env() as client:
@@ -404,16 +405,17 @@ async def main():
 
     # Manual initialization
     client = AsyncFMPDataClient(
-        api_key="your_api_key", # pragma: allowlist secret
+        api_key="your_api_key",  # pragma: allowlist secret
         timeout=30,
         max_retries=3,
-        debug=True
+        debug=True,
     )
     try:
         quote = await client.company.get_quote("AAPL")
         print(f"Price: ${quote.price}")
     finally:
         await client.aclose()
+
 
 asyncio.run(main())
 ```
@@ -424,6 +426,7 @@ asyncio.run(main())
 import asyncio
 from fmp_data import AsyncFMPDataClient
 
+
 async def fetch_multiple_profiles(symbols: list[str]):
     async with AsyncFMPDataClient.from_env() as client:
         # Fetch all profiles concurrently
@@ -432,6 +435,7 @@ async def fetch_multiple_profiles(symbols: list[str]):
 
         for profile in profiles:
             print(f"{profile.symbol}: {profile.company_name}")
+
 
 asyncio.run(fetch_multiple_profiles(["AAPL", "MSFT", "GOOGL"]))
 ```
@@ -443,7 +447,7 @@ from fmp_data import FMPDataClient, ClientConfig, LoggingConfig, LogHandlerConfi
 
 # Custom configuration
 config = ClientConfig(
-    api_key="your_api_key", # pragma: allowlist secret
+    api_key="your_api_key",  # pragma: allowlist secret
     base_url="https://financialmodelingprep.com",
     timeout=60,
     max_retries=5,
@@ -453,10 +457,10 @@ config = ClientConfig(
             "console": LogHandlerConfig(
                 class_name="StreamHandler",
                 level="INFO",
-                format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+                format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
             )
-        }
-    )
+        },
+    ),
 )
 
 client = FMPDataClient(config=config)
@@ -470,7 +474,7 @@ from fmp_data.exceptions import (
     FMPError,
     RateLimitError,
     AuthenticationError,
-    ValidationError
+    ValidationError,
 )
 
 try:
@@ -503,15 +507,15 @@ logging_config = LoggingConfig(
         "console": LogHandlerConfig(
             class_name="StreamHandler",
             level="INFO",
-            format="%(levelname)s - %(message)s"
-        )
-    }
+            format="%(levelname)s - %(message)s",
+        ),
+    },
 )
 
 client = FMPDataClient(
     config=ClientConfig(
         api_key="your_api_key",  # pragma: allowlist secret
-        logging=logging_config
+        logging=logging_config,
     )
 )
 ```

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -49,13 +49,16 @@ tests/
 ```python
 import pytest
 
+
 @pytest.fixture
 def api_key():
     return "test_api_key"
 
+
 @pytest.fixture
 def client(api_key):
     from fmp_data import FMPDataClient
+
     return FMPDataClient(api_key=api_key)
 ```
 
@@ -65,11 +68,10 @@ from unittest.mock import Mock
 
 from fmp_data.company.models import CompanyProfile
 
+
 def test_get_company_profile(client):
     """Test retrieving company profile."""
-    client.company.client.request = Mock(
-        return_value=[CompanyProfile(symbol="AAPL")]
-    )
+    client.company.client.request = Mock(return_value=[CompanyProfile(symbol="AAPL")])
     profile = client.company.get_profile("AAPL")
     assert profile.symbol == "AAPL"
 ```
@@ -83,11 +85,10 @@ from unittest.mock import Mock
 
 from fmp_data.company.models import CompanyProfile
 
+
 def test_api_call(client):
     # Mock API response at the client request layer
-    client.company.client.request = Mock(
-        return_value=[CompanyProfile(symbol="AAPL")]
-    )
+    client.company.client.request = Mock(return_value=[CompanyProfile(symbol="AAPL")])
 
     # Make request through business logic
     result = client.company.get_profile("AAPL")

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,6 +91,7 @@ For async applications, use `AsyncFMPDataClient`:
 import asyncio
 from fmp_data import AsyncFMPDataClient
 
+
 async def main():
     async with AsyncFMPDataClient.from_env() as client:
         # All methods are async - same names as sync client
@@ -100,9 +101,10 @@ async def main():
         # Fetch multiple items concurrently
         quote, income = await asyncio.gather(
             client.company.get_quote("AAPL"),
-            client.fundamental.get_income_statement("AAPL", period="annual")
+            client.fundamental.get_income_statement("AAPL", period="annual"),
         )
         print(f"Price: ${quote.price}, Revenue: ${income[0].revenue:,.0f}")
+
 
 asyncio.run(main())
 ```
@@ -242,6 +244,7 @@ with FMPDataClient.from_env() as client:
 import asyncio
 from fmp_data import AsyncFMPDataClient
 
+
 async def analyze_portfolio(symbols: list[str]):
     async with AsyncFMPDataClient.from_env() as client:
         # Fetch all profiles concurrently
@@ -256,6 +259,7 @@ async def analyze_portfolio(symbols: list[str]):
 
         for profile, quote in zip(profiles, quotes):
             print(f"{profile.symbol}: ${quote.price:,.2f} ({profile.sector})")
+
 
 asyncio.run(analyze_portfolio(["AAPL", "MSFT", "GOOGL", "AMZN"]))
 ```

--- a/docs/mcp/troubleshooting.md
+++ b/docs/mcp/troubleshooting.md
@@ -121,9 +121,10 @@ Update your config with the correct path:
 ```python
 # Check your current limits
 import requests
+
 response = requests.get(
     "https://financialmodelingprep.com/stable/profile?symbol=AAPL",
-    params={"apikey": "YOUR_KEY"}
+    params={"apikey": "YOUR_KEY"},
 )
 print(f"Remaining calls: {response.headers.get('X-Rate-Limit-Remaining', 'Unknown')}")
 print(f"Limit: {response.headers.get('X-Rate-Limit-Limit', 'Unknown')}")
@@ -220,6 +221,7 @@ except json.JSONDecodeError as e:
 ```python
 # test_mcp.py
 import os
+
 os.environ["FMP_API_KEY"] = "your_key_here"
 
 from fmp_data.mcp.server import create_app
@@ -230,6 +232,7 @@ try:
 
     # Test a simple tool
     from fmp_data import FMPDataClient
+
     client = FMPDataClient.from_env()
     quote = client.company.get_quote("AAPL")
     print(f"✅ API working - AAPL price: ${quote.price}")

--- a/examples/mcp/claude_desktop/README.md
+++ b/examples/mcp/claude_desktop/README.md
@@ -118,7 +118,6 @@ TOOLS = [
     "company.profile",
     "company.quote",
     "market.quote",
-
     # Add more tools as needed
     "fundamental.income_statement",
     "intelligence.stock_news",

--- a/examples/mcp/claude_desktop/troubleshooting.md
+++ b/examples/mcp/claude_desktop/troubleshooting.md
@@ -121,9 +121,10 @@ Update your config with the correct path:
 ```python
 # Check your current limits
 import requests
+
 response = requests.get(
     "https://financialmodelingprep.com/api/v3/profile/AAPL",
-    params={"apikey": "YOUR_KEY"}
+    params={"apikey": "YOUR_KEY"},
 )
 print(f"Remaining calls: {response.headers.get('X-Rate-Limit-Remaining', 'Unknown')}")
 print(f"Limit: {response.headers.get('X-Rate-Limit-Limit', 'Unknown')}")
@@ -220,6 +221,7 @@ except json.JSONDecodeError as e:
 ```python
 # test_mcp.py
 import os
+
 os.environ["FMP_API_KEY"] = "your_key_here"
 
 from fmp_data.mcp.server import create_app
@@ -230,6 +232,7 @@ try:
 
     # Test a simple tool
     from fmp_data import FMPDataClient
+
     client = FMPDataClient.from_env()
     quote = client.company.get_quote("AAPL")
     print(f"✅ API working - AAPL price: ${quote.price}")

--- a/examples/workflows/portfolio_analysis.py
+++ b/examples/workflows/portfolio_analysis.py
@@ -69,7 +69,9 @@ def analyze_portfolio(client: FMPDataClient, portfolio: list[str]) -> None:
                 signal = (
                     "Overbought"
                     if current_rsi > 70
-                    else "Oversold" if current_rsi < 30 else "Neutral"
+                    else "Oversold"
+                    if current_rsi < 30
+                    else "Neutral"
                 )
                 print(f"{symbol}: RSI = {current_rsi:.2f} ({signal})")
         except FMPError as e:

--- a/fmp_data/intelligence/async_client.py
+++ b/fmp_data/intelligence/async_client.py
@@ -2,9 +2,10 @@
 """Async client for market intelligence endpoints."""
 
 from datetime import date
+from typing import Any
 
 from fmp_data.base import AsyncEndpointGroup
-from fmp_data.helpers import RemovedEndpointError, removed
+from fmp_data.helpers import RemovedEndpointError, deprecated, removed
 from fmp_data.intelligence.endpoints import (
     CROWDFUNDING_BY_CIK,
     CROWDFUNDING_RSS,
@@ -126,27 +127,87 @@ class AsyncMarketIntelligenceClient(AsyncEndpointGroup):
         return params
 
     async def get_earnings_calendar(
-        self, start_date: date | None = None, end_date: date | None = None
+        self,
+        start_date: date | None = None,
+        end_date: date | None = None,
+        include_report_times: bool | None = None,
     ) -> list[EarningEvent]:
-        """Get earnings calendar"""
-        params = self._build_date_params(start_date, end_date)
+        """Get earnings calendar
+
+        Args:
+            start_date: Earliest reporting date to include
+            end_date: Latest reporting date to include
+            include_report_times: When True, each event also carries ``time``
+                ('bmo'/'amc'), ``period_ending``, ``fiscal_period``,
+                ``fiscal_year`` and ``confirmed``
+
+        Returns:
+            list[EarningEvent]: Earnings events in the requested window
+        """
+        params: dict[str, Any] = self._build_date_params(start_date, end_date)
+        if include_report_times is not None:
+            params["include_report_times"] = include_report_times
         return await self.client.request_async(EARNINGS_CALENDAR, **params)
 
-    async def get_historical_earnings(self, symbol: str) -> list[EarningEvent]:
-        """Get historical earnings"""
-        return await self.client.request_async(HISTORICAL_EARNINGS, symbol=symbol)
+    async def get_historical_earnings(
+        self,
+        symbol: str,
+        limit: int | None = None,
+        include_report_times: bool | None = None,
+    ) -> list[EarningEvent]:
+        """Get historical and upcoming earnings reports for a symbol
 
+        Args:
+            symbol: Stock symbol
+            limit: Maximum number of reports to return
+            include_report_times: When True, each report also carries ``time``
+                ('bmo'/'amc'), ``period_ending``, ``fiscal_period``,
+                ``fiscal_year`` and ``confirmed``
+
+        Returns:
+            list[EarningEvent]: Earnings reports for the symbol
+        """
+        params: dict[str, Any] = {"symbol": symbol}
+        if limit is not None:
+            params["limit"] = limit
+        if include_report_times is not None:
+            params["include_report_times"] = include_report_times
+        return await self.client.request_async(HISTORICAL_EARNINGS, **params)
+
+    @deprecated(
+        "The FMP API no longer serves the confirmed earnings calendar. Use "
+        "get_earnings_calendar(include_report_times=True) and read the "
+        "`confirmed` and `time` fields instead."
+    )
     async def get_earnings_confirmed(
         self,
         start_date: date | None = None,
         end_date: date | None = None,
     ) -> list[EarningConfirmed]:
-        """Get confirmed earnings dates"""
+        """Get confirmed earnings dates
+
+        .. deprecated::
+            This endpoint is no longer available on the FMP API and will be
+            removed in a future version. Use
+            :meth:`get_earnings_calendar` with ``include_report_times=True``
+            and read the ``confirmed`` and ``time`` fields instead.
+        """
         params = self._build_date_params(start_date, end_date)
         return await self.client.request_async(EARNINGS_CONFIRMED, **params)
 
+    @deprecated(
+        "The FMP API no longer serves earnings surprises. Use "
+        "get_historical_earnings() and compare `eps` against `eps_estimated` "
+        "instead."
+    )
     async def get_earnings_surprises(self, symbol: str) -> list[EarningSurprise]:
-        """Get earnings surprises"""
+        """Get earnings surprises
+
+        .. deprecated::
+            This endpoint is no longer available on the FMP API and will be
+            removed in a future version. Use :meth:`get_historical_earnings`
+            and compare ``eps`` against ``eps_estimated`` instead.
+        """
         return await self.client.request_async(EARNINGS_SURPRISES, symbol=symbol)
 
     async def get_dividends_calendar(

--- a/fmp_data/intelligence/client.py
+++ b/fmp_data/intelligence/client.py
@@ -1,8 +1,9 @@
 # fmp_data/intelligence/client.py
 from datetime import date
+from typing import Any
 
 from fmp_data.base import EndpointGroup
-from fmp_data.helpers import RemovedEndpointError, removed
+from fmp_data.helpers import RemovedEndpointError, deprecated, removed
 from fmp_data.intelligence.endpoints import (
     CROWDFUNDING_BY_CIK,
     CROWDFUNDING_RSS,
@@ -124,27 +125,87 @@ class MarketIntelligenceClient(EndpointGroup):
         return params
 
     def get_earnings_calendar(
-        self, start_date: date | None = None, end_date: date | None = None
+        self,
+        start_date: date | None = None,
+        end_date: date | None = None,
+        include_report_times: bool | None = None,
     ) -> list[EarningEvent]:
-        """Get earnings calendar"""
-        params = self._build_date_params(start_date, end_date)
+        """Get earnings calendar
+
+        Args:
+            start_date: Earliest reporting date to include
+            end_date: Latest reporting date to include
+            include_report_times: When True, each event also carries ``time``
+                ('bmo'/'amc'), ``period_ending``, ``fiscal_period``,
+                ``fiscal_year`` and ``confirmed``
+
+        Returns:
+            list[EarningEvent]: Earnings events in the requested window
+        """
+        params: dict[str, Any] = self._build_date_params(start_date, end_date)
+        if include_report_times is not None:
+            params["include_report_times"] = include_report_times
         return self.client.request(EARNINGS_CALENDAR, **params)
 
-    def get_historical_earnings(self, symbol: str) -> list[EarningEvent]:
-        """Get historical earnings"""
-        return self.client.request(HISTORICAL_EARNINGS, symbol=symbol)
+    def get_historical_earnings(
+        self,
+        symbol: str,
+        limit: int | None = None,
+        include_report_times: bool | None = None,
+    ) -> list[EarningEvent]:
+        """Get historical and upcoming earnings reports for a symbol
 
+        Args:
+            symbol: Stock symbol
+            limit: Maximum number of reports to return
+            include_report_times: When True, each report also carries ``time``
+                ('bmo'/'amc'), ``period_ending``, ``fiscal_period``,
+                ``fiscal_year`` and ``confirmed``
+
+        Returns:
+            list[EarningEvent]: Earnings reports for the symbol
+        """
+        params: dict[str, Any] = {"symbol": symbol}
+        if limit is not None:
+            params["limit"] = limit
+        if include_report_times is not None:
+            params["include_report_times"] = include_report_times
+        return self.client.request(HISTORICAL_EARNINGS, **params)
+
+    @deprecated(
+        "The FMP API no longer serves the confirmed earnings calendar. Use "
+        "get_earnings_calendar(include_report_times=True) and read the "
+        "`confirmed` and `time` fields instead."
+    )
     def get_earnings_confirmed(
         self,
         start_date: date | None = None,
         end_date: date | None = None,
     ) -> list[EarningConfirmed]:
-        """Get confirmed earnings dates"""
+        """Get confirmed earnings dates
+
+        .. deprecated::
+            This endpoint is no longer available on the FMP API and will be
+            removed in a future version. Use
+            :meth:`get_earnings_calendar` with ``include_report_times=True``
+            and read the ``confirmed`` and ``time`` fields instead.
+        """
         params = self._build_date_params(start_date, end_date)
         return self.client.request(EARNINGS_CONFIRMED, **params)
 
+    @deprecated(
+        "The FMP API no longer serves earnings surprises. Use "
+        "get_historical_earnings() and compare `eps` against `eps_estimated` "
+        "instead."
+    )
     def get_earnings_surprises(self, symbol: str) -> list[EarningSurprise]:
-        """Get earnings surprises"""
+        """Get earnings surprises
+
+        .. deprecated::
+            This endpoint is no longer available on the FMP API and will be
+            removed in a future version. Use :meth:`get_historical_earnings`
+            and compare ``eps`` against ``eps_estimated`` instead.
+        """
         return self.client.request(EARNINGS_SURPRISES, symbol=symbol)
 
     def get_dividends_calendar(

--- a/fmp_data/intelligence/endpoints.py
+++ b/fmp_data/intelligence/endpoints.py
@@ -68,6 +68,17 @@ EARNINGS_CALENDAR: Endpoint = Endpoint(
             description="End date",
             alias="to",
         ),
+        EndpointParam(
+            name="include_report_times",
+            location=ParamLocation.QUERY,
+            param_type=ParamType.BOOLEAN,
+            required=False,
+            description=(
+                "Include report time, fiscal period and confirmation fields "
+                "in the response"
+            ),
+            alias="includeReportTimes",
+        ),
     ],
     response_model=EarningEvent,
 )
@@ -123,11 +134,11 @@ EARNINGS_SURPRISES: Endpoint = Endpoint(
 
 HISTORICAL_EARNINGS: Endpoint = Endpoint(
     name="historical_earnings",
-    path="historical/earning-calendar",
+    path="earnings",
     version=APIVersion.STABLE,
     url_type=URLType.API,
     method=HTTPMethod.GET,
-    description="Get historical earnings",
+    description="Get historical and upcoming earnings reports for a symbol",
     mandatory_params=[
         EndpointParam(
             name="symbol",
@@ -137,7 +148,26 @@ HISTORICAL_EARNINGS: Endpoint = Endpoint(
             description="Stock symbol",
         )
     ],
-    optional_params=[],
+    optional_params=[
+        EndpointParam(
+            name="limit",
+            location=ParamLocation.QUERY,
+            param_type=ParamType.INTEGER,
+            required=False,
+            description="Maximum number of reports to return",
+        ),
+        EndpointParam(
+            name="include_report_times",
+            location=ParamLocation.QUERY,
+            param_type=ParamType.BOOLEAN,
+            required=False,
+            description=(
+                "Include report time, fiscal period and confirmation fields "
+                "in the response"
+            ),
+            alias="includeReportTimes",
+        ),
+    ],
     response_model=EarningEvent,
 )
 

--- a/fmp_data/intelligence/mapping.py
+++ b/fmp_data/intelligence/mapping.py
@@ -103,6 +103,29 @@ SYMBOL_HINT = ParameterHint(
     context_clues=["company", "stock", "ticker", "symbol"],
 )
 
+INCLUDE_REPORT_TIMES_HINT = ParameterHint(
+    natural_names=[
+        "report time",
+        "announcement time",
+        "confirmed",
+        "before/after hours",
+    ],
+    extraction_patterns=[
+        r"(?i)(before|after)\s+(the\s+)?(market|bell|hours)",
+        r"(?i)\b(bmo|amc)\b",
+        r"(?i)confirmed\s+(earnings|dates?)",
+    ],
+    examples=["true", "false"],
+    context_clues=[
+        "report time",
+        "before market open",
+        "after market close",
+        "confirmed",
+        "fiscal period",
+    ],
+    required=False,
+)
+
 CRYPTO_PAIR_HINT = ParameterHint(
     natural_names=["crypto pair", "crypto symbol", "digital asset", "cryptocurrency"],
     extraction_patterns=[
@@ -218,6 +241,7 @@ INTELLIGENCE_ENDPOINTS_SEMANTICS = {
         parameter_hints={
             "start_date": DATE_HINTS["start_date"],
             "end_date": DATE_HINTS["end_date"],
+            "include_report_times": INCLUDE_REPORT_TIMES_HINT,
         },
         response_hints={
             "date": ResponseFieldInfo(
@@ -1340,7 +1364,10 @@ INTELLIGENCE_ENDPOINTS_SEMANTICS = {
         ],
         category=SemanticCategory.INTELLIGENCE,
         sub_category="Calendar Events",
-        parameter_hints={"symbol": SYMBOL_HINT},
+        parameter_hints={
+            "symbol": SYMBOL_HINT,
+            "include_report_times": INCLUDE_REPORT_TIMES_HINT,
+        },
         response_hints={
             "date": ResponseFieldInfo(
                 description="Earnings report date",

--- a/fmp_data/intelligence/models.py
+++ b/fmp_data/intelligence/models.py
@@ -41,12 +41,51 @@ class EarningEvent(BaseModel):
     eps_estimated: float | None = Field(
         alias="epsEstimated", default=None, description="Estimated earnings per share"
     )
-    time: str | None = Field(default=None, description="Time of day (amc/bmo)")
+    time: str | None = Field(
+        default=None,
+        description=(
+            "Time of day the report is released ('bmo' before market open, "
+            "'amc' after market close). Only returned when the request is made "
+            "with include_report_times=True."
+        ),
+    )
     revenue: float | None = Field(
         default=None, alias="revenueActual", description="Actual revenue"
     )
     revenue_estimated: float | None = Field(
         alias="revenueEstimated", default=None, description="Estimated revenue"
+    )
+    period_ending: date | None = Field(
+        None,
+        alias="periodEnding",
+        description=(
+            "Fiscal period end date. Only returned when the request is made "
+            "with include_report_times=True."
+        ),
+    )
+    fiscal_period: str | None = Field(
+        None,
+        alias="fiscalPeriod",
+        description=(
+            "Fiscal period the report covers (e.g. 'Q3'). Only returned when "
+            "the request is made with include_report_times=True."
+        ),
+    )
+    fiscal_year: int | None = Field(
+        None,
+        alias="fiscalYear",
+        description=(
+            "Fiscal year the report covers. Only returned when the request is "
+            "made with include_report_times=True."
+        ),
+    )
+    confirmed: bool | None = Field(
+        None,
+        description=(
+            "Whether the reporting date has been confirmed by the company. "
+            "Only returned when the request is made with "
+            "include_report_times=True."
+        ),
     )
     fiscal_date_ending: date | None = Field(
         None, alias="fiscalDateEnding", description="Fiscal period end date"

--- a/fmp_data/mcp/__main__.py
+++ b/fmp_data/mcp/__main__.py
@@ -15,9 +15,9 @@ import os
 from pathlib import Path
 import sys
 
-try:
-    import mcp.server.fastmcp  # noqa: F401
-except ImportError:
+from fmp_data.mcp._compat import mcp_server_available
+
+if not mcp_server_available():
     print(
         "Error: MCP dependencies not installed.\n"
         "Please install with: uv pip install 'fmp-data[mcp]'",

--- a/fmp_data/mcp/_compat.py
+++ b/fmp_data/mcp/_compat.py
@@ -1,0 +1,49 @@
+"""Compatibility layer across MCP SDK major versions.
+
+The MCP Python SDK renamed its high-level server class in 2.0:
+``mcp.server.fastmcp.FastMCP`` became ``mcp.server.MCPServer``. The parts of
+the API this package relies on — the constructor's ``name`` argument,
+``add_tool(fn, name=..., description=...)`` and ``run(transport=...)`` — are
+identical across both, so resolving the class at import time is enough to
+support either SDK.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+# The concrete class differs per SDK major, so the public surface is typed as
+# Any rather than pinning callers to one SDK's symbol.
+MCPServerType = Any
+
+__all__ = ["MCPServerType", "import_mcp_server_class", "mcp_server_available"]
+
+
+def import_mcp_server_class() -> type[Any]:
+    """Return the installed SDK's high-level server class.
+
+    Raises:
+        ImportError: if no supported MCP SDK is installed.
+    """
+    # Both branches are cast: mypy runs without the mcp extra installed, so
+    # neither symbol resolves to a real class there.
+    try:  # MCP SDK >= 2.0
+        from mcp.server import MCPServer
+    except ImportError:
+        pass
+    else:
+        return cast(type[Any], MCPServer)
+
+    # MCP SDK 1.x
+    from mcp.server.fastmcp import FastMCP
+
+    return cast(type[Any], FastMCP)
+
+
+def mcp_server_available() -> bool:
+    """Return True when a supported MCP SDK is importable."""
+    try:
+        import_mcp_server_class()
+    except ImportError:
+        return False
+    return True

--- a/fmp_data/mcp/server.py
+++ b/fmp_data/mcp/server.py
@@ -4,14 +4,10 @@ from __future__ import annotations
 from collections.abc import Iterable, Sequence
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING
-
-from fmp_data.exceptions import DependencyError
-
-if TYPE_CHECKING:
-    from mcp.server.fastmcp import FastMCP
 
 from fmp_data.client import FMPDataClient
+from fmp_data.exceptions import DependencyError
+from fmp_data.mcp._compat import MCPServerType, import_mcp_server_class
 from fmp_data.mcp.tool_loader import register_from_manifest
 from fmp_data.mcp.utils import load_manifest_tools
 
@@ -19,9 +15,9 @@ from fmp_data.mcp.utils import load_manifest_tools
 ToolIterable = str | Sequence[str] | Iterable[str]
 
 
-def create_app(tools: ToolIterable | None = None) -> FastMCP:
+def create_app(tools: ToolIterable | None = None) -> MCPServerType:
     """
-    Build and return a :class:`FastMCP` server instance.
+    Build and return an MCP server instance.
 
     Parameters
     ----------
@@ -32,7 +28,7 @@ def create_app(tools: ToolIterable | None = None) -> FastMCP:
 
     Returns
     -------
-    FastMCP
+    MCPServer (SDK >= 2.0) or FastMCP (SDK 1.x)
         Configured with the requested tools and a ready-made FMPDataClient.
 
     Notes
@@ -62,16 +58,16 @@ def create_app(tools: ToolIterable | None = None) -> FastMCP:
     fmp_client = FMPDataClient.from_env()
 
     # ------------------------------------------------------------------ #
-    # 3) FastMCP skeleton (lazy import for runtime use)
+    # 3) Server skeleton (lazy import for runtime use)
     # ------------------------------------------------------------------ #
     try:
-        from mcp.server.fastmcp import FastMCP
+        server_cls = import_mcp_server_class()
     except ImportError as e:
         raise DependencyError(
             feature="MCP server", install_command="pip install fmp-data[mcp]"
         ) from e
 
-    app = FastMCP("fmp-data")
+    app = server_cls("fmp-data")
 
     # ------------------------------------------------------------------ #
     # 4) Register our tools

--- a/fmp_data/mcp/setup.py
+++ b/fmp_data/mcp/setup.py
@@ -195,12 +195,11 @@ class SetupWizard:
             return False
 
         # Check if MCP dependencies are installed
-        try:
-            import mcp  # noqa: F401
-            from mcp.server.fastmcp import FastMCP  # noqa: F401
+        from fmp_data.mcp._compat import mcp_server_available
 
+        if mcp_server_available():
             self.print("MCP dependencies are installed", "success")
-        except ImportError:
+        else:
             self.print("MCP dependencies not installed", "error")
             self.print("Install with: pip install fmp-data[mcp]", "info")
             return False

--- a/fmp_data/mcp/tool_loader.py
+++ b/fmp_data/mcp/tool_loader.py
@@ -5,12 +5,10 @@ from collections.abc import Callable
 import importlib
 import inspect
 import os
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from mcp.server.fastmcp import FastMCP
+from typing import Any
 
 from fmp_data.client import FMPDataClient
+from fmp_data.mcp._compat import MCPServerType
 
 ERR = RuntimeError  # shorten
 
@@ -104,7 +102,7 @@ def _validate_tool_names(
 
 
 def register_from_manifest(
-    mcp: FastMCP,
+    mcp: MCPServerType,
     fmp_client: FMPDataClient,
     tool_specs: list[str],
 ) -> None:

--- a/noxfile.py
+++ b/noxfile.py
@@ -327,10 +327,12 @@ def typecheck(session: Session) -> None:
 def security(session: Session) -> None:
     """Check dependencies for known CVEs."""
     _sync_with_uv(session, extras=["dev"])
-    # TODO: Remove --ignore-vuln once GitHub Actions updates to pip 26.0+
-    # CVE-2026-1703 is a low-severity path traversal in pip <26.0 (fixed Jan 31, 2026)
-    # This is a CI environment issue, not a project dependency vulnerability
-    session.run("pip-audit", "--ignore-vuln", "CVE-2026-1703")
+    # virtualenv seeds this session with whatever pip it bundles, which lags
+    # behind the current release and drags its own CVEs into the audit. Upgrade
+    # it first so the report covers project dependencies rather than the
+    # scaffolding around them.
+    session.run("python", "-m", "pip", "install", "--upgrade", "pip")
+    session.run("pip-audit")
 
 
 @nox.session(python=DEFAULT_PYTHON, tags=["smoke"])

--- a/tests/examples/test_examples_smoke.py
+++ b/tests/examples/test_examples_smoke.py
@@ -276,7 +276,9 @@ def test_example_runs_without_error(
     module = load_module_from_path(example_path)
 
     # Mock both FMPDataClient() and FMPDataClient.from_env() in the loaded module
-    with (patch.object(module, "FMPDataClient") as mock_client_class,):
+    with (
+        patch.object(module, "FMPDataClient") as mock_client_class,
+    ):
         # Mock the context manager
         mock_client_class.from_env.return_value.__enter__.return_value = mock_client
         mock_client_class.from_env.return_value.__exit__.return_value = None
@@ -306,9 +308,9 @@ def test_all_examples_have_main_function() -> None:
         assert "def main(" in content, f"Example {example_file} missing main() function"
 
         # Check for if __name__ == "__main__"
-        assert (
-            'if __name__ == "__main__"' in content
-        ), f"Example {example_file} missing if __name__ == '__main__' guard"
+        assert 'if __name__ == "__main__"' in content, (
+            f"Example {example_file} missing if __name__ == '__main__' guard"
+        )
 
 
 def test_all_examples_use_context_manager() -> None:
@@ -320,9 +322,9 @@ def test_all_examples_use_context_manager() -> None:
         content = example_path.read_text()
 
         # Check for context manager usage
-        assert (
-            "with FMPDataClient" in content
-        ), f"Example {example_file} not using context manager pattern"
+        assert "with FMPDataClient" in content, (
+            f"Example {example_file} not using context manager pattern"
+        )
 
 
 def test_no_hardcoded_api_keys() -> None:

--- a/tests/integration/test_economics.py
+++ b/tests/integration/test_economics.py
@@ -82,9 +82,9 @@ class TestEconomicsEndpoints(BaseTestCase):
             for event in events:
                 assert isinstance(event, EconomicEvent), "event is not EconomicEvent"
                 assert event.event, "event is empty string"
-                assert isinstance(
-                    event.event_date, datetime
-                ), "event_date is not datetime"
+                assert isinstance(event.event_date, datetime), (
+                    "event_date is not datetime"
+                )
                 # Verify country attribute exists
                 _ = event.country
                 assert (
@@ -106,18 +106,18 @@ class TestEconomicsEndpoints(BaseTestCase):
             # Test specific example from response
             example = next(p for p in premiums if p.country == "Germany")
             assert isinstance(example.continent, str), "continent is not string"
-            assert isinstance(
-                example.country_risk_premium, float
-            ), "country_risk_premium is not float"
-            assert isinstance(
-                example.total_equity_risk_premium, float
-            ), "total_equity_risk_premium is not float"
+            assert isinstance(example.country_risk_premium, float), (
+                "country_risk_premium is not float"
+            )
+            assert isinstance(example.total_equity_risk_premium, float), (
+                "total_equity_risk_premium is not float"
+            )
 
             # Test general structure
             for premium in premiums:
-                assert isinstance(
-                    premium, MarketRiskPremium
-                ), "premium is not MarketRiskPremium"
+                assert isinstance(premium, MarketRiskPremium), (
+                    "premium is not MarketRiskPremium"
+                )
                 assert isinstance(premium.country, str), "country is not string"
                 assert premium.continent is None or isinstance(
                     premium.continent, str

--- a/tests/integration/test_intelligence.py
+++ b/tests/integration/test_intelligence.py
@@ -89,17 +89,17 @@ class TestIntelligenceEndpoints(BaseTestCase):
             assert isinstance(events, list), "events is not a list"
             if len(events) > 0:
                 for event in events:
-                    assert isinstance(
-                        event, EarningConfirmed
-                    ), "event tpye is not Earning Confirmed"
+                    assert isinstance(event, EarningConfirmed), (
+                        "event tpye is not Earning Confirmed"
+                    )
                     if event.time is not None:
-                        assert isinstance(
-                            event.time, str
-                        ), "event time is not of type string, it"
+                        assert isinstance(event.time, str), (
+                            "event time is not of type string, it"
+                        )
                     if event.event_date is not None:
-                        assert isinstance(
-                            event.event_date, datetime
-                        ), "event date is not of datetime type"
+                        assert isinstance(event.event_date, datetime), (
+                            "event date is not of datetime type"
+                        )
 
     def test_get_historical_earnings(self, fmp_client: FMPDataClient, vcr_instance):
         """Test getting historical earnings"""
@@ -109,14 +109,60 @@ class TestIntelligenceEndpoints(BaseTestCase):
             )
 
             assert isinstance(events, list)
-            # API may return empty array if no historical data available
-            if len(events) > 0:
-                for event in events:
-                    assert isinstance(event, EarningEvent)
-                    assert event.symbol == "AAPL"
-                    assert isinstance(event.event_date, date)
-                    if event.time is not None:
-                        assert isinstance(event.time, str)
+            assert len(events) > 0
+            for event in events:
+                assert isinstance(event, EarningEvent)
+                assert event.symbol == "AAPL"
+                assert isinstance(event.event_date, date)
+                if event.time is not None:
+                    assert isinstance(event.time, str)
+
+    def test_get_historical_earnings_with_report_times(
+        self, fmp_client: FMPDataClient, vcr_instance
+    ):
+        """Report time fields are populated when include_report_times is set"""
+        with vcr_instance.use_cassette(
+            "intelligence/historical_earnings_report_times.yaml"
+        ):
+            events = self._handle_rate_limit(
+                fmp_client.intelligence.get_historical_earnings,
+                "AAPL",
+                include_report_times=True,
+            )
+
+            assert isinstance(events, list)
+            assert len(events) > 0
+            # At least one report carries the extra fields the flag unlocks
+            assert any(event.time in {"bmo", "amc"} for event in events)
+            assert any(event.confirmed is not None for event in events)
+            assert any(event.fiscal_period is not None for event in events)
+            for event in events:
+                if event.period_ending is not None:
+                    assert isinstance(event.period_ending, date)
+                if event.fiscal_year is not None:
+                    assert isinstance(event.fiscal_year, int)
+
+    def test_get_earnings_calendar_with_report_times(
+        self, fmp_client: FMPDataClient, vcr_instance, frozen_today: date
+    ):
+        """Earnings calendar exposes report times when the flag is set"""
+        with vcr_instance.use_cassette(
+            "intelligence/earnings_calendar_report_times.yaml"
+        ):
+            events = self._handle_rate_limit(
+                fmp_client.intelligence.get_earnings_calendar,
+                start_date=frozen_today,
+                end_date=frozen_today + timedelta(days=30),
+                include_report_times=True,
+            )
+
+            assert isinstance(events, list)
+            assert len(events) > 0
+            assert any(event.confirmed is not None for event in events)
+            for event in events:
+                assert isinstance(event, EarningEvent)
+                if event.time is not None:
+                    assert event.time in {"bmo", "amc"}
 
     def test_get_earnings_surprises(self, fmp_client: FMPDataClient, vcr_instance):
         """Test getting earnings surprises"""

--- a/tests/integration/test_market.py
+++ b/tests/integration/test_market.py
@@ -90,13 +90,13 @@ class TestMarketClientEndpoints(BaseTestCase):
                 assert isinstance(gainer.change, float), "gainer change is not float"
                 assert isinstance(gainer.price, float), "gainer price is not float"
                 if gainer.change_percentage:
-                    assert isinstance(
-                        gainer.change_percentage, float
-                    ), "gainer change_percentage is not float"
+                    assert isinstance(gainer.change_percentage, float), (
+                        "gainer change_percentage is not float"
+                    )
                 if gainer.change_percentage:
-                    assert (
-                        gainer.change_percentage > 0
-                    ), "gainer change_percentage is not positive"
+                    assert gainer.change_percentage > 0, (
+                        "gainer change_percentage is not positive"
+                    )
 
     def test_get_losers(self, fmp_client: FMPDataClient, vcr_instance):
         """Test getting market losers"""
@@ -137,9 +137,9 @@ class TestMarketClientEndpoints(BaseTestCase):
                 assert active.symbol
                 assert active.name
                 if active.change:
-                    assert isinstance(
-                        active.change, float
-                    ), "active change is not float"
+                    assert isinstance(active.change, float), (
+                        "active change is not float"
+                    )
                 if active.price:
                     assert isinstance(active.price, float), "active price is not float"
                 if active.change_percentage:

--- a/tests/unit/test_async_clients.py
+++ b/tests/unit/test_async_clients.py
@@ -1162,6 +1162,42 @@ class TestAsyncIntelligenceClient:
             end_date="2024-01-15",
         )
 
+    @pytest.mark.asyncio
+    async def test_get_earnings_calendar_include_report_times(self, mock_client):
+        """Test earnings calendar forwards include_report_times."""
+        from fmp_data.intelligence import endpoints as intelligence_endpoints
+        from fmp_data.intelligence.async_client import AsyncMarketIntelligenceClient
+
+        mock_client.request_async.return_value = []
+        async_client = AsyncMarketIntelligenceClient(mock_client)
+
+        await async_client.get_earnings_calendar(include_report_times=True)
+
+        mock_client.request_async.assert_called_once_with(
+            intelligence_endpoints.EARNINGS_CALENDAR,
+            include_report_times=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_historical_earnings_optional_params(self, mock_client):
+        """Test historical earnings forwards limit and include_report_times."""
+        from fmp_data.intelligence import endpoints as intelligence_endpoints
+        from fmp_data.intelligence.async_client import AsyncMarketIntelligenceClient
+
+        mock_client.request_async.return_value = []
+        async_client = AsyncMarketIntelligenceClient(mock_client)
+
+        await async_client.get_historical_earnings(
+            "AAPL", limit=5, include_report_times=True
+        )
+
+        mock_client.request_async.assert_called_once_with(
+            intelligence_endpoints.HISTORICAL_EARNINGS,
+            symbol="AAPL",
+            limit=5,
+            include_report_times=True,
+        )
+
     def test_build_date_params_custom_keys(self):
         """Test _build_date_params supports custom keys."""
         from fmp_data.intelligence.async_client import AsyncMarketIntelligenceClient

--- a/tests/unit/test_intelligence.py
+++ b/tests/unit/test_intelligence.py
@@ -76,6 +76,25 @@ def earnings_calendar_data():
 
 
 @pytest.fixture
+def earnings_report_times_data():
+    """Earnings payload as returned with includeReportTimes=true"""
+    return {
+        "symbol": "AAPL",
+        "date": "2026-07-30",
+        "epsActual": 2.02,
+        "epsEstimated": 1.89,
+        "revenueActual": 109417000000,
+        "revenueEstimated": 109038900000,
+        "time": "amc",
+        "periodEnding": "2026-06-27",
+        "fiscalPeriod": "Q3",
+        "fiscalYear": 2026,
+        "confirmed": True,
+        "lastUpdated": "2026-08-01",
+    }
+
+
+@pytest.fixture
 def earnings_confirmed_data():
     return {
         "symbol": "AAPL",
@@ -212,6 +231,36 @@ class TestMarketIntelligenceClientCalendar:
         assert kwargs["end_date"] == "2024-01-31"
         assert isinstance(result, list)
 
+    def test_get_earnings_calendar_with_report_times(
+        self, fmp_client, mock_client, earnings_report_times_data
+    ):
+        """include_report_times is forwarded and its extra fields parse"""
+        mock_client.request.return_value = [EarningEvent(**earnings_report_times_data)]
+
+        result = fmp_client.intelligence.get_earnings_calendar(
+            include_report_times=True
+        )
+
+        _args, kwargs = mock_client.request.call_args
+        assert kwargs["include_report_times"] is True
+        event = result[0]
+        assert event.time == "amc"
+        assert event.confirmed is True
+        assert event.period_ending == date(2026, 6, 27)
+        assert event.fiscal_period == "Q3"
+        assert event.fiscal_year == 2026
+
+    def test_get_earnings_calendar_omits_report_times_when_unset(
+        self, fmp_client, mock_client, earnings_calendar_data
+    ):
+        """The flag is left off the request entirely when not supplied"""
+        mock_client.request.return_value = [EarningEvent(**earnings_calendar_data)]
+
+        fmp_client.intelligence.get_earnings_calendar()
+
+        _args, kwargs = mock_client.request.call_args
+        assert "include_report_times" not in kwargs
+
     def test_get_historical_earnings(
         self, fmp_client, mock_client, earnings_calendar_data
     ):
@@ -223,7 +272,24 @@ class TestMarketIntelligenceClientCalendar:
         mock_client.request.assert_called_once()
         _args, kwargs = mock_client.request.call_args
         assert kwargs["symbol"] == "AAPL"
+        assert "limit" not in kwargs
+        assert "include_report_times" not in kwargs
         assert isinstance(result, list)
+
+    def test_get_historical_earnings_with_optional_params(
+        self, fmp_client, mock_client, earnings_report_times_data
+    ):
+        """limit and include_report_times are forwarded when supplied"""
+        mock_client.request.return_value = [EarningEvent(**earnings_report_times_data)]
+
+        fmp_client.intelligence.get_historical_earnings(
+            "AAPL", limit=5, include_report_times=True
+        )
+
+        _args, kwargs = mock_client.request.call_args
+        assert kwargs["symbol"] == "AAPL"
+        assert kwargs["limit"] == 5
+        assert kwargs["include_report_times"] is True
 
     def test_get_earnings_confirmed(
         self, fmp_client, mock_client, earnings_confirmed_data
@@ -257,6 +323,22 @@ class TestMarketIntelligenceClientCalendar:
         _args, kwargs = mock_client.request.call_args
         assert kwargs["symbol"] == "AAPL"
         assert isinstance(result, list)
+
+    @pytest.mark.parametrize(
+        ("method_name", "args"),
+        [
+            ("get_earnings_confirmed", ()),
+            ("get_earnings_surprises", ("AAPL",)),
+        ],
+    )
+    def test_dead_earnings_endpoints_warn(
+        self, fmp_client, mock_client, method_name, args
+    ):
+        """Endpoints FMP no longer serves emit a DeprecationWarning"""
+        mock_client.request.return_value = []
+
+        with pytest.warns(DeprecationWarning, match=method_name):
+            getattr(fmp_client.intelligence, method_name)(*args)
 
     def test_get_dividends_calendar(
         self, fmp_client, mock_client, dividends_calendar_data

--- a/tests/unit/test_mcp.py
+++ b/tests/unit/test_mcp.py
@@ -14,7 +14,11 @@ from unittest.mock import Mock, patch
 import pytest
 
 pytest.importorskip("mcp", reason="MCP dependencies not installed")
-pytest.importorskip("mcp.server.fastmcp", reason="FastMCP not available")
+
+from fmp_data.mcp._compat import mcp_server_available
+
+if not mcp_server_available():
+    pytest.skip("No supported MCP server class available", allow_module_level=True)
 
 
 class TestMCPServer:
@@ -34,7 +38,7 @@ class TestMCPServer:
 
         assert app is not None
         assert app.name == "fmp-data"
-        # FastMCP doesn't have a description attribute, just check basic functionality
+        # The server class has no description attribute; check basic wiring only
         mock_client_class.from_env.assert_called_once()
         mock_register.assert_called_once()
 
@@ -205,9 +209,9 @@ class TestToolsManifest:
         ]
 
         for tool in expected_tools:
-            assert (
-                tool in DEFAULT_TOOLS
-            ), f"Expected tool {tool} not found in DEFAULT_TOOLS"
+            assert tool in DEFAULT_TOOLS, (
+                f"Expected tool {tool} not found in DEFAULT_TOOLS"
+            )
 
 
 class TestMCPManifestLoading:
@@ -429,3 +433,43 @@ class TestMCPSetupSecurity:
         assert "secret123" not in output
         assert "[REDACTED]" in output or "Setup failed" in output
         assert result == 1  # Should return error code
+
+
+class TestMCPCompat:
+    """Test suite for the MCP SDK compatibility shim."""
+
+    def test_import_mcp_server_class_returns_usable_class(self):
+        """The resolved class exposes the surface create_app relies on."""
+        from fmp_data.mcp._compat import import_mcp_server_class
+
+        server_cls = import_mcp_server_class()
+
+        assert isinstance(server_cls, type)
+        assert server_cls.__name__ in {"MCPServer", "FastMCP"}
+        for attr in ("add_tool", "run"):
+            assert callable(getattr(server_cls, attr))
+
+    def test_prefers_v2_server_class(self):
+        """MCPServer wins when the 2.x SDK is importable."""
+        import sys
+
+        from fmp_data.mcp._compat import import_mcp_server_class
+
+        if "mcp.server" not in sys.modules:
+            import mcp.server  # noqa: F401
+
+        import mcp.server as mcp_server
+
+        if not hasattr(mcp_server, "MCPServer"):
+            pytest.skip("MCP SDK 1.x installed")
+
+        assert import_mcp_server_class() is mcp_server.MCPServer
+
+    def test_mcp_server_available_false_without_sdk(self):
+        """Availability check reports False when neither SDK import works."""
+        from fmp_data.mcp import _compat
+
+        with patch.object(
+            _compat, "import_mcp_server_class", side_effect=ImportError("no sdk")
+        ):
+            assert _compat.mcp_server_available() is False

--- a/tests/unit/test_vcr_sanitization.py
+++ b/tests/unit/test_vcr_sanitization.py
@@ -113,8 +113,7 @@ def test_no_api_key_leaks_in_cassettes() -> None:
                         f"{relative}:{lineno}  apikey={value} (JSON body)"
                     )
 
-    assert (
-        not violations
-    ), f"Found {len(violations)} API key leak(s) in VCR cassettes:\n" + "\n".join(
-        f"  - {v}" for v in violations
+    assert not violations, (
+        f"Found {len(violations)} API key leak(s) in VCR cassettes:\n"
+        + "\n".join(f"  - {v}" for v in violations)
     )


### PR DESCRIPTION
Closes #111. Closes #107, #108, #109, #110.

## Earnings report times (#111)

FMP's `earnings-calendar` and `earnings` endpoints accept an `includeReportTimes` flag that returns the report time plus fiscal-period and confirmation metadata. Neither endpoint exposed it.

```python
events = client.intelligence.get_earnings_calendar(
    start_date=date(2026, 8, 10),
    end_date=date(2026, 8, 11),
    include_report_times=True,
)
events[0].time            # 'amc' | 'bmo' | None
events[0].confirmed       # bool | None
events[0].period_ending   # date | None
events[0].fiscal_period   # 'Q3' | None
events[0].fiscal_year     # int | None
```

The five new `EarningEvent` fields default to `None`, so existing calls are unaffected. `get_historical_earnings()` also accepts `limit` now. Both sync and async clients.

### Related endpoint fixes

While verifying paths against the live API, three were confirmed dead on `/stable`:

| Endpoint | Status | Action |
|---|---|---|
| `historical/earning-calendar` | 404 | Repointed to the stable `earnings` path |
| `earning-calendar-confirmed` | 404 | `get_earnings_confirmed()` deprecated |
| `earnings-surprises` | 404 | `get_earnings_surprises()` deprecated |

`get_historical_earnings()` was silently returning nothing — its cassette recorded a 404 and the integration test only asserted `isinstance(result, list)`. It now records a 200 with real data and the test asserts a non-empty response so a future path break fails loudly.

The deprecations answer @joshuatz's question on the issue about overlap with `EarningConfirmed`: the models are retained, the methods warn and name their replacement (`include_report_times=True` for confirmed dates; `eps` vs `eps_estimated` for surprises). Removal is planned for the next major.

## Dependency refresh

All locked dependencies and GitHub Actions bumped to latest. Notable:

- **`mcp` 1.28.1 → 2.0.0** — SDK 2.0 renamed `mcp.server.fastmcp.FastMCP` to `mcp.server.MCPServer`, which broke every MCP entrypoint. Added `fmp_data.mcp._compat` to resolve whichever class the installed SDK provides. The `mcp` extra floor stays at `>=1.28.1`, so **no forced SDK upgrade for existing installs** — both majors work.
- **`ruff` 0.15.21 → 0.16.1** — 0.16 also formats Python blocks inside Markdown, which is the docs/README churn in this diff. Formatting only, no behavior change. Dropped the `black` pre-commit hook: black 24.x and ruff 0.16 disagree on assert-message wrapping, and ruff already formats this project.
- `mypy` 2.2.0 → 2.3.0, `cryptography` 49 → 50, `twine` 6.2.0 → 7.0.0, plus ~40 others.
- Actions: `checkout` v7.0.1, `setup-python` v7.0.0, `setup-uv` v9.0.0, `gh-action-pypi-publish` v1.14.1. Neither major bump affects us — `setup-python` v7 removed the `pip-install` input (unused here) and `setup-uv` v9 only flips the `prune-cache` default.
- `nox -s security` now upgrades pip before auditing rather than suppressing `CVE-2026-1703`. The session was already failing on `dev` because virtualenv seeds it with pip 26.0.1, which carries PYSEC-2026-2875/2876; the audit now covers project dependencies instead of the scaffolding.

## Verification

- `1329 passed, 5 skipped` (unit + integration)
- `nox -s lint typecheck security` all green
- New cassettes verified at `code: 200`, checked for API-key leakage
- Endpoint paths and the `includeReportTimes` response shape confirmed against the live FMP API before coding

🤖 Generated with [Claude Code](https://claude.com/claude-code)
