### PR TITLE
fix(ci): address CodeRabbit findings for release PR #113

### DIFF
--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -42,6 +42,7 @@ jobs:
       - uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-python@v7.0.0
         with:

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -40,16 +40,17 @@ jobs:
         with:
           fetch-depth: 0  # Needed for version calculation
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: 🐍  Set up Python
         uses: actions/setup-python@v7.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: ⚡  Install uv (with cache)
+      - name: ⚡  Install uv
         uses: astral-sh/setup-uv@v9.0.0
         with:
-          enable-cache: true
+          enable-cache: false
 
       - name: 📦  Install build tools
         run: |
@@ -182,16 +183,17 @@ jobs:
         uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0  # Needed for hatch-vcs versioning
+          persist-credentials: false
 
       - name: 🐍  Set up Python
         uses: actions/setup-python@v7.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: ⚡  Install uv (with cache)
+      - name: ⚡  Install uv
         uses: astral-sh/setup-uv@v9.0.0
         with:
-          enable-cache: true
+          enable-cache: false
 
       - name: 📦  Build wheel & sdist
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
       - name: ⚡ Install uv
         uses: astral-sh/setup-uv@v9.0.0
         with:
-          enable-cache: true
+          enable-cache: false
 
       - name: 📦 Install dependencies
         run: |

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -175,9 +175,9 @@ All endpoints use the `/stable` prefix unless explicitly marked as `DIRECT` or `
 | `crowdfunding_rss` | `/stable/crowdfunding-offerings-latest` | Get latest crowdfunding offerings |
 | `crowdfunding_search` | `/stable/crowdfunding-offerings-search` | Search crowdfunding offerings |
 | `dividends_calendar` | `/stable/dividends-calendar` | Get dividends calendar |
-| `earnings_confirmed` | `/stable/earning-calendar-confirmed` | **Deprecated** — returns `[]`; use `earnings_calendar` with `includeReportTimes` |
-| `earnings_calendar` | `/stable/earnings-calendar` | Get earnings calendar |
-| `earnings_surprises` | `/stable/earnings-surprises` | **Deprecated** — returns `[]`; use `historical_earnings` and compare eps |
+| `earnings_confirmed` | `/stable/earning-calendar-confirmed` | **Deprecated** — client returns `[]` without calling this removed path; use `earnings_calendar` with `includeReportTimes` |
+| `earnings_calendar` | `/stable/earnings-calendar` | Get earnings calendar (`includeReportTimes`) |
+| `earnings_surprises` | `/stable/earnings-surprises` | **Deprecated** — client returns `[]` without calling this removed path; use `historical_earnings` and compare `eps` with `eps_estimated` |
 | `esg_benchmark` | `/stable/esg-benchmark` | Get ESG benchmark data |
 | `esg_data` | `/stable/esg-disclosures` | Get ESG data for a company |
 | `esg_ratings` | `/stable/esg-ratings` | Get ESG ratings for a company |

--- a/fmp_data/helpers.py
+++ b/fmp_data/helpers.py
@@ -1,6 +1,7 @@
 # src/helpers.py
 from collections.abc import Callable
 import functools
+import inspect
 from typing import Any, TypeVar
 import warnings
 
@@ -18,6 +19,8 @@ def deprecated(reason: str = "") -> Callable[[F], F]:
 
     Returns:
         A decorator that emits a DeprecationWarning when the function is called.
+        Coroutine functions are wrapped with an async wrapper so
+        ``inspect.iscoroutinefunction`` remains True.
 
     Example:
         >>> @deprecated("Use `new_method` instead.")
@@ -29,6 +32,15 @@ def deprecated(reason: str = "") -> Callable[[F], F]:
         msg = f"{func.__name__} is deprecated."
         if reason:
             msg += f" {reason}"
+
+        if inspect.iscoroutinefunction(func):
+
+            @functools.wraps(func)
+            async def async_wrapped(*args: Any, **kwargs: Any) -> Any:
+                warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
+                return await func(*args, **kwargs)
+
+            return async_wrapped  # type: ignore[return-value]
 
         @functools.wraps(func)
         def wrapped(*args: Any, **kwargs: Any) -> Any:

--- a/tests/integration/test_intelligence.py
+++ b/tests/integration/test_intelligence.py
@@ -71,22 +71,20 @@ class TestIntelligenceEndpoints(BaseTestCase):
                     assert isinstance(event.eps_estimated, float)
 
     def test_get_earnings_confirmed(
-        self, fmp_client: FMPDataClient, vcr_instance, frozen_today: date
+        self, fmp_client: FMPDataClient, frozen_today: date
     ):
-        """Deprecated confirmed calendar soft-fails with empty list"""
-        with vcr_instance.use_cassette("intelligence/earnings_confirmed.yaml"):
-            start_date = frozen_today
-            end_date = start_date + timedelta(days=30)
+        """Deprecated confirmed calendar soft-fails with empty list (no HTTP)."""
+        start_date = frozen_today
+        end_date = start_date + timedelta(days=30)
 
-            with pytest.warns(DeprecationWarning, match="get_earnings_confirmed"):
-                events = self._handle_rate_limit(
-                    fmp_client.intelligence.get_earnings_confirmed,
-                    start_date=start_date,
-                    end_date=end_date,
-                )
+        with pytest.warns(DeprecationWarning, match="get_earnings_confirmed"):
+            events = fmp_client.intelligence.get_earnings_confirmed(
+                start_date=start_date,
+                end_date=end_date,
+            )
 
-            assert isinstance(events, list)
-            assert events == [], "Deprecated endpoint should return empty list"
+        assert isinstance(events, list)
+        assert events == [], "Deprecated endpoint should return empty list"
 
     def test_get_historical_earnings(self, fmp_client: FMPDataClient, vcr_instance):
         """Test getting historical earnings"""
@@ -151,16 +149,13 @@ class TestIntelligenceEndpoints(BaseTestCase):
                 if event.time is not None:
                     assert event.time in {"bmo", "amc"}
 
-    def test_get_earnings_surprises(self, fmp_client: FMPDataClient, vcr_instance):
-        """Deprecated surprises endpoint soft-fails with empty list"""
-        with vcr_instance.use_cassette("intelligence/earnings_surprises.yaml"):
-            with pytest.warns(DeprecationWarning, match="get_earnings_surprises"):
-                surprises = self._handle_rate_limit(
-                    fmp_client.intelligence.get_earnings_surprises, "AAPL"
-                )
+    def test_get_earnings_surprises(self, fmp_client: FMPDataClient):
+        """Deprecated surprises endpoint soft-fails with empty list (no HTTP)."""
+        with pytest.warns(DeprecationWarning, match="get_earnings_surprises"):
+            surprises = fmp_client.intelligence.get_earnings_surprises("AAPL")
 
-            assert isinstance(surprises, list)
-            assert surprises == [], "Deprecated endpoint should return empty list"
+        assert isinstance(surprises, list)
+        assert surprises == [], "Deprecated endpoint should return empty list"
 
     def test_get_dividends_calendar(
         self, fmp_client: FMPDataClient, vcr_instance, frozen_today: date

--- a/tests/unit/test_async_clients.py
+++ b/tests/unit/test_async_clients.py
@@ -1247,11 +1247,15 @@ class TestAsyncIntelligenceClient:
         self, mock_client, method_name, args, hint
     ):
         """Async dead earnings endpoints warn and soft-fail without HTTP."""
+        import inspect
+
         from fmp_data.intelligence.async_client import AsyncMarketIntelligenceClient
 
         async_client = AsyncMarketIntelligenceClient(mock_client)
+        method = getattr(async_client, method_name)
+        assert inspect.iscoroutinefunction(method)
         with pytest.warns(DeprecationWarning, match=method_name) as record:
-            result = await getattr(async_client, method_name)(*args)
+            result = await method(*args)
 
         assert result == []
         mock_client.request_async.assert_not_called()

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -115,3 +115,27 @@ class TestDeprecatedDecorator:
             assert result == "old result"
             assert len(w) == 1
             assert "old_method is deprecated." in str(w[0].message)
+
+    def test_deprecated_async_preserves_coroutine(self):
+        """Async wrappers stay coroutine functions and still warn on await."""
+        import asyncio
+        import inspect
+
+        @deprecated("Use new_async instead.")
+        async def old_async() -> str:
+            return "result"
+
+        assert inspect.iscoroutinefunction(old_async)
+
+        async def _run() -> str:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                result = await old_async()
+                assert result == "result"
+                assert len(w) == 1
+                assert issubclass(w[0].category, DeprecationWarning)
+                assert "old_async is deprecated." in str(w[0].message)
+                assert "Use new_async instead." in str(w[0].message)
+            return result
+
+        assert asyncio.run(_run()) == "result"


### PR DESCRIPTION
## Summary
Isolated follow-up for CodeRabbit review on **#113**:

| Finding | Fix |
|---|---|
| Checkout credential persistence (docs / TestPyPI) | `persist-credentials: false` |
| uv cache on publish/release (cache poisoning) | `enable-cache: false` on setup-uv |
| `@deprecated` breaks `iscoroutinefunction` | Async-aware wrapper in `helpers.deprecated` |
| Docs soft-fail wording | Clarify client returns `[]` without calling removed paths; document `includeReportTimes` on calendar |
| VCR on soft-fail integration tests | Drop cassette contexts (no HTTP) |

## Test plan
- [x] `pytest tests/unit/test_helpers.py tests/unit/test_async_clients.py::TestAsyncIntelligenceClient`
- [x] pre-commit hooks
- [ ] CI green; merge to `dev` updates #113