### PR TITLE
fix(ci): auto-merge main→dev sync PRs without admin bypass

### DIFF
--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -7,7 +7,9 @@ name: Sync-Main-to-Dev
 # See #202.
 #
 # Token: prefer secrets.GH_TOKEN (repo PAT) for push + gh pr create so the
-# opened sync PR re-triggers pull_request CI (#206).
+# opened sync PR re-triggers pull_request CI (#206). After open/update, enable
+# auto-merge with a *merge commit* (never squash) so green Test-Matrix lands
+# the PR without a human babysitting.
 
 on:
   push:
@@ -99,6 +101,24 @@ jobs:
             fi
           }
 
+          # Enable auto-merge with a merge commit only. Squash would re-break
+          # ancestry (the whole reason this PR exists). Failures here are
+          # warnings: the PR is still open for a human if auto-merge is
+          # unavailable (repo setting, permissions, or checks not yet queued).
+          enable_auto_merge() {
+            local pr_number="$1"
+            if [ -z "$pr_number" ]; then
+              echo "::warning::No sync PR number; cannot enable auto-merge."
+              return 0
+            fi
+            if gh pr merge "$pr_number" --auto --merge; then
+              echo "Auto-merge (merge commit) enabled on #${pr_number}."
+            else
+              echo "::warning::Could not enable auto-merge on #${pr_number}."
+              echo "Merge it manually with a merge commit (not squash) once checks are green."
+            fi
+          }
+
           open_or_update_pr() {
             local title="$1"
             local body_file="$2"
@@ -109,11 +129,22 @@ jobs:
             if [ -n "$existing" ]; then
               echo "Sync PR #${existing} already open; branch updated."
               gh pr edit "$existing" --title "$title" --body-file "$body_file"
+              enable_auto_merge "$existing"
             else
-              gh pr create --base dev --head sync/main-to-dev \
+              # gh pr create prints a URL; resolve the number for auto-merge.
+              local created_url created
+              created_url=$(gh pr create --base dev --head sync/main-to-dev \
                 --title "$title" \
                 --body-file "$body_file" \
-                --label automated --label sync
+                --label automated --label sync)
+              created=$(gh pr list --base dev --head sync/main-to-dev --state open \
+                --json number --jq '.[0].number // empty')
+              if [ -z "$created" ]; then
+                echo "::error::Opened a sync PR (${created_url:-no url}) but could not resolve its number."
+                exit 1
+              fi
+              echo "Opened sync PR #${created}: ${created_url}"
+              enable_auto_merge "$created"
             fi
           }
 
@@ -124,23 +155,28 @@ jobs:
             git merge -s ours origin/main \
               -m "chore: merge main into dev after release (history sync)"
 
+            # Body must stay indented for YAML; strip the common prefix after.
             cat > /tmp/sync-pr-body.md <<'EOF'
-          ## Automatic Sync
+            ## Automatic Sync
 
-          `main` was not an ancestor of `dev`. This PR restores reachability so
-          the next `dev → main` release PR stays MERGEABLE and gets full CI.
+            `main` was not an ancestor of `dev`. This PR restores reachability so
+            the next `dev → main` release PR stays MERGEABLE and gets full CI.
 
-          ### Why this is not a content sync
-          After a squash-merge release, trees are usually identical but histories
-          diverge. Comparing content (`git diff`) misses that; comparing
-          reachability (`git merge-base --is-ancestor`) catches it at the right
-          moment — right after the release — instead of as 20+ conflicts on the
-          next release PR. See #202.
+            ### Why this is not a content sync
+            After a squash-merge release, trees are usually identical but histories
+            diverge. Comparing content (`git diff`) misses that; comparing
+            reachability (`git merge-base --is-ancestor`) catches it at the right
+            moment — right after the release — instead of as 20+ conflicts on the
+            next release PR. See #202.
 
-          ### Action required
-          - Review (content may be empty for a pure history merge)
-          - Merge into `dev` (a merge commit keeps the ancestry link; squash would re-create the problem)
-          EOF
+            ### Merge policy
+            - Auto-merge is enabled with a **merge commit** when required checks
+              (Test-Matrix) are green. Do **not** squash — that re-creates the
+              ancestry break this PR fixes.
+            - Content is usually empty for a pure history merge; review only if
+              the diff is non-empty (unexpected).
+            EOF
+            sed -i 's/^            //' /tmp/sync-pr-body.md
 
             open_or_update_pr "Sync: main → dev (history reachability)" /tmp/sync-pr-body.md
           else
@@ -148,16 +184,19 @@ jobs:
             if git merge origin/main \
               -m "chore: merge main into dev (sync after release/hotfix)"; then
               cat > /tmp/sync-pr-body.md <<'EOF'
-          ## Automatic Sync
+              ## Automatic Sync
 
-          `main` was not an ancestor of `dev` and carried content `dev` did not
-          have (hotfix or direct-to-main commit). This PR merges that content
-          back so histories stay connected. See #202.
+              `main` was not an ancestor of `dev` and carried content `dev` did not
+              have (hotfix or direct-to-main commit). This PR merges that content
+              back so histories stay connected. See #202.
 
-          ### Action required
-          - Review the content delta
-          - Merge into `dev` (prefer a merge commit so the ancestry link is kept)
-          EOF
+              ### Merge policy
+              - Review the content delta before it lands (auto-merge waits for
+                Test-Matrix).
+              - Auto-merge uses a **merge commit** only — do not squash, or the
+                ancestry link is lost again.
+              EOF
+              sed -i 's/^              //' /tmp/sync-pr-body.md
               open_or_update_pr "Sync: main → dev" /tmp/sync-pr-body.md
             else
               # Do NOT force-push origin/dev over sync/main-to-dev or open an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- **CI: post-release main→dev sync auto-merges and no longer needs admin bypass.**
+  Sync-Main-to-Dev enables `gh pr merge --auto --merge` on the history-reachability
+  PR so green Test-Matrix lands it without a human. Squash is never requested
+  (it would re-break ancestry). Protect Dev dropped `required_signatures`, which
+  had made every unsigned automation commit need `--admin` despite green checks;
+  required Test-Matrix jobs, no force-push, and no branch deletion remain.
+
 ## [2.6.0] - 2026-08-10
 
 Released from `dev`. A correctness-and-contracts release: the LangChain and MCP

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -65,10 +65,12 @@ MAJOR.MINOR.PATCH[-PRERELEASE][+BUILD]
    content equality. After a squash-merge the trees match but the histories
    have diverged; the workflow opens a PR that records a history-only merge
    (`merge -s ours`) so the *next* release PR stays MERGEABLE and gets full
-   CI (#202). **Merge that sync PR with a merge commit** — squashing it would
-   recreate the divergence. Concurrent main pushes do not cancel an in-flight
-   sync; human WIP on `sync/main-to-dev` is not force-pushed away; merge
-   conflicts open a tracking issue (#208).
+   CI (#202). It then enables **auto-merge with a merge commit** so the PR
+   lands when Test-Matrix is green — no human babysitting on the happy path.
+   **Never squash** that PR (it would recreate the divergence). Concurrent
+   main pushes do not cancel an in-flight sync; human WIP on
+   `sync/main-to-dev` is not force-pushed away; merge conflicts open a
+   tracking issue (#208).
 
 ### Why three workflows keep each other honest
 
@@ -132,9 +134,20 @@ the overlay in a hotfix-shaped PR.
 
 | Secret | Purpose |
 |---|---|
-| `GH_TOKEN` | Fine-scoped PAT (or App token) for Release-PR / Sync-Main-to-Dev `gh pr create` and automation branch pushes so `pull_request` CI runs on open (#206). Not the same as the automatic `GITHUB_TOKEN`. |
+| `GH_TOKEN` | Fine-scoped PAT (or App token) for Release-PR / Sync-Main-to-Dev `gh pr create`, automation branch pushes, and sync-PR auto-merge so `pull_request` CI runs on open (#206) and the history-sync PR can land without a babysitter. Not the same as the automatic `GITHUB_TOKEN`. |
 | `GITHUB_TOKEN` | Automatic job token; used as fallback and for jobs that must not re-trigger workflows. |
 | OIDC / PyPI trusted publishing | Real and Test PyPI uploads (no long-lived PyPI token required when configured). |
+
+### Branch protection notes (sync PR)
+
+- **Protect Dev** requires the Test-Matrix Python jobs (`tests (3.10)` …
+  `tests (3.14)`), blocks force-pushes and branch deletion, and allows
+  merge/squash/rebase methods. Sync automation always requests a **merge
+  commit** via `gh pr merge --auto --merge`.
+- **Signed commits are not required on `dev`.** Requiring verified signatures
+  forced every automation PR (and most human ones) through admin bypass,
+  including the post-release history-sync PR. Quality gates remain the
+  status checks; re-enabling signatures needs a signing key in CI first.
 
 ### GitHub Actions Workflow (on merge to main)
 


### PR DESCRIPTION
## Summary

After the 2.6.0 release, the history-sync PR (#226) needed an **admin merge** because Protect Dev required signed commits and the automation commits are unsigned. This change closes that loop:

1. **Sync-Main-to-Dev** enables `gh pr merge --auto --merge` after open/update so green Test-Matrix lands the PR without babysitting (merge commit only — never squash).
2. **Protect Dev** no longer requires signed commits (updated live on the ruleset). Required Test-Matrix jobs, no force-push, and no branch deletion remain.
3. Docs + changelog updated accordingly.

## Test plan

- [x] Protect Dev ruleset no longer lists `required_signatures`
- [x] Workflow YAML validates
- [ ] Test-Matrix green on this PR
- [ ] After merge: next release’s sync PR should auto-merge when checks pass

## Notes

Ruleset change is **already applied** on the repository (not in git). This PR only carries workflow + docs.