### PR TITLE
test(ci): harden check-pr-mergeable mock matrix (#215)

### DIFF
--- a/.github/actions/check-pr-mergeable/test-check.sh
+++ b/.github/actions/check-pr-mergeable/test-check.sh
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
 # Local fail-closed matrix for check.sh (no network). Run:
 #   bash .github/actions/check-pr-mergeable/test-check.sh
+#
+# Asserts exit codes, GITHUB_OUTPUT, and (where relevant) step summary
+# wording so silent case drops or output drift fail CI (#215).
+# Bump EXPECTED_PASS in the same commit when adding/removing PASS lines.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")" && pwd)"
 CHECK="${ROOT}/check.sh"
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
+
+# Bump when adding/removing PASS lines so a silent case drop fails CI (#215).
+EXPECTED_PASS=24
 
 install_mock_gh() {
   cat >"$tmpdir/gh" <<'EOF'
@@ -29,7 +36,7 @@ install_mock_gh
 
 export PATH="$tmpdir:$PATH"
 export GH_TOKEN=fake REPO=o/r PR_NUMBER=1
-export MAX_ATTEMPTS=3 SLEEP_SECONDS=0
+export MAX_ATTEMPTS=3 SLEEP_SECONDS=0 API_MAX_RETRIES=3
 export GITHUB_OUTPUT="$tmpdir/out" GITHUB_STEP_SUMMARY="$tmpdir/sum"
 export MOCK_STATE_FILE="$tmpdir/state"
 
@@ -43,6 +50,27 @@ indent_out() {
   done <<<"$1"
 }
 
+assert_outputs() {
+  # assert_outputs name expect_mergeable expect_mstate [summary_substr]
+  local name="$1" em="$2" es="$3" sum_sub="${4:-}"
+  local got_m got_s
+  got_m=$(grep -E '^mergeable=' "$GITHUB_OUTPUT" | tail -n1 | cut -d= -f2- || true)
+  got_s=$(grep -E '^mergeable_state=' "$GITHUB_OUTPUT" | tail -n1 | cut -d= -f2- || true)
+  if [ "$got_m" != "$em" ] || [ "$got_s" != "$es" ]; then
+    echo "FAIL: $name outputs expected mergeable=${em} mergeable_state=${es} got mergeable=${got_m} mergeable_state=${got_s}"
+    indent_out "$(cat "$GITHUB_OUTPUT" 2>/dev/null || true)"
+    return 1
+  fi
+  if [ -n "$sum_sub" ] && ! grep -Fq "$sum_sub" "$GITHUB_STEP_SUMMARY"; then
+    echo "FAIL: $name step summary missing '${sum_sub}'"
+    indent_out "$(cat "$GITHUB_STEP_SUMMARY" 2>/dev/null || true)"
+    return 1
+  fi
+  return 0
+}
+
+# run_case name expect_exit [state lines...]
+# Optional env before call: EXPECT_MERGEABLE, EXPECT_MSTATE, EXPECT_SUMMARY
 run_case() {
   local name="$1" expect="$2"
   shift 2
@@ -57,32 +85,68 @@ run_case() {
   out=$(bash "$CHECK" 2>&1)
   code=$?
   set -e
-  if [ "$code" -eq "$expect" ]; then
-    echo "PASS: $name (exit $code)"
-    pass=$((pass + 1))
-  else
+  if [ "$code" -ne "$expect" ]; then
     echo "FAIL: $name expected exit $expect got $code"
     indent_out "$out"
     fail=$((fail + 1))
+    return
   fi
+  if [ -n "${EXPECT_MERGEABLE:-}" ] || [ -n "${EXPECT_MSTATE:-}" ]; then
+    if ! assert_outputs "$name" "${EXPECT_MERGEABLE:-}" "${EXPECT_MSTATE:-}" "${EXPECT_SUMMARY:-}"; then
+      fail=$((fail + 1))
+      unset EXPECT_MERGEABLE EXPECT_MSTATE EXPECT_SUMMARY
+      return
+    fi
+  fi
+  echo "PASS: $name (exit $code)"
+  pass=$((pass + 1))
+  unset EXPECT_MERGEABLE EXPECT_MSTATE EXPECT_SUMMARY
 }
 
-run_case "unknown->clean" 0 $'null\tunknown' $'true\tclean'
-run_case "dirty" 1 $'false\tdirty'
-run_case "unknown-forever" 1 $'null\tunknown' $'null\tunknown' $'null\tunknown'
-run_case "false-blocked" 1 $'false\tblocked'
-run_case "false-unknown" 1 $'false\tunknown'
-run_case "unstable-ok" 0 $'true\tunstable'
-# #213 / #216: null mergeable with a resolved non-dirty state must not go green.
-# Production after #216: jq tostring encodes JSON null as the literal "null"
-# token ($'null\tclean'). empty-*-fails remains defensive for a drifted
-# extraction that still emits an empty field.
-run_case "null-clean-fails" 1 $'null\tclean'
-run_case "empty-clean-fails" 1 $'\tclean'
-run_case "null-blocked-fails" 1 $'null\tblocked'
-run_case "true-blocked-ok" 0 $'true\tblocked'
+# --- core mergeability matrix ---
+EXPECT_MERGEABLE=true EXPECT_MSTATE=clean EXPECT_SUMMARY='ok (mergeable=true)' \
+  run_case "unknown->clean" 0 $'null\tunknown' $'true\tclean'
 
-# Lock the production jq extraction used by check.sh (#216). No network.
+EXPECT_MERGEABLE=false EXPECT_MSTATE=dirty EXPECT_SUMMARY='failed (dirty)' \
+  run_case "dirty" 1 $'false\tdirty'
+
+EXPECT_MERGEABLE=null EXPECT_MSTATE=unknown EXPECT_SUMMARY='failed (unknown after retries)' \
+  run_case "unknown-forever" 1 $'null\tunknown' $'null\tunknown' $'null\tunknown'
+
+EXPECT_MERGEABLE=false EXPECT_MSTATE=blocked EXPECT_SUMMARY='failed (mergeable=false, state=blocked)' \
+  run_case "false-blocked" 1 $'false\tblocked'
+
+EXPECT_MERGEABLE=false EXPECT_MSTATE=unknown EXPECT_SUMMARY='failed (mergeable=false)' \
+  run_case "false-unknown" 1 $'false\tunknown'
+
+EXPECT_MERGEABLE=true EXPECT_MSTATE=unstable EXPECT_SUMMARY='ok (mergeable=true)' \
+  run_case "unstable-ok" 0 $'true\tunstable'
+
+EXPECT_MERGEABLE=null EXPECT_MSTATE=clean EXPECT_SUMMARY='failed (mergeable not true, state=clean)' \
+  run_case "null-clean-fails" 1 $'null\tclean'
+
+EXPECT_MERGEABLE=null EXPECT_MSTATE=clean EXPECT_SUMMARY='failed (mergeable not true, state=clean)' \
+  run_case "empty-clean-fails" 1 $'\tclean'
+
+EXPECT_MERGEABLE=null EXPECT_MSTATE=blocked EXPECT_SUMMARY='failed (mergeable not true, state=blocked)' \
+  run_case "null-blocked-fails" 1 $'null\tblocked'
+
+EXPECT_MERGEABLE=true EXPECT_MSTATE=blocked EXPECT_SUMMARY='ok (mergeable=true)' \
+  run_case "true-blocked-ok" 0 $'true\tblocked'
+
+# #215 edge cases
+EXPECT_MERGEABLE=true EXPECT_MSTATE=unknown EXPECT_SUMMARY='failed (unknown after retries)' \
+  run_case "true-unknown-exhausted" 1 $'true\tunknown' $'true\tunknown' $'true\tunknown'
+
+EXPECT_MERGEABLE=true EXPECT_MSTATE=dirty EXPECT_SUMMARY='failed (dirty)' \
+  run_case "true-dirty-short-circuit" 1 $'true\tdirty'
+
+# Defense-in-depth: literal "null" state token (if extraction drifts) must
+# exhaust as unresolved, not hit *) and go green when mergeable=true (#216).
+EXPECT_MERGEABLE=true EXPECT_MSTATE=null EXPECT_SUMMARY='failed (unknown after retries)' \
+  run_case "true-null-state-exhausts" 1 $'true\tnull' $'true\tnull' $'true\tnull'
+
+# --- jq encoding locks (#216) ---
 jq_prod=$(jq -rn '([(null | tostring), ((null // "unknown") | tostring)] | @tsv)')
 if [ "$jq_prod" = $'null\tunknown' ]; then
   echo "PASS: jq-tostring-prod-extraction (null mergeable + null state→unknown)"
@@ -99,11 +163,8 @@ else
   printf 'FAIL: jq-tostring-true-field expected true\\tclean got %q\n' "$jq_tsv_true"
   fail=$((fail + 1))
 fi
-# Defense-in-depth: literal "null" state token (if extraction drifts) must
-# exhaust as unresolved, not hit *) and go green when mergeable=true (#216).
-run_case "true-null-state-exhausts" 1 $'true\tnull' $'true\tnull' $'true\tnull'
 
-# invalid max via env (before gh is called)
+# --- input validation (before gh) ---
 set +e
 out=$(MAX_ATTEMPTS=0 bash "$CHECK" 2>&1)
 code=$?
@@ -117,6 +178,32 @@ else
   fail=$((fail + 1))
 fi
 
+set +e
+out=$(SLEEP_SECONDS=-1 bash "$CHECK" 2>&1)
+code=$?
+set -e
+if [ "$code" -ne 0 ] && echo "$out" | grep -q 'sleep-seconds'; then
+  echo "PASS: invalid-sleep (exit $code)"
+  pass=$((pass + 1))
+else
+  echo "FAIL: invalid-sleep expected non-zero + message"
+  indent_out "$out"
+  fail=$((fail + 1))
+fi
+
+set +e
+out=$(API_MAX_RETRIES=0 bash "$CHECK" 2>&1)
+code=$?
+set -e
+if [ "$code" -ne 0 ] && echo "$out" | grep -q 'api-max-retries'; then
+  echo "PASS: invalid-api-max-retries (exit $code)"
+  pass=$((pass + 1))
+else
+  echo "FAIL: invalid-api-max-retries expected non-zero + message"
+  indent_out "$out"
+  fail=$((fail + 1))
+fi
+
 # dirty + conflict-guidance printed
 export CONFLICT_GUIDANCE="Sync main into dev with a merge commit, not squash."
 printf '%s\n' $'false\tdirty' >"$MOCK_STATE_FILE"
@@ -126,7 +213,8 @@ set +e
 out=$(bash "$CHECK" 2>&1)
 code=$?
 set -e
-if [ "$code" -ne 0 ] && echo "$out" | grep -q 'merge commit, not squash'; then
+if [ "$code" -ne 0 ] && echo "$out" | grep -q 'merge commit, not squash' \
+  && assert_outputs "conflict-guidance" "false" "dirty" "failed (dirty)"; then
   echo "PASS: conflict-guidance (printed on dirty)"
   pass=$((pass + 1))
 else
@@ -136,7 +224,7 @@ else
 fi
 unset CONFLICT_GUIDANCE
 
-# API failure path: always-fail 500 exhausts transient retries (#217)
+# --- API error paths (#217) ---
 cat >"$tmpdir/gh" <<'EOF'
 #!/usr/bin/env bash
 echo "HTTP 500: boom" >&2
@@ -151,7 +239,8 @@ out=$(bash "$CHECK" 2>&1)
 code=$?
 set -e
 if [ "$code" -ne 0 ] && echo "$out" | grep -q 'gh api failed' \
-  && echo "$out" | grep -q 'transient errors exhausted'; then
+  && echo "$out" | grep -q 'transient errors exhausted' \
+  && assert_outputs "gh-api-error-transient-exhausted" "null" "api_error" "failed (gh api error)"; then
   echo "PASS: gh-api-error-transient-exhausted (exit $code)"
   pass=$((pass + 1))
 else
@@ -160,7 +249,6 @@ else
   fail=$((fail + 1))
 fi
 
-# Permanent 401 fails immediately (no "retrying in" / exhausted wording)
 cat >"$tmpdir/gh" <<'EOF'
 #!/usr/bin/env bash
 echo "HTTP 401: Bad credentials" >&2
@@ -175,7 +263,8 @@ out=$(bash "$CHECK" 2>&1)
 code=$?
 set -e
 if [ "$code" -ne 0 ] && echo "$out" | grep -q 'permanent error' \
-  && ! echo "$out" | grep -q 'retrying in'; then
+  && ! echo "$out" | grep -q 'retrying in' \
+  && assert_outputs "gh-api-error-permanent-no-retry" "null" "api_error" "failed (gh api error)"; then
   echo "PASS: gh-api-error-permanent-no-retry (exit $code)"
   pass=$((pass + 1))
 else
@@ -184,10 +273,34 @@ else
   fail=$((fail + 1))
 fi
 
+# Unknown-shape API error: fail closed without retry (#217 / #215 follow-up)
+cat >"$tmpdir/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "HTTP 400: Bad Request" >&2
+exit 1
+EOF
+chmod +x "$tmpdir/gh"
+export API_MAX_RETRIES=3 SLEEP_SECONDS=0
+: >"$GITHUB_OUTPUT"
+: >"$GITHUB_STEP_SUMMARY"
+set +e
+out=$(bash "$CHECK" 2>&1)
+code=$?
+set -e
+if [ "$code" -ne 0 ] && echo "$out" | grep -q 'cannot evaluate mergeability' \
+  && ! echo "$out" | grep -q 'retrying in' \
+  && assert_outputs "gh-api-error-unknown-shape" "null" "api_error" "failed (gh api error)"; then
+  echo "PASS: gh-api-error-unknown-shape (exit $code)"
+  pass=$((pass + 1))
+else
+  echo "FAIL: gh-api-error-unknown-shape"
+  indent_out "$out"
+  fail=$((fail + 1))
+fi
+
 # Flaky then success: first call 503, second returns true\tclean (#217)
 cat >"$tmpdir/gh" <<'EOF'
 #!/usr/bin/env bash
-# First invocation fails transiently; subsequent read mergeable\tmstate lines.
 counter_file="${MOCK_API_COUNTER:?}"
 n=$(cat "$counter_file" 2>/dev/null || echo 0)
 n=$((n + 1))
@@ -217,7 +330,8 @@ set +e
 out=$(bash "$CHECK" 2>&1)
 code=$?
 set -e
-if [ "$code" -eq 0 ] && echo "$out" | grep -q 'Transient gh api error'; then
+if [ "$code" -eq 0 ] && echo "$out" | grep -q 'Transient gh api error' \
+  && assert_outputs "gh-api-flaky-then-success" "true" "clean" "ok (mergeable=true)"; then
   echo "PASS: gh-api-flaky-then-success (exit $code)"
   pass=$((pass + 1))
 else
@@ -226,7 +340,7 @@ else
   fail=$((fail + 1))
 fi
 
-# Secondary rate limit is HTTP 403-shaped but must retry (#217 follow-up)
+# Secondary rate limit is HTTP 403-shaped but must retry (#217)
 cat >"$tmpdir/gh" <<'EOF'
 #!/usr/bin/env bash
 counter_file="${MOCK_API_COUNTER:?}"
@@ -257,7 +371,8 @@ set +e
 out=$(bash "$CHECK" 2>&1)
 code=$?
 set -e
-if [ "$code" -eq 0 ] && echo "$out" | grep -q 'Transient gh api error'; then
+if [ "$code" -eq 0 ] && echo "$out" | grep -q 'Transient gh api error' \
+  && assert_outputs "gh-api-secondary-rate-limit-then-success" "true" "clean" "ok (mergeable=true)"; then
   echo "PASS: gh-api-secondary-rate-limit-then-success (exit $code)"
   pass=$((pass + 1))
 else
@@ -266,8 +381,15 @@ else
   fail=$((fail + 1))
 fi
 unset MOCK_API_COUNTER
-export API_MAX_RETRIES=3
+export API_MAX_RETRIES=3 MAX_ATTEMPTS=3
 
 echo ""
-echo "Results: $pass passed, $fail failed"
-[ "$fail" -eq 0 ]
+echo "Results: $pass passed, $fail failed (expected $EXPECTED_PASS pass)"
+if [ "$fail" -ne 0 ]; then
+  exit 1
+fi
+if [ "$pass" -ne "$EXPECTED_PASS" ]; then
+  echo "FAIL: pass count $pass != EXPECTED_PASS $EXPECTED_PASS (silent case drop or extra case?)"
+  exit 1
+fi
+echo "PASS: expected-pass-count ($EXPECTED_PASS)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **CI: harden check-pr-mergeable mock matrix** (#215). Matrix asserts `GITHUB_OUTPUT` / step summary on success and key failure paths; adds `true\tunknown` exhausted, `true\tdirty` short-circuit, invalid `SLEEP_SECONDS` / `API_MAX_RETRIES`, unknown-shape API errors; locks expected PASS count so silent case drops fail CI.
 - **CI: retry transient gh api failures in check-pr-mergeable** (#217). Bounded `api-max-retries` (default 3) with linear backoff for HTTP 408/425/429/5xx and transport blips; permanent 401/403/404/410/422 fail immediately. Does not change the `mergeable=true` success criteria. Mock matrix covers flaky-then-success and permanent no-retry.
 - **CI: explicit mergeable extraction (no `@tsv` null→empty)** (#216). `check-pr-mergeable` now extracts REST `.mergeable` with `jq tostring` so JSON `null` is the literal token `null` in logs, outputs, and mocks (bare `@tsv` encoded null as an empty field). Fail-closed contract unchanged: green only when `mergeable=true`.
 - **CI: document Guard base-pin lag for mergeability contract** (#218). Guard-Main-Origin overlays `.github/actions/check-pr-mergeable` from `origin/<base>` when present; contract tightenings therefore apply to Guard only after they land on the PR base (usually `main`), while Release-PR on `dev` picks them up immediately. Documented in `docs/contributing/releasing.md` and `action.yml` so operators can explain Guard vs Release-PR mismatches after a `dev`-only contract change.


### PR DESCRIPTION
## Summary

Closes #215. Stacked on the #217 branch (and #219 for #216).

- Assert `GITHUB_OUTPUT` / step summary on success and key failure paths
- Edge cases: `true\tunknown` exhausted retries, `true\tdirty` short-circuit, invalid `SLEEP_SECONDS` / `API_MAX_RETRIES`
- Expected PASS count lock so silent case drops fail CI

## Out of scope

- Changing mergeability contract
- Live GitHub API integration tests

## Test plan

- [x] `bash .github/actions/check-pr-mergeable/test-check.sh` → 22 passed + expected-pass-count
- [ ] CI `actions-shell` green after stack base merges
- [ ] Retarget base to `dev` after #221 merges

Closes #215

Depends on PR for #217