### PR TITLE
fix(intelligence): soft-fail dead earnings endpoints (release polish for #113)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Earnings Report Times** (#111) - Added the `includeReportTimes` parameter to the earnings endpoints:
   - `get_earnings_calendar(include_report_times=True)` and `get_historical_earnings(include_report_times=True)` on both sync and async clients
-  - When set, `EarningEvent` carries `time` (`"bmo"` / `"amc"`), `period_ending`, `fiscal_period`, `fiscal_year` and `confirmed`
-  - These five fields are `None` when the flag is omitted, so existing calls are unaffected
+  - Python kwarg `include_report_times=True` maps to query `includeReportTimes=true`
+  - When set, events may include `time` (`"bmo"` / `"amc"`), `period_ending`, `fiscal_period`, `fiscal_year` and `confirmed` (per-row optional)
+  - Fields are optional on the model; without the flag the API typically omits the confirmation/fiscal extras (`periodEnding`, `fiscalPeriod`, `fiscalYear`, `confirmed`). Session `time` can still appear on base `/earnings` payloads
   - `get_historical_earnings()` also accepts `limit` now
   - Thanks to @joshuatz for the report
 - **New Company Endpoint** - Added `get_profile_cik()` method to retrieve company profile using CIK (Central Index Key) number
@@ -46,8 +47,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **Historical Earnings 404** (#111) - Fixed `get_historical_earnings()` returning nothing:
   - The endpoint pointed at the legacy `historical/earning-calendar` path, which 404s on `/stable`
-  - Now uses the stable `/earnings` path; the VCR cassette records a 200 with real data
+  - Now uses the stable `/earnings` path; re-record the local VCR cassette so path regressions fail with a non-empty assertion
   - Integration test now asserts a non-empty response so a future path break fails loudly
+- **Dead earnings endpoints soft-fail** - `get_earnings_confirmed()` and `get_earnings_surprises()` now warn and return `[]` instead of calling 404 FMP paths (same pattern as `get_stock_news_sentiments`)
+- **MCP default toolset hygiene** - Removed dead/deprecated intelligence tools from `DEFAULT_TOOLS` (`earnings_confirmed`, `earnings_surprises`, `stock_news_sentiments`, social-sentiment trio) so the default server no longer advertises tools that always fail or return empty
 - **Bulk CSV Volume String Coercion** (#104) - Fixed silent bulk row drops when FMP sends volume as a fractional numeric string:
   - `coerce_volume_value` now coerces numeric strings such as `"475.9"` via `int(float(...))` for `CompanyProfile` / `Quote` volume fields
   - Empty/whitespace volume cells become `None`; non-numeric strings still surface as validation errors

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -175,9 +175,9 @@ All endpoints use the `/stable` prefix unless explicitly marked as `DIRECT` or `
 | `crowdfunding_rss` | `/stable/crowdfunding-offerings-latest` | Get latest crowdfunding offerings |
 | `crowdfunding_search` | `/stable/crowdfunding-offerings-search` | Search crowdfunding offerings |
 | `dividends_calendar` | `/stable/dividends-calendar` | Get dividends calendar |
-| `earnings_confirmed` | `/stable/earning-calendar-confirmed` | Get confirmed earnings dates |
+| `earnings_confirmed` | `/stable/earning-calendar-confirmed` | **Deprecated** — returns `[]`; use `earnings_calendar` with `includeReportTimes` |
 | `earnings_calendar` | `/stable/earnings-calendar` | Get earnings calendar |
-| `earnings_surprises` | `/stable/earnings-surprises` | Get earnings surprises |
+| `earnings_surprises` | `/stable/earnings-surprises` | **Deprecated** — returns `[]`; use `historical_earnings` and compare eps |
 | `esg_benchmark` | `/stable/esg-benchmark` | Get ESG benchmark data |
 | `esg_data` | `/stable/esg-disclosures` | Get ESG data for a company |
 | `esg_ratings` | `/stable/esg-ratings` | Get ESG ratings for a company |
@@ -190,8 +190,8 @@ All endpoints use the `/stable` prefix unless explicitly marked as `DIRECT` or `
 | `grades_historical` | `/stable/grades-historical` | Get historical stock grades |
 | `grades_latest_news` | `/stable/grades-latest-news` | Get latest stock grade news |
 | `grades_news` | `/stable/grades-news` | Get stock grade news |
-| `historical_earnings` | `/stable/historical/earning-calendar` | Get historical earnings |
-| `historical_social_sentiment` | `/stable/historical/social-sentiment` | Get historical social sentiment data |
+| `historical_earnings` | `/stable/earnings` | Get historical/upcoming earnings for a symbol (`limit`, `includeReportTimes`) |
+| `historical_social_sentiment` | `/stable/historical/social-sentiment` | **Removed** — raises `RemovedEndpointError` |
 | `house_latest` | `/stable/house-latest` | Get latest House financial disclosures |
 | `house_disclosure` | `/stable/house-trades` | Get House trading data by symbol |
 | `house_trades_by_name` | `/stable/house-trades-by-name` | Get House trading data by name |

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -145,8 +145,8 @@ For full FMP endpoint coverage, use the Python client. The MCP tool catalog incl
 | `crypto_symbol_news` | Search cryptocurrency news for a specific trading pair to track asset-specific developments |
 | `dividends_calendar` | Get upcoming and historical dividend events including ex-dividend dates, payment dates, and dividend amounts |
 | `earnings_calendar` | Access comprehensive earnings calendar showing upcoming earnings releases, estimated and actual results, and historical earnings data |
-| `earnings_confirmed` | Access confirmed earnings dates and times for companies including timing details and publication information |
-| `earnings_surprises` | Retrieve historical earnings surprises including actual vs estimated earnings, surprise percentages, and earnings dates |
+| `earnings_confirmed` | **Deprecated / not in DEFAULT_TOOLS** — client returns `[]`; prefer `earnings_calendar` + `include_report_times` |
+| `earnings_surprises` | **Deprecated / not in DEFAULT_TOOLS** — client returns `[]`; prefer `historical_earnings` and compare eps |
 | `equity_offering_by_cik` | Retrieve equity offerings for a specific company using CIK number including historical and current offerings |
 | `equity_offering_rss` | Get latest equity offerings including new issues, follow-on offerings, and capital raising events |
 | `equity_offering_search` | Search for equity offerings including public and private placements, with detailed offering terms and company information |
@@ -157,8 +157,8 @@ For full FMP endpoint coverage, use the Python client. The MCP tool catalog incl
 | `forex_news` | Retrieve forex market news including currency pair updates, exchange rate movements, and international market developments |
 | `forex_symbol_news` | Search forex news for a specific currency pair to monitor pair-specific developments and analysis |
 | `general_news` | Retrieve general financial news and market updates from various sources covering markets, economy, and business |
-| `historical_earnings` | Access historical earnings reports including revenue, EPS, and dates for past quarters and fiscal years |
-| `historical_social_sentiment` | Retrieve historical social media sentiment data including sentiment scores, engagement metrics, and trend analysis |
+| `historical_earnings` | Historical/upcoming earnings for a symbol (optional `limit`, `include_report_times`) |
+| `historical_social_sentiment` | **Removed / not in DEFAULT_TOOLS** — raises `RemovedEndpointError` |
 | `house_disclosure` | Access House of Representatives trading disclosures including transaction details, filing information, and trade specifics |
 | `house_latest` | Get the latest House financial disclosures with transaction details |
 | `house_trades_by_name` | Get House trading data filtered by representative name |
@@ -169,11 +169,11 @@ For full FMP endpoint coverage, use the Python client. The MCP tool catalog incl
 | `senate_trades_by_name` | Get Senate trading data filtered by senator name |
 | `senate_trading` | Access Senate trading activity and disclosures including stock trades, transaction details, and filing information |
 | `senate_trading_rss` | Get real-time RSS feed of Senate trading disclosures including new filings and transaction updates |
-| `social_sentiment_changes` | Track changes in social media sentiment including sentiment shifts, momentum changes, and trend developments |
+| `social_sentiment_changes` | **Removed / not in DEFAULT_TOOLS** — raises `RemovedEndpointError` |
 | `stock_news` | Access stock-specific news and updates including company events, market moves, and corporate developments |
-| `stock_news_sentiments` | Get stock news with sentiment analysis including positive/negative sentiment scores and market impact assessment |
+| `stock_news_sentiments` | **Deprecated / not in DEFAULT_TOOLS** — client returns `[]` |
 | `stock_splits_calendar` | Access upcoming and historical stock split events including split ratios, dates, and affected securities |
-| `trending_social_sentiment` | Get current trending social media sentiment data including most discussed stocks and sentiment rankings |
+| `trending_social_sentiment` | **Removed / not in DEFAULT_TOOLS** — raises `RemovedEndpointError` |
 
 ## Investment
 

--- a/fmp_data/intelligence/async_client.py
+++ b/fmp_data/intelligence/async_client.py
@@ -14,8 +14,6 @@ from fmp_data.intelligence.endpoints import (
     CRYPTO_SYMBOL_NEWS_ENDPOINT,
     DIVIDENDS_CALENDAR,
     EARNINGS_CALENDAR,
-    EARNINGS_CONFIRMED,
-    EARNINGS_SURPRISES,
     EQUITY_OFFERING_BY_CIK,
     EQUITY_OFFERING_RSS,
     EQUITY_OFFERING_SEARCH,
@@ -137,9 +135,10 @@ class AsyncMarketIntelligenceClient(AsyncEndpointGroup):
         Args:
             start_date: Earliest reporting date to include
             end_date: Latest reporting date to include
-            include_report_times: When True, each event also carries ``time``
-                ('bmo'/'amc'), ``period_ending``, ``fiscal_period``,
-                ``fiscal_year`` and ``confirmed``
+            include_report_times: When True, the API may include session
+                ``time`` ('bmo'/'amc'), ``period_ending``, ``fiscal_period``,
+                ``fiscal_year`` and ``confirmed`` on events (per-row optional).
+                Omitted from the query when unset; explicit True/False is sent.
 
         Returns:
             list[EarningEvent]: Earnings events in the requested window
@@ -160,9 +159,10 @@ class AsyncMarketIntelligenceClient(AsyncEndpointGroup):
         Args:
             symbol: Stock symbol
             limit: Maximum number of reports to return
-            include_report_times: When True, each report also carries ``time``
-                ('bmo'/'amc'), ``period_ending``, ``fiscal_period``,
-                ``fiscal_year`` and ``confirmed``
+            include_report_times: When True, the API may include session
+                ``time`` ('bmo'/'amc'), ``period_ending``, ``fiscal_period``,
+                ``fiscal_year`` and ``confirmed`` on reports (per-row optional).
+                Omitted from the query when unset; explicit True/False is sent.
 
         Returns:
             list[EarningEvent]: Earnings reports for the symbol
@@ -177,7 +177,7 @@ class AsyncMarketIntelligenceClient(AsyncEndpointGroup):
     @deprecated(
         "The FMP API no longer serves the confirmed earnings calendar. Use "
         "get_earnings_calendar(include_report_times=True) and read the "
-        "`confirmed` and `time` fields instead."
+        "`confirmed` field (and `time` as 'bmo'/'amc', not HH:MM) instead."
     )
     async def get_earnings_confirmed(
         self,
@@ -188,12 +188,12 @@ class AsyncMarketIntelligenceClient(AsyncEndpointGroup):
 
         .. deprecated::
             This endpoint is no longer available on the FMP API and will be
-            removed in a future version. Use
-            :meth:`get_earnings_calendar` with ``include_report_times=True``
-            and read the ``confirmed`` and ``time`` fields instead.
+            removed in a future version. It currently returns an empty list.
+            Use :meth:`get_earnings_calendar` with ``include_report_times=True``
+            and read ``confirmed`` plus session ``time`` (``bmo``/``amc``),
+            which is not a drop-in for the old clock-time field.
         """
-        params = self._build_date_params(start_date, end_date)
-        return await self.client.request_async(EARNINGS_CONFIRMED, **params)
+        return []
 
     @deprecated(
         "The FMP API no longer serves earnings surprises. Use "
@@ -205,10 +205,12 @@ class AsyncMarketIntelligenceClient(AsyncEndpointGroup):
 
         .. deprecated::
             This endpoint is no longer available on the FMP API and will be
-            removed in a future version. Use :meth:`get_historical_earnings`
-            and compare ``eps`` against ``eps_estimated`` instead.
+            removed in a future version. It currently returns an empty list.
+            Use :meth:`get_historical_earnings` and compare ``eps`` against
+            ``eps_estimated`` (old model used ``actual_earning_result`` /
+            ``estimated_earning``).
         """
-        return await self.client.request_async(EARNINGS_SURPRISES, symbol=symbol)
+        return []
 
     async def get_dividends_calendar(
         self, start_date: date | None = None, end_date: date | None = None

--- a/fmp_data/intelligence/client.py
+++ b/fmp_data/intelligence/client.py
@@ -12,8 +12,6 @@ from fmp_data.intelligence.endpoints import (
     CRYPTO_SYMBOL_NEWS_ENDPOINT,
     DIVIDENDS_CALENDAR,
     EARNINGS_CALENDAR,
-    EARNINGS_CONFIRMED,
-    EARNINGS_SURPRISES,
     EQUITY_OFFERING_BY_CIK,
     EQUITY_OFFERING_RSS,
     EQUITY_OFFERING_SEARCH,
@@ -135,9 +133,10 @@ class MarketIntelligenceClient(EndpointGroup):
         Args:
             start_date: Earliest reporting date to include
             end_date: Latest reporting date to include
-            include_report_times: When True, each event also carries ``time``
-                ('bmo'/'amc'), ``period_ending``, ``fiscal_period``,
-                ``fiscal_year`` and ``confirmed``
+            include_report_times: When True, the API may include session
+                ``time`` ('bmo'/'amc'), ``period_ending``, ``fiscal_period``,
+                ``fiscal_year`` and ``confirmed`` on events (per-row optional).
+                Omitted from the query when unset; explicit True/False is sent.
 
         Returns:
             list[EarningEvent]: Earnings events in the requested window
@@ -158,9 +157,10 @@ class MarketIntelligenceClient(EndpointGroup):
         Args:
             symbol: Stock symbol
             limit: Maximum number of reports to return
-            include_report_times: When True, each report also carries ``time``
-                ('bmo'/'amc'), ``period_ending``, ``fiscal_period``,
-                ``fiscal_year`` and ``confirmed``
+            include_report_times: When True, the API may include session
+                ``time`` ('bmo'/'amc'), ``period_ending``, ``fiscal_period``,
+                ``fiscal_year`` and ``confirmed`` on reports (per-row optional).
+                Omitted from the query when unset; explicit True/False is sent.
 
         Returns:
             list[EarningEvent]: Earnings reports for the symbol
@@ -175,7 +175,7 @@ class MarketIntelligenceClient(EndpointGroup):
     @deprecated(
         "The FMP API no longer serves the confirmed earnings calendar. Use "
         "get_earnings_calendar(include_report_times=True) and read the "
-        "`confirmed` and `time` fields instead."
+        "`confirmed` field (and `time` as 'bmo'/'amc', not HH:MM) instead."
     )
     def get_earnings_confirmed(
         self,
@@ -186,12 +186,12 @@ class MarketIntelligenceClient(EndpointGroup):
 
         .. deprecated::
             This endpoint is no longer available on the FMP API and will be
-            removed in a future version. Use
-            :meth:`get_earnings_calendar` with ``include_report_times=True``
-            and read the ``confirmed`` and ``time`` fields instead.
+            removed in a future version. It currently returns an empty list.
+            Use :meth:`get_earnings_calendar` with ``include_report_times=True``
+            and read ``confirmed`` plus session ``time`` (``bmo``/``amc``),
+            which is not a drop-in for the old clock-time field.
         """
-        params = self._build_date_params(start_date, end_date)
-        return self.client.request(EARNINGS_CONFIRMED, **params)
+        return []
 
     @deprecated(
         "The FMP API no longer serves earnings surprises. Use "
@@ -203,10 +203,12 @@ class MarketIntelligenceClient(EndpointGroup):
 
         .. deprecated::
             This endpoint is no longer available on the FMP API and will be
-            removed in a future version. Use :meth:`get_historical_earnings`
-            and compare ``eps`` against ``eps_estimated`` instead.
+            removed in a future version. It currently returns an empty list.
+            Use :meth:`get_historical_earnings` and compare ``eps`` against
+            ``eps_estimated`` (old model used ``actual_earning_result`` /
+            ``estimated_earning``).
         """
-        return self.client.request(EARNINGS_SURPRISES, symbol=symbol)
+        return []
 
     def get_dividends_calendar(
         self, start_date: date | None = None, end_date: date | None = None

--- a/fmp_data/intelligence/mapping.py
+++ b/fmp_data/intelligence/mapping.py
@@ -636,8 +636,10 @@ INTELLIGENCE_ENDPOINTS_SEMANTICS = {
         client_name="intelligence",
         method_name="get_earnings_confirmed",
         natural_description=(
-            "Access confirmed earnings dates and times for companies including "
-            "timing details and publication information"
+            "DEPRECATED: FMP no longer serves this endpoint; the client returns "
+            "an empty list. Prefer get_earnings_calendar with "
+            "include_report_times=True and read confirmed plus session time "
+            "(bmo/amc)."
         ),
         example_queries=[
             "Show confirmed earnings dates",
@@ -1300,10 +1302,9 @@ INTELLIGENCE_ENDPOINTS_SEMANTICS = {
         client_name="intelligence",
         method_name="get_earnings_surprises",
         natural_description=(
-            "Retrieve historical earnings "
-            "surprises including actual vs "
-            "estimated earnings, "
-            "surprise percentages, and earnings dates"
+            "DEPRECATED: FMP no longer serves this endpoint; the client returns "
+            "an empty list. Prefer get_historical_earnings and compare eps "
+            "against eps_estimated (compute surprise percentage yourself)."
         ),
         example_queries=[
             "Get earnings surprises for AAPL",
@@ -1344,10 +1345,9 @@ INTELLIGENCE_ENDPOINTS_SEMANTICS = {
         client_name="intelligence",
         method_name="get_historical_earnings",
         natural_description=(
-            "Access historical earnings "
-            "reports including revenue, "
-            "EPS, and dates for "
-            "past quarters and fiscal years"
+            "Access historical and upcoming earnings reports for a symbol "
+            "including revenue, EPS, dates, and optional report-time metadata "
+            "when include_report_times is set"
         ),
         example_queries=[
             "Show historical earnings for AAPL",
@@ -1366,6 +1366,7 @@ INTELLIGENCE_ENDPOINTS_SEMANTICS = {
         sub_category="Calendar Events",
         parameter_hints={
             "symbol": SYMBOL_HINT,
+            "limit": LIMIT_HINT,
             "include_report_times": INCLUDE_REPORT_TIMES_HINT,
         },
         response_hints={

--- a/fmp_data/intelligence/mapping.py
+++ b/fmp_data/intelligence/mapping.py
@@ -636,10 +636,8 @@ INTELLIGENCE_ENDPOINTS_SEMANTICS = {
         client_name="intelligence",
         method_name="get_earnings_confirmed",
         natural_description=(
-            "DEPRECATED: FMP no longer serves this endpoint; the client returns "
-            "an empty list. Prefer get_earnings_calendar with "
-            "include_report_times=True and read confirmed plus session time "
-            "(bmo/amc)."
+            "DEPRECATED: empty list. Prefer earnings_calendar with "
+            "include_report_times=True (confirmed + bmo/amc time)."
         ),
         example_queries=[
             "Show confirmed earnings dates",
@@ -1302,9 +1300,8 @@ INTELLIGENCE_ENDPOINTS_SEMANTICS = {
         client_name="intelligence",
         method_name="get_earnings_surprises",
         natural_description=(
-            "DEPRECATED: FMP no longer serves this endpoint; the client returns "
-            "an empty list. Prefer get_historical_earnings and compare eps "
-            "against eps_estimated (compute surprise percentage yourself)."
+            "DEPRECATED: empty list. Prefer historical_earnings and "
+            "compare eps vs eps_estimated."
         ),
         example_queries=[
             "Get earnings surprises for AAPL",
@@ -1345,9 +1342,8 @@ INTELLIGENCE_ENDPOINTS_SEMANTICS = {
         client_name="intelligence",
         method_name="get_historical_earnings",
         natural_description=(
-            "Access historical and upcoming earnings reports for a symbol "
-            "including revenue, EPS, dates, and optional report-time metadata "
-            "when include_report_times is set"
+            "Historical/upcoming earnings for a symbol, with optional "
+            "limit and include_report_times metadata."
         ),
         example_queries=[
             "Show historical earnings for AAPL",

--- a/fmp_data/intelligence/models.py
+++ b/fmp_data/intelligence/models.py
@@ -44,9 +44,9 @@ class EarningEvent(BaseModel):
     time: str | None = Field(
         default=None,
         description=(
-            "Time of day the report is released ('bmo' before market open, "
-            "'amc' after market close). Only returned when the request is made "
-            "with include_report_times=True."
+            "Session bucket for the report ('bmo' before market open, "
+            "'amc' after market close). Often present on /earnings payloads; "
+            "calendar extras are more complete with include_report_times=True."
         ),
     )
     revenue: float | None = Field(
@@ -59,36 +59,43 @@ class EarningEvent(BaseModel):
         None,
         alias="periodEnding",
         description=(
-            "Fiscal period end date. Only returned when the request is made "
-            "with include_report_times=True."
+            "Fiscal period end date from includeReportTimes-style payloads "
+            "(wire key periodEnding). Prefer this when set; base calendar "
+            "payloads more often use fiscal_date_ending instead."
         ),
     )
     fiscal_period: str | None = Field(
         None,
         alias="fiscalPeriod",
         description=(
-            "Fiscal period the report covers (e.g. 'Q3'). Only returned when "
-            "the request is made with include_report_times=True."
+            "Fiscal period label (e.g. 'Q3'). Primarily returned when the "
+            "request includes include_report_times=True."
         ),
     )
     fiscal_year: int | None = Field(
         None,
         alias="fiscalYear",
         description=(
-            "Fiscal year the report covers. Only returned when the request is "
-            "made with include_report_times=True."
+            "Fiscal year for the report. Primarily returned when the request "
+            "includes include_report_times=True."
         ),
     )
     confirmed: bool | None = Field(
         None,
         description=(
             "Whether the reporting date has been confirmed by the company. "
-            "Only returned when the request is made with "
+            "Primarily returned when the request includes "
             "include_report_times=True."
         ),
     )
     fiscal_date_ending: date | None = Field(
-        None, alias="fiscalDateEnding", description="Fiscal period end date"
+        None,
+        alias="fiscalDateEnding",
+        description=(
+            "Fiscal period end date from base calendar/earnings payloads "
+            "(wire key fiscalDateEnding). Same concept as period_ending under "
+            "a different response shape."
+        ),
     )
     updated_from_date: date | None = Field(
         None, alias="updatedFromDate", description="Last update date"

--- a/fmp_data/mcp/tools_manifest.py
+++ b/fmp_data/mcp/tools_manifest.py
@@ -90,15 +90,17 @@ DEFAULT_TOOLS: list[str] = [
     "institutional.insider_trades",
     "institutional.institutional_holdings",
     "institutional.transaction_types",
-    # Intelligence (34 tools) - News, Sentiment, and Market Events
+    # Intelligence (28 tools) - News and Market Events
+    # Dead/deprecated FMP endpoints intentionally omitted from defaults:
+    # earnings_confirmed, earnings_surprises, stock_news_sentiments,
+    # historical_social_sentiment, trending_social_sentiment,
+    # social_sentiment_changes (still importable on the client).
     "intelligence.crowdfunding_by_cik",
     "intelligence.crowdfunding_rss",
     "intelligence.crypto_news",
     "intelligence.crypto_symbol_news",
     "intelligence.dividends_calendar",
     "intelligence.earnings_calendar",
-    "intelligence.earnings_confirmed",
-    "intelligence.earnings_surprises",
     "intelligence.equity_offering_by_cik",
     "intelligence.equity_offering_rss",
     "intelligence.esg_benchmark",
@@ -109,7 +111,6 @@ DEFAULT_TOOLS: list[str] = [
     "intelligence.forex_symbol_news",
     "intelligence.general_news",
     "intelligence.historical_earnings",
-    "intelligence.historical_social_sentiment",
     "intelligence.house_disclosure",
     "intelligence.house_latest",
     "intelligence.house_trades_by_name",
@@ -120,11 +121,8 @@ DEFAULT_TOOLS: list[str] = [
     "intelligence.senate_trading_rss",
     "intelligence.senate_latest",
     "intelligence.senate_trades_by_name",
-    "intelligence.social_sentiment_changes",
     "intelligence.stock_news",
-    "intelligence.stock_news_sentiments",
     "intelligence.stock_splits_calendar",
-    "intelligence.trending_social_sentiment",
     # Investment (11 tools) - ETFs and Mutual Funds
     "investment.etf_country_weightings",
     "investment.etf_exposure",

--- a/tests/integration/test_intelligence.py
+++ b/tests/integration/test_intelligence.py
@@ -11,9 +11,7 @@ from fmp_data.intelligence.models import (
     CrowdfundingOfferingSearchItem,
     CryptoNewsArticle,
     DividendEvent,
-    EarningConfirmed,
     EarningEvent,
-    EarningSurprise,
     EquityOffering,
     EquityOfferingSearchItem,
     ESGBenchmark,
@@ -75,31 +73,20 @@ class TestIntelligenceEndpoints(BaseTestCase):
     def test_get_earnings_confirmed(
         self, fmp_client: FMPDataClient, vcr_instance, frozen_today: date
     ):
-        """Test getting confirmed earnings"""
+        """Deprecated confirmed calendar soft-fails with empty list"""
         with vcr_instance.use_cassette("intelligence/earnings_confirmed.yaml"):
             start_date = frozen_today
             end_date = start_date + timedelta(days=30)
 
-            events = self._handle_rate_limit(
-                fmp_client.intelligence.get_earnings_confirmed,
-                start_date=start_date,
-                end_date=end_date,
-            )
+            with pytest.warns(DeprecationWarning, match="get_earnings_confirmed"):
+                events = self._handle_rate_limit(
+                    fmp_client.intelligence.get_earnings_confirmed,
+                    start_date=start_date,
+                    end_date=end_date,
+                )
 
-            assert isinstance(events, list), "events is not a list"
-            if len(events) > 0:
-                for event in events:
-                    assert isinstance(event, EarningConfirmed), (
-                        "event tpye is not Earning Confirmed"
-                    )
-                    if event.time is not None:
-                        assert isinstance(event.time, str), (
-                            "event time is not of type string, it"
-                        )
-                    if event.event_date is not None:
-                        assert isinstance(event.event_date, datetime), (
-                            "event date is not of datetime type"
-                        )
+            assert isinstance(events, list)
+            assert events == [], "Deprecated endpoint should return empty list"
 
     def test_get_historical_earnings(self, fmp_client: FMPDataClient, vcr_instance):
         """Test getting historical earnings"""
@@ -165,21 +152,15 @@ class TestIntelligenceEndpoints(BaseTestCase):
                     assert event.time in {"bmo", "amc"}
 
     def test_get_earnings_surprises(self, fmp_client: FMPDataClient, vcr_instance):
-        """Test getting earnings surprises"""
+        """Deprecated surprises endpoint soft-fails with empty list"""
         with vcr_instance.use_cassette("intelligence/earnings_surprises.yaml"):
-            surprises = self._handle_rate_limit(
-                fmp_client.intelligence.get_earnings_surprises, "AAPL"
-            )
+            with pytest.warns(DeprecationWarning, match="get_earnings_surprises"):
+                surprises = self._handle_rate_limit(
+                    fmp_client.intelligence.get_earnings_surprises, "AAPL"
+                )
 
             assert isinstance(surprises, list)
-            # API may return empty array if no data available
-            if len(surprises) > 0:
-                for surprise in surprises:
-                    assert isinstance(surprise, EarningSurprise)
-                    assert surprise.symbol == "AAPL"
-                    assert isinstance(surprise.surprise_date, date)
-                    assert isinstance(surprise.actual_earning_result, float)
-                    assert isinstance(surprise.estimated_earning, float)
+            assert surprises == [], "Deprecated endpoint should return empty list"
 
     def test_get_dividends_calendar(
         self, fmp_client: FMPDataClient, vcr_instance, frozen_today: date

--- a/tests/unit/test_async_clients.py
+++ b/tests/unit/test_async_clients.py
@@ -1198,6 +1198,65 @@ class TestAsyncIntelligenceClient:
             include_report_times=True,
         )
 
+    @pytest.mark.asyncio
+    async def test_get_historical_earnings_omits_optional_params(self, mock_client):
+        """Default historical call must not send limit/include_report_times."""
+        from fmp_data.intelligence import endpoints as intelligence_endpoints
+        from fmp_data.intelligence.async_client import AsyncMarketIntelligenceClient
+
+        mock_client.request_async.return_value = []
+        async_client = AsyncMarketIntelligenceClient(mock_client)
+
+        await async_client.get_historical_earnings("AAPL")
+
+        mock_client.request_async.assert_called_once_with(
+            intelligence_endpoints.HISTORICAL_EARNINGS,
+            symbol="AAPL",
+        )
+        kwargs = mock_client.request_async.call_args.kwargs
+        assert "limit" not in kwargs
+        assert "include_report_times" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_include_report_times_false_is_forwarded_async(self, mock_client):
+        """Explicit False is sent on async calendar and historical paths."""
+        from fmp_data.intelligence.async_client import AsyncMarketIntelligenceClient
+
+        mock_client.request_async.return_value = []
+        async_client = AsyncMarketIntelligenceClient(mock_client)
+
+        await async_client.get_earnings_calendar(include_report_times=False)
+        assert (
+            mock_client.request_async.call_args.kwargs["include_report_times"] is False
+        )
+
+        await async_client.get_historical_earnings("AAPL", include_report_times=False)
+        assert (
+            mock_client.request_async.call_args.kwargs["include_report_times"] is False
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method_name", "args", "hint"),
+        [
+            ("get_earnings_confirmed", (), "include_report_times"),
+            ("get_earnings_surprises", ("AAPL",), "eps_estimated"),
+        ],
+    )
+    async def test_dead_earnings_endpoints_warn_async(
+        self, mock_client, method_name, args, hint
+    ):
+        """Async dead earnings endpoints warn and soft-fail without HTTP."""
+        from fmp_data.intelligence.async_client import AsyncMarketIntelligenceClient
+
+        async_client = AsyncMarketIntelligenceClient(mock_client)
+        with pytest.warns(DeprecationWarning, match=method_name) as record:
+            result = await getattr(async_client, method_name)(*args)
+
+        assert result == []
+        mock_client.request_async.assert_not_called()
+        assert hint in str(record[0].message)
+
     def test_build_date_params_custom_keys(self):
         """Test _build_date_params supports custom keys."""
         from fmp_data.intelligence.async_client import AsyncMarketIntelligenceClient

--- a/tests/unit/test_intelligence.py
+++ b/tests/unit/test_intelligence.py
@@ -11,9 +11,7 @@ from fmp_data.intelligence.models import (
     CrowdfundingOfferingSearchItem,
     CryptoNewsArticle,
     DividendEvent,
-    EarningConfirmed,
     EarningEvent,
-    EarningSurprise,
     EquityOffering,
     EquityOfferingSearchItem,
     ESGBenchmark,
@@ -91,20 +89,6 @@ def earnings_report_times_data():
         "fiscalYear": 2026,
         "confirmed": True,
         "lastUpdated": "2026-08-01",
-    }
-
-
-@pytest.fixture
-def earnings_confirmed_data():
-    return {
-        "symbol": "AAPL",
-        "exchange": "NASDAQ",
-        "time": "16:30",
-        "when": "post market",
-        "date": "2024-01-15T16:30:00",
-        "publicationDate": "2024-01-01T10:00:00",
-        "title": "Apple Q1 2024 Earnings",
-        "url": "https://example.com",
     }
 
 
@@ -249,6 +233,11 @@ class TestMarketIntelligenceClientCalendar:
         assert event.period_ending == date(2026, 6, 27)
         assert event.fiscal_period == "Q3"
         assert event.fiscal_year == 2026
+        assert event.eps == 2.02
+        assert event.revenue == 109_417_000_000
+        assert event.eps_estimated == 1.89
+        assert event.revenue_estimated == 109_038_900_000
+        assert event.last_updated == date(2026, 8, 1)
 
     def test_get_earnings_calendar_omits_report_times_when_unset(
         self, fmp_client, mock_client, earnings_calendar_data
@@ -291,54 +280,72 @@ class TestMarketIntelligenceClientCalendar:
         assert kwargs["limit"] == 5
         assert kwargs["include_report_times"] is True
 
-    def test_get_earnings_confirmed(
-        self, fmp_client, mock_client, earnings_confirmed_data
-    ):
-        """Test get_earnings_confirmed"""
-        mock_client.request.return_value = [EarningConfirmed(**earnings_confirmed_data)]
+    def test_get_earnings_confirmed_soft_fails(self, fmp_client, mock_client):
+        """Deprecated confirmed calendar warns and returns [] without HTTP"""
+        with pytest.warns(DeprecationWarning, match="get_earnings_confirmed"):
+            result = fmp_client.intelligence.get_earnings_confirmed(
+                start_date=date(2024, 1, 1), end_date=date(2024, 1, 31)
+            )
 
-        result = fmp_client.intelligence.get_earnings_confirmed(
-            start_date=date(2024, 1, 1), end_date=date(2024, 1, 31)
-        )
+        assert result == []
+        mock_client.request.assert_not_called()
 
-        mock_client.request.assert_called_once()
-        _args, kwargs = mock_client.request.call_args
-        assert kwargs["start_date"] == "2024-01-01"
-        assert kwargs["end_date"] == "2024-01-31"
-        assert isinstance(result, list)
+    def test_get_earnings_surprises_soft_fails(self, fmp_client, mock_client):
+        """Deprecated surprises endpoint warns and returns [] without HTTP"""
+        with pytest.warns(DeprecationWarning, match="get_earnings_surprises"):
+            result = fmp_client.intelligence.get_earnings_surprises("AAPL")
 
-    def test_get_earnings_surprises(self, fmp_client, mock_client):
-        """Test get_earnings_surprises"""
-        mock_data = {
-            "symbol": "AAPL",
-            "date": "2024-01-15",
-            "actualEarningResult": 1.25,
-            "estimatedEarning": 1.20,
-        }
-        mock_client.request.return_value = [EarningSurprise(**mock_data)]
-
-        result = fmp_client.intelligence.get_earnings_surprises("AAPL")
-
-        mock_client.request.assert_called_once()
-        _args, kwargs = mock_client.request.call_args
-        assert kwargs["symbol"] == "AAPL"
-        assert isinstance(result, list)
+        assert result == []
+        mock_client.request.assert_not_called()
 
     @pytest.mark.parametrize(
-        ("method_name", "args"),
+        ("method_name", "args", "hint"),
         [
-            ("get_earnings_confirmed", ()),
-            ("get_earnings_surprises", ("AAPL",)),
+            ("get_earnings_confirmed", (), "include_report_times"),
+            ("get_earnings_surprises", ("AAPL",), "eps_estimated"),
         ],
     )
     def test_dead_earnings_endpoints_warn(
-        self, fmp_client, mock_client, method_name, args
+        self, fmp_client, mock_client, method_name, args, hint
     ):
         """Endpoints FMP no longer serves emit a DeprecationWarning"""
+        with pytest.warns(DeprecationWarning, match=method_name) as record:
+            result = getattr(fmp_client.intelligence, method_name)(*args)
+
+        assert result == []
+        mock_client.request.assert_not_called()
+        assert hint in str(record[0].message)
+
+    def test_include_report_times_false_is_forwarded(self, fmp_client, mock_client):
+        """Explicit False is sent, not treated as omit"""
         mock_client.request.return_value = []
 
-        with pytest.warns(DeprecationWarning, match=method_name):
-            getattr(fmp_client.intelligence, method_name)(*args)
+        fmp_client.intelligence.get_earnings_calendar(include_report_times=False)
+        assert mock_client.request.call_args.kwargs["include_report_times"] is False
+
+        fmp_client.intelligence.get_historical_earnings(
+            "AAPL", include_report_times=False
+        )
+        assert mock_client.request.call_args.kwargs["include_report_times"] is False
+
+    def test_historical_earnings_uses_stable_earnings_path(self):
+        """Unit guard against reverting the dead historical/earning-calendar path"""
+        from fmp_data.intelligence.endpoints import HISTORICAL_EARNINGS
+
+        assert HISTORICAL_EARNINGS.path == "earnings"
+        assert "historical/earning-calendar" not in HISTORICAL_EARNINGS.path
+
+    def test_earning_event_accepts_legacy_and_report_times_field_names(self):
+        """eps/revenue aliases accept both legacy and epsActual/revenueActual keys"""
+        legacy = EarningEvent(date="2024-01-15", symbol="AAPL", eps=1.2, revenue=1e9)
+        modern = EarningEvent(
+            date="2024-01-15",
+            symbol="AAPL",
+            epsActual=1.2,
+            revenueActual=1e9,
+        )
+        assert legacy.eps == modern.eps == 1.2
+        assert legacy.revenue == modern.revenue == 1e9
 
     def test_get_dividends_calendar(
         self, fmp_client, mock_client, dividends_calendar_data

--- a/tests/unit/test_mcp.py
+++ b/tests/unit/test_mcp.py
@@ -473,3 +473,34 @@ class TestMCPCompat:
             _compat, "import_mcp_server_class", side_effect=ImportError("no sdk")
         ):
             assert _compat.mcp_server_available() is False
+
+    def test_falls_back_to_fastmcp_on_v1_sdk(self):
+        """When MCPServer is missing, FastMCP from 1.x is used."""
+        import sys
+        import types
+
+        from fmp_data.mcp import _compat
+
+        class _FastMCP:
+            def add_tool(self, *args, **kwargs):
+                return None
+
+            def run(self, *args, **kwargs):
+                return None
+
+        fake_server = types.ModuleType("mcp.server")
+        fake_fastmcp = types.ModuleType("mcp.server.fastmcp")
+        fake_fastmcp.FastMCP = _FastMCP
+        # Parent package stubs so nested imports resolve
+        fake_mcp = types.ModuleType("mcp")
+        fake_mcp.server = fake_server
+
+        modules = {
+            "mcp": fake_mcp,
+            "mcp.server": fake_server,
+            "mcp.server.fastmcp": fake_fastmcp,
+        }
+        with patch.dict(sys.modules, modules, clear=False):
+            cls = _compat.import_mcp_server_class()
+
+        assert cls is _FastMCP


### PR DESCRIPTION
## Summary
Release-polish follow-up for **#113** from the multi-agent review:

- Soft-fail `get_earnings_confirmed` / `get_earnings_surprises` (warn + `[]`, no HTTP to 404 paths)
- Prune dead/deprecated tools from MCP `DEFAULT_TOOLS`
- Soften overstated report-times field docs + CHANGELOG accuracy
- Fix public docs path for historical earnings (`/stable/earnings`)
- Tests: async omit/false/deprecation paths, `epsActual` alias assertions, FastMCP fallback

## Broader work deferred to issues
- #114 — mapping method-name drift (`search_*` vs `get_*`)
- #115 — ghost intelligence semantics for other clients
- #116 — wire grades/ratings into MCP mapping

## Test plan
- [x] `pytest tests/unit/test_intelligence.py`
- [x] `pytest tests/unit/test_async_clients.py::TestAsyncIntelligenceClient`
- [x] `pytest tests/unit/test_mcp.py` (with mcp extra)
- [ ] CI green on this PR
- [ ] Merge to `dev` updates #113