### PR TITLE
test(intelligence): annotate earnings tests for PR #113 polish

### DIFF
--- a/tests/integration/test_intelligence.py
+++ b/tests/integration/test_intelligence.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 
 from pydantic import HttpUrl
 import pytest
+import vcr
 
 from fmp_data import FMPDataClient
 from fmp_data.helpers import RemovedEndpointError
@@ -72,7 +73,7 @@ class TestIntelligenceEndpoints(BaseTestCase):
 
     def test_get_earnings_confirmed(
         self, fmp_client: FMPDataClient, frozen_today: date
-    ):
+    ) -> None:
         """Deprecated confirmed calendar soft-fails with empty list (no HTTP)."""
         start_date = frozen_today
         end_date = start_date + timedelta(days=30)
@@ -86,7 +87,9 @@ class TestIntelligenceEndpoints(BaseTestCase):
         assert isinstance(events, list)
         assert events == [], "Deprecated endpoint should return empty list"
 
-    def test_get_historical_earnings(self, fmp_client: FMPDataClient, vcr_instance):
+    def test_get_historical_earnings(
+        self, fmp_client: FMPDataClient, vcr_instance: vcr.VCR
+    ) -> None:
         """Test getting historical earnings"""
         with vcr_instance.use_cassette("intelligence/historical_earnings.yaml"):
             events = self._handle_rate_limit(
@@ -103,8 +106,8 @@ class TestIntelligenceEndpoints(BaseTestCase):
                     assert isinstance(event.time, str)
 
     def test_get_historical_earnings_with_report_times(
-        self, fmp_client: FMPDataClient, vcr_instance
-    ):
+        self, fmp_client: FMPDataClient, vcr_instance: vcr.VCR
+    ) -> None:
         """Report time fields are populated when include_report_times is set"""
         with vcr_instance.use_cassette(
             "intelligence/historical_earnings_report_times.yaml"
@@ -128,8 +131,8 @@ class TestIntelligenceEndpoints(BaseTestCase):
                     assert isinstance(event.fiscal_year, int)
 
     def test_get_earnings_calendar_with_report_times(
-        self, fmp_client: FMPDataClient, vcr_instance, frozen_today: date
-    ):
+        self, fmp_client: FMPDataClient, vcr_instance: vcr.VCR, frozen_today: date
+    ) -> None:
         """Earnings calendar exposes report times when the flag is set"""
         with vcr_instance.use_cassette(
             "intelligence/earnings_calendar_report_times.yaml"
@@ -149,7 +152,7 @@ class TestIntelligenceEndpoints(BaseTestCase):
                 if event.time is not None:
                     assert event.time in {"bmo", "amc"}
 
-    def test_get_earnings_surprises(self, fmp_client: FMPDataClient):
+    def test_get_earnings_surprises(self, fmp_client: FMPDataClient) -> None:
         """Deprecated surprises endpoint soft-fails with empty list (no HTTP)."""
         with pytest.warns(DeprecationWarning, match="get_earnings_surprises"):
             surprises = fmp_client.intelligence.get_earnings_surprises("AAPL")

--- a/tests/unit/test_async_clients.py
+++ b/tests/unit/test_async_clients.py
@@ -1163,7 +1163,9 @@ class TestAsyncIntelligenceClient:
         )
 
     @pytest.mark.asyncio
-    async def test_get_earnings_calendar_include_report_times(self, mock_client):
+    async def test_get_earnings_calendar_include_report_times(
+        self, mock_client: MagicMock
+    ) -> None:
         """Test earnings calendar forwards include_report_times."""
         from fmp_data.intelligence import endpoints as intelligence_endpoints
         from fmp_data.intelligence.async_client import AsyncMarketIntelligenceClient
@@ -1179,7 +1181,9 @@ class TestAsyncIntelligenceClient:
         )
 
     @pytest.mark.asyncio
-    async def test_get_historical_earnings_optional_params(self, mock_client):
+    async def test_get_historical_earnings_optional_params(
+        self, mock_client: MagicMock
+    ) -> None:
         """Test historical earnings forwards limit and include_report_times."""
         from fmp_data.intelligence import endpoints as intelligence_endpoints
         from fmp_data.intelligence.async_client import AsyncMarketIntelligenceClient
@@ -1199,7 +1203,9 @@ class TestAsyncIntelligenceClient:
         )
 
     @pytest.mark.asyncio
-    async def test_get_historical_earnings_omits_optional_params(self, mock_client):
+    async def test_get_historical_earnings_omits_optional_params(
+        self, mock_client: MagicMock
+    ) -> None:
         """Default historical call must not send limit/include_report_times."""
         from fmp_data.intelligence import endpoints as intelligence_endpoints
         from fmp_data.intelligence.async_client import AsyncMarketIntelligenceClient
@@ -1218,7 +1224,9 @@ class TestAsyncIntelligenceClient:
         assert "include_report_times" not in kwargs
 
     @pytest.mark.asyncio
-    async def test_include_report_times_false_is_forwarded_async(self, mock_client):
+    async def test_include_report_times_false_is_forwarded_async(
+        self, mock_client: MagicMock
+    ) -> None:
         """Explicit False is sent on async calendar and historical paths."""
         from fmp_data.intelligence.async_client import AsyncMarketIntelligenceClient
 
@@ -1244,8 +1252,12 @@ class TestAsyncIntelligenceClient:
         ],
     )
     async def test_dead_earnings_endpoints_warn_async(
-        self, mock_client, method_name, args, hint
-    ):
+        self,
+        mock_client: MagicMock,
+        method_name: str,
+        args: tuple[str, ...],
+        hint: str,
+    ) -> None:
         """Async dead earnings endpoints warn and soft-fail without HTTP."""
         import inspect
 

--- a/tests/unit/test_intelligence.py
+++ b/tests/unit/test_intelligence.py
@@ -1,9 +1,11 @@
 # tests/unit/test_intelligence_client.py (Enhanced version)
 from datetime import date, datetime
+from typing import Any
 from unittest.mock import Mock
 
 import pytest
 
+from fmp_data import FMPDataClient
 from fmp_data.helpers import RemovedEndpointError
 from fmp_data.intelligence.client import MarketIntelligenceClient
 from fmp_data.intelligence.models import (
@@ -39,15 +41,15 @@ from fmp_data.intelligence.models import (
 
 
 @pytest.fixture
-def mock_client():
+def mock_client() -> Mock:
     """Create a mock client for testing"""
     return Mock()
 
 
 @pytest.fixture
-def fmp_client(mock_client):
+def fmp_client(mock_client: Mock) -> FMPDataClient:
     """Create FMP client with mocked intelligence client"""
-    from fmp_data import ClientConfig, FMPDataClient
+    from fmp_data import ClientConfig
 
     client = FMPDataClient(config=ClientConfig(api_key="dummy"))
     # Replace the intelligence client with our properly mocked one
@@ -59,7 +61,7 @@ def fmp_client(mock_client):
 
 # Test Data Fixtures
 @pytest.fixture
-def earnings_calendar_data():
+def earnings_calendar_data() -> dict[str, Any]:
     return {
         "date": "2024-01-15",
         "symbol": "AAPL",
@@ -74,7 +76,7 @@ def earnings_calendar_data():
 
 
 @pytest.fixture
-def earnings_report_times_data():
+def earnings_report_times_data() -> dict[str, Any]:
     """Earnings payload as returned with includeReportTimes=true"""
     return {
         "symbol": "AAPL",
@@ -183,8 +185,11 @@ class TestMarketIntelligenceClientCalendar:
     """Test calendar functionality"""
 
     def test_get_earnings_calendar_no_dates(
-        self, fmp_client, mock_client, earnings_calendar_data
-    ):
+        self,
+        fmp_client: FMPDataClient,
+        mock_client: Mock,
+        earnings_calendar_data: dict[str, Any],
+    ) -> None:
         """Test get_earnings_calendar without date filters"""
         mock_client.request.return_value = [EarningEvent(**earnings_calendar_data)]
 
@@ -198,8 +203,11 @@ class TestMarketIntelligenceClientCalendar:
         assert result[0].symbol == "AAPL"
 
     def test_get_earnings_calendar_with_dates(
-        self, fmp_client, mock_client, earnings_calendar_data
-    ):
+        self,
+        fmp_client: FMPDataClient,
+        mock_client: Mock,
+        earnings_calendar_data: dict[str, Any],
+    ) -> None:
         """Test get_earnings_calendar with date filters"""
         mock_client.request.return_value = [EarningEvent(**earnings_calendar_data)]
 
@@ -216,8 +224,11 @@ class TestMarketIntelligenceClientCalendar:
         assert isinstance(result, list)
 
     def test_get_earnings_calendar_with_report_times(
-        self, fmp_client, mock_client, earnings_report_times_data
-    ):
+        self,
+        fmp_client: FMPDataClient,
+        mock_client: Mock,
+        earnings_report_times_data: dict[str, Any],
+    ) -> None:
         """include_report_times is forwarded and its extra fields parse"""
         mock_client.request.return_value = [EarningEvent(**earnings_report_times_data)]
 
@@ -240,8 +251,11 @@ class TestMarketIntelligenceClientCalendar:
         assert event.last_updated == date(2026, 8, 1)
 
     def test_get_earnings_calendar_omits_report_times_when_unset(
-        self, fmp_client, mock_client, earnings_calendar_data
-    ):
+        self,
+        fmp_client: FMPDataClient,
+        mock_client: Mock,
+        earnings_calendar_data: dict[str, Any],
+    ) -> None:
         """The flag is left off the request entirely when not supplied"""
         mock_client.request.return_value = [EarningEvent(**earnings_calendar_data)]
 
@@ -251,8 +265,11 @@ class TestMarketIntelligenceClientCalendar:
         assert "include_report_times" not in kwargs
 
     def test_get_historical_earnings(
-        self, fmp_client, mock_client, earnings_calendar_data
-    ):
+        self,
+        fmp_client: FMPDataClient,
+        mock_client: Mock,
+        earnings_calendar_data: dict[str, Any],
+    ) -> None:
         """Test get_historical_earnings"""
         mock_client.request.return_value = [EarningEvent(**earnings_calendar_data)]
 
@@ -266,8 +283,11 @@ class TestMarketIntelligenceClientCalendar:
         assert isinstance(result, list)
 
     def test_get_historical_earnings_with_optional_params(
-        self, fmp_client, mock_client, earnings_report_times_data
-    ):
+        self,
+        fmp_client: FMPDataClient,
+        mock_client: Mock,
+        earnings_report_times_data: dict[str, Any],
+    ) -> None:
         """limit and include_report_times are forwarded when supplied"""
         mock_client.request.return_value = [EarningEvent(**earnings_report_times_data)]
 
@@ -280,7 +300,9 @@ class TestMarketIntelligenceClientCalendar:
         assert kwargs["limit"] == 5
         assert kwargs["include_report_times"] is True
 
-    def test_get_earnings_confirmed_soft_fails(self, fmp_client, mock_client):
+    def test_get_earnings_confirmed_soft_fails(
+        self, fmp_client: FMPDataClient, mock_client: Mock
+    ) -> None:
         """Deprecated confirmed calendar warns and returns [] without HTTP"""
         with pytest.warns(DeprecationWarning, match="get_earnings_confirmed"):
             result = fmp_client.intelligence.get_earnings_confirmed(
@@ -290,7 +312,9 @@ class TestMarketIntelligenceClientCalendar:
         assert result == []
         mock_client.request.assert_not_called()
 
-    def test_get_earnings_surprises_soft_fails(self, fmp_client, mock_client):
+    def test_get_earnings_surprises_soft_fails(
+        self, fmp_client: FMPDataClient, mock_client: Mock
+    ) -> None:
         """Deprecated surprises endpoint warns and returns [] without HTTP"""
         with pytest.warns(DeprecationWarning, match="get_earnings_surprises"):
             result = fmp_client.intelligence.get_earnings_surprises("AAPL")
@@ -306,8 +330,13 @@ class TestMarketIntelligenceClientCalendar:
         ],
     )
     def test_dead_earnings_endpoints_warn(
-        self, fmp_client, mock_client, method_name, args, hint
-    ):
+        self,
+        fmp_client: FMPDataClient,
+        mock_client: Mock,
+        method_name: str,
+        args: tuple[str, ...],
+        hint: str,
+    ) -> None:
         """Endpoints FMP no longer serves emit a DeprecationWarning"""
         with pytest.warns(DeprecationWarning, match=method_name) as record:
             result = getattr(fmp_client.intelligence, method_name)(*args)
@@ -316,7 +345,9 @@ class TestMarketIntelligenceClientCalendar:
         mock_client.request.assert_not_called()
         assert hint in str(record[0].message)
 
-    def test_include_report_times_false_is_forwarded(self, fmp_client, mock_client):
+    def test_include_report_times_false_is_forwarded(
+        self, fmp_client: FMPDataClient, mock_client: Mock
+    ) -> None:
         """Explicit False is sent, not treated as omit"""
         mock_client.request.return_value = []
 
@@ -328,14 +359,14 @@ class TestMarketIntelligenceClientCalendar:
         )
         assert mock_client.request.call_args.kwargs["include_report_times"] is False
 
-    def test_historical_earnings_uses_stable_earnings_path(self):
+    def test_historical_earnings_uses_stable_earnings_path(self) -> None:
         """Unit guard against reverting the dead historical/earning-calendar path"""
         from fmp_data.intelligence.endpoints import HISTORICAL_EARNINGS
 
         assert HISTORICAL_EARNINGS.path == "earnings"
         assert "historical/earning-calendar" not in HISTORICAL_EARNINGS.path
 
-    def test_earning_event_accepts_legacy_and_report_times_field_names(self):
+    def test_earning_event_accepts_legacy_and_report_times_field_names(self) -> None:
         """eps/revenue aliases accept both legacy and epsActual/revenueActual keys"""
         legacy = EarningEvent(date="2024-01-15", symbol="AAPL", eps=1.2, revenue=1e9)
         modern = EarningEvent(

--- a/tests/unit/test_intelligence.py
+++ b/tests/unit/test_intelligence.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from fmp_data import FMPDataClient
+from fmp_data import ClientConfig, FMPDataClient
 from fmp_data.helpers import RemovedEndpointError
 from fmp_data.intelligence.client import MarketIntelligenceClient
 from fmp_data.intelligence.models import (
@@ -49,8 +49,6 @@ def mock_client() -> Mock:
 @pytest.fixture
 def fmp_client(mock_client: Mock) -> FMPDataClient:
     """Create FMP client with mocked intelligence client"""
-    from fmp_data import ClientConfig
-
     client = FMPDataClient(config=ClientConfig(api_key="dummy"))
     # Replace the intelligence client with our properly mocked one
     mock_base_client = Mock()


### PR DESCRIPTION
## Summary
- Add return (`-> None`) and fixture type annotations to new earnings calendar / historical / soft-fail tests introduced for the v2.5.0 release.
- Addresses remaining CodeRabbit **outside-diff** feedback on release PR #113 without expanding into full-file test typing cleanup.

## Context
Inline CodeRabbit findings on #113 were already fixed via #119. This lands the leftover typing polish so the release PR can re-fire required `Test-Matrix` checks after earlier Actions outages cancelled matrix runs.

## Test plan
- [x] `uv run pytest tests/unit/test_intelligence.py::TestMarketIntelligenceClientCalendar tests/unit/test_async_clients.py::TestAsyncIntelligenceClient`
- [x] ruff check/format on touched files
- [ ] CI Test-Matrix on this PR
- [ ] After merge, confirm #113 re-runs tests 3.10–3.14

Refs: #113

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved type annotations across intelligence and asynchronous client test suites.
  * Expanded earnings test coverage for report-time options, field aliases, endpoint routing, and deprecated endpoint handling.
  * Preserved existing request, response, and error-handling validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->