### PR TITLE
fix(ci): shared mergeable.jq + primary rate-limit retry (#223)

### DIFF
--- a/.github/actions/check-pr-mergeable/action.yml
+++ b/.github/actions/check-pr-mergeable/action.yml
@@ -3,12 +3,11 @@
 #
 # Contract (do not weaken):
 # - Poll REST mergeable / mergeable_state via gh api
-# - Extract with jq tostring so JSON null mergeable is the literal token
-#   "null" (not an empty @tsv field); null mergeable_state maps to
-#   "unknown" (unresolved retry path) — operators/mocks match production (#216)
+# - Extract via shared mergeable.jq (#223): JSON null mergeable → literal
+#   "null"; null mergeable_state → "unknown" (unresolved retry path) (#216)
 # - Retry while mergeable_state is unknown (GitHub computes async)
-# - Retry only transient gh api failures (5xx / 429 / transport / secondary
-#   rate-limit 403); fail immediately on permanent 401/403/404/… (#217).
+# - Retry only transient gh api failures (5xx / 429 / transport / primary+
+#   secondary rate-limit 403); fail immediately on permanent 401/403/404/… (#217, #223).
 #   Exhausting api-max-retries aborts the whole step (does not spend further
 #   max-attempts). Does not change the mergeable=true success criteria.
 # - Fail on dirty, mergeable=false, null/empty mergeable (JSON null), or

--- a/.github/actions/check-pr-mergeable/check.sh
+++ b/.github/actions/check-pr-mergeable/check.sh
@@ -6,16 +6,25 @@
 #   GH_TOKEN, PR_NUMBER, REPO
 # Optional env:
 #   MAX_ATTEMPTS (default 6), SLEEP_SECONDS (default 5)
-#   API_MAX_RETRIES (default 3) — bounded retries for transient gh api failures
+#   API_MAX_RETRIES (default 3) — max gh api attempts per poll for transient failures
 #   CONFLICT_GUIDANCE — extra operator lines on dirty (workflow-specific)
 #   GITHUB_OUTPUT, GITHUB_STEP_SUMMARY (set by Actions)
 set -euo pipefail
+
+ACTION_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Single shared jq program used by check.sh and the mock matrix (#223).
+MERGEABLE_JQ="${ACTION_DIR}/mergeable.jq"
+if [ ! -f "$MERGEABLE_JQ" ]; then
+  echo "::error::missing shared jq extraction program: ${MERGEABLE_JQ}"
+  exit 1
+fi
+MERGEABLE_JQ_PROG="$(cat "$MERGEABLE_JQ")"
 
 PR_NUMBER="${PR_NUMBER:?PR_NUMBER is required}"
 REPO="${REPO:?REPO is required}"
 MAX_ATTEMPTS="${MAX_ATTEMPTS:-6}"
 SLEEP_SECONDS="${SLEEP_SECONDS:-5}"
-API_MAX_RETRIES="${API_MAX_RETRIES:-3}"
+API_MAX_RETRIES="${API_MAX_RETRIES:-3}"  # max gh api attempts per poll (not "retries after first")
 CONFLICT_GUIDANCE="${CONFLICT_GUIDANCE:-}"
 
 if ! [[ "$MAX_ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
@@ -64,10 +73,20 @@ write_summary() {
 #
 # Exhausting API_MAX_RETRIES aborts the whole step (does not consume further
 # MAX_ATTEMPTS unknown-poll budget) — fail closed when we cannot talk to the API.
+is_rate_limit_gh_error() {
+  local err="$1"
+  # Primary + secondary rate limits (often HTTP 403 with rate-limit wording).
+  # Real authz 403s do not include these phrases and stay permanent (#223).
+  if echo "$err" | grep -Eqi \
+    'secondary rate limit|exceeded a secondary rate|API rate limit exceeded|rate limit exceeded|x-ratelimit-remaining'; then
+    return 0
+  fi
+  return 1
+}
+
 is_transient_gh_error() {
   local err="$1"
-  # Secondary rate limits often surface as HTTP 403 with this wording (#217).
-  if echo "$err" | grep -Eqi 'secondary rate limit|exceeded a secondary rate'; then
+  if is_rate_limit_gh_error "$err"; then
     return 0
   fi
   # gh prints "HTTP NNN:" for API status errors; match common transient codes.
@@ -84,8 +103,8 @@ is_transient_gh_error() {
 
 is_permanent_gh_error() {
   local err="$1"
-  # Secondary rate limit is 403-shaped but transient — not permanent.
-  if echo "$err" | grep -Eqi 'secondary rate limit|exceeded a secondary rate'; then
+  # Rate limits are 403-shaped but transient — not permanent (#217 / #223).
+  if is_rate_limit_gh_error "$err"; then
     return 1
   fi
   if echo "$err" | grep -Eqi 'HTTP[[:space:]]+(401|403|404|410|422)\b'; then
@@ -107,7 +126,7 @@ fetch_state() {
     # (fail closed). A literal "null" token would otherwise hit *) and could go
     # green when mergeable=true (#216 follow-up).
     if STATE=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" \
-      --jq '[(.mergeable | tostring), ((.mergeable_state // "unknown") | tostring)] | @tsv' \
+      --jq "$MERGEABLE_JQ_PROG" \
       2>"$gh_err_file"); then
       rm -f "$gh_err_file"
       return 0

--- a/.github/actions/check-pr-mergeable/mergeable.jq
+++ b/.github/actions/check-pr-mergeable/mergeable.jq
@@ -1,0 +1,7 @@
+# Shared REST → TSV extraction for check-pr-mergeable (#216 / #223).
+# Input: GitHub pull object (or mock JSON with mergeable + mergeable_state).
+# Output: single TSV line: mergeable\tmergeable_state
+#
+# - JSON null mergeable → literal token "null" (not empty @tsv field)
+# - null mergeable_state → "unknown" (unresolved retry path; fail closed)
+[(.mergeable | tostring), ((.mergeable_state // "unknown") | tostring)] | @tsv

--- a/.github/actions/check-pr-mergeable/test-check.sh
+++ b/.github/actions/check-pr-mergeable/test-check.sh
@@ -13,7 +13,7 @@ tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
 
 # Bump when adding/removing PASS lines so a silent case drop fails CI (#215).
-EXPECTED_PASS=24
+EXPECTED_PASS=26
 
 install_mock_gh() {
   cat >"$tmpdir/gh" <<'EOF'
@@ -146,22 +146,30 @@ EXPECT_MERGEABLE=true EXPECT_MSTATE=dirty EXPECT_SUMMARY='failed (dirty)' \
 EXPECT_MERGEABLE=true EXPECT_MSTATE=null EXPECT_SUMMARY='failed (unknown after retries)' \
   run_case "true-null-state-exhausts" 1 $'true\tnull' $'true\tnull' $'true\tnull'
 
-# --- jq encoding locks (#216) ---
-jq_prod=$(jq -rn '([(null | tostring), ((null // "unknown") | tostring)] | @tsv)')
-if [ "$jq_prod" = $'null\tunknown' ]; then
-  echo "PASS: jq-tostring-prod-extraction (null mergeable + null state→unknown)"
-  pass=$((pass + 1))
-else
-  printf 'FAIL: jq-tostring-prod-extraction expected null\\tunknown got %q\n' "$jq_prod"
+# --- jq encoding locks via shared mergeable.jq (#216 / #223) ---
+JQ_PROG_FILE="${ROOT}/mergeable.jq"
+if [ ! -f "$JQ_PROG_FILE" ]; then
+  echo "FAIL: missing shared mergeable.jq"
   fail=$((fail + 1))
-fi
-jq_tsv_true=$(jq -rn '([(true | tostring), (("clean" // "unknown") | tostring)] | @tsv)')
-if [ "$jq_tsv_true" = $'true\tclean' ]; then
-  echo "PASS: jq-tostring-true-field"
-  pass=$((pass + 1))
 else
-  printf 'FAIL: jq-tostring-true-field expected true\\tclean got %q\n' "$jq_tsv_true"
-  fail=$((fail + 1))
+  jq_prod=$(jq -rn --argjson o '{"mergeable":null,"mergeable_state":null}' '$o | input' 2>/dev/null || true)
+  # Apply production program to a JSON object (same path check.sh uses via --jq)
+  jq_prod=$(printf '%s\n' '{"mergeable":null,"mergeable_state":null}' | jq -rf "$JQ_PROG_FILE")
+  if [ "$jq_prod" = $'null\tunknown' ]; then
+    echo "PASS: shared-jq-null-state (mergeable.jq null→null/unknown)"
+    pass=$((pass + 1))
+  else
+    printf 'FAIL: shared-jq-null-state expected null\\tunknown got %q\n' "$jq_prod"
+    fail=$((fail + 1))
+  fi
+  jq_tsv_true=$(printf '%s\n' '{"mergeable":true,"mergeable_state":"clean"}' | jq -rf "$JQ_PROG_FILE")
+  if [ "$jq_tsv_true" = $'true\tclean' ]; then
+    echo "PASS: shared-jq-true-clean (mergeable.jq)"
+    pass=$((pass + 1))
+  else
+    printf 'FAIL: shared-jq-true-clean expected true\\tclean got %q\n' "$jq_tsv_true"
+    fail=$((fail + 1))
+  fi
 fi
 
 # --- input validation (before gh) ---
@@ -382,6 +390,87 @@ else
 fi
 unset MOCK_API_COUNTER
 export API_MAX_RETRIES=3 MAX_ATTEMPTS=3
+
+# Primary REST rate-limit 403 is transient (#223)
+cat >"$tmpdir/gh" <<'EOF'
+#!/usr/bin/env bash
+counter_file="${MOCK_API_COUNTER:?}"
+n=$(cat "$counter_file" 2>/dev/null || echo 0)
+n=$((n + 1))
+echo "$n" >"$counter_file"
+if [ "$n" -eq 1 ]; then
+  echo "HTTP 403: API rate limit exceeded" >&2
+  exit 1
+fi
+state_file="${MOCK_STATE_FILE:?}"
+if [ ! -s "$state_file" ]; then
+  echo "mock gh: state file empty" >&2
+  exit 1
+fi
+line=$(head -n1 "$state_file")
+tail -n +2 "$state_file" >"${state_file}.tmp"
+mv "${state_file}.tmp" "$state_file"
+printf '%s\n' "$line"
+EOF
+chmod +x "$tmpdir/gh"
+export MOCK_API_COUNTER="$tmpdir/api_counter"
+echo 0 >"$MOCK_API_COUNTER"
+printf '%s\n' $'true\tclean' >"$MOCK_STATE_FILE"
+export MAX_ATTEMPTS=2 API_MAX_RETRIES=3 SLEEP_SECONDS=0
+: >"$GITHUB_OUTPUT"
+: >"$GITHUB_STEP_SUMMARY"
+set +e
+out=$(bash "$CHECK" 2>&1)
+code=$?
+set -e
+if [ "$code" -eq 0 ] && echo "$out" | grep -q 'Transient gh api error' \
+  && assert_outputs "gh-api-primary-rate-limit-then-success" "true" "clean" "ok (mergeable=true)"; then
+  echo "PASS: gh-api-primary-rate-limit-then-success (exit $code)"
+  pass=$((pass + 1))
+else
+  echo "FAIL: gh-api-primary-rate-limit-then-success"
+  indent_out "$out"
+  fail=$((fail + 1))
+fi
+unset MOCK_API_COUNTER
+
+# End-to-end: mock returns JSON; production mergeable.jq produces TSV (#223)
+cat >"$tmpdir/gh" <<EOF
+#!/usr/bin/env bash
+# Rotate JSON lines from MOCK_STATE_FILE, pipe through production mergeable.jq.
+state_file="\${MOCK_STATE_FILE:?}"
+if [ ! -s "\$state_file" ]; then
+  echo "mock gh: state file empty" >&2
+  exit 1
+fi
+line=\$(head -n1 "\$state_file")
+tail -n +2 "\$state_file" >"\${state_file}.tmp"
+mv "\${state_file}.tmp" "\$state_file"
+printf '%s\n' "\$line" | jq -rf "${ROOT}/mergeable.jq"
+EOF
+chmod +x "$tmpdir/gh"
+# JSON null mergeable + null state → null\tunknown → exhaust (MAX_ATTEMPTS=1)
+printf '%s\n' '{"mergeable":null,"mergeable_state":null}' >"$MOCK_STATE_FILE"
+export MAX_ATTEMPTS=1 API_MAX_RETRIES=1 SLEEP_SECONDS=0
+: >"$GITHUB_OUTPUT"
+: >"$GITHUB_STEP_SUMMARY"
+set +e
+out=$(bash "$CHECK" 2>&1)
+code=$?
+set -e
+if [ "$code" -ne 0 ] \
+  && assert_outputs "json-mock-null-state-exhausts" "null" "unknown" "failed (unknown after retries)"; then
+  echo "PASS: json-mock-null-state-exhausts (production jq path)"
+  pass=$((pass + 1))
+else
+  echo "FAIL: json-mock-null-state-exhausts"
+  indent_out "$out"
+  fail=$((fail + 1))
+fi
+
+# Restore TSV mock for any later local runs
+install_mock_gh
+export MAX_ATTEMPTS=3 API_MAX_RETRIES=3
 
 echo ""
 echo "Results: $pass passed, $fail failed (expected $EXPECTED_PASS pass)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **CI: shared mergeable.jq + primary rate-limit retry** (#223). check-pr-mergeable loads extraction from `mergeable.jq` (single fixture for production and mocks); primary REST rate-limit 403 retries like secondary; mock matrix exercises the production jq path end-to-end.
 - **CI: harden check-pr-mergeable mock matrix** (#215). Matrix asserts `GITHUB_OUTPUT` / step summary on success and key failure paths; adds `true\tunknown` exhausted, `true\tdirty` short-circuit, invalid `SLEEP_SECONDS` / `API_MAX_RETRIES`, unknown-shape API errors; locks expected PASS count so silent case drops fail CI.
 - **CI: retry transient gh api failures in check-pr-mergeable** (#217). Bounded `api-max-retries` (default 3) with linear backoff for HTTP 408/425/429/5xx and transport blips; permanent 401/403/404/410/422 fail immediately. Secondary rate-limit 403 is retried. Does not change the `mergeable=true` success criteria.
 - **CI: explicit mergeable extraction (no `@tsv` null→empty)** (#216). `check-pr-mergeable` now extracts REST `.mergeable` with `jq tostring` so JSON `null` is the literal token `null` in logs, outputs, and mocks (bare `@tsv` encoded null as an empty field). Fail-closed contract unchanged: green only when `mergeable=true`.


### PR DESCRIPTION
## Summary

Closes #223 (follow-ups from the #219–#222 stack).

### Done here
1. **Shared `mergeable.jq`** — one extraction program for production `check.sh` and the mock matrix encoding locks
2. **JSON mock path** — mock returns JSON and pipes through production jq end-to-end
3. **Primary rate-limit 403 is transient** — same carve-out as secondary; real authz 403 stays permanent
4. **Naming note** — `API_MAX_RETRIES` documents max *attempts* per poll

### Deferred (documented in issue, not blocking)
- Longer / `Retry-After` aware backoff for secondary limits
- Allowlist of resolved success states (`clean|unstable|blocked` only)

## Test plan

- [x] `bash .github/actions/check-pr-mergeable/test-check.sh` → 26 passed + expected-pass-count
- [ ] CI green

Closes #223