### PR TITLE
feat(client): absorb FMP changelog diluted PE, screener page, senateID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,8 @@ None. No FMP path we ship was newly retired by this changelog window.
   - **`CompanyRating` score columns.** `rating-bulk` headers
     `discountedCashFlowScore` / `returnOnEquityScore` / `returnOnAssetsScore`
     / `debtToEquityScore` / `priceToEarningsScore` / `priceToBookScore` are
-    now typed attributes.
+    now typed attributes. Fractional CSV cells such as ``"3.0"`` coerce to
+    ``int`` so ``parse_csv_models`` does not skip the whole company row.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### FMP API surface (scan this first)
+
+Source: FMP public changelog
+([docs/changelog](https://site.financialmodelingprep.com/developer/docs/changelog))
+plus a live `/stable` probe on 2026-08-12. Marketing-only items (dashboard,
+localization, Insights Hub, plan add-ons) and FMP's hosted MCP product are
+out of scope.
+
+#### New (now first-class in this client)
+
+| Surface | What you get | Wire key / param | Client |
+|---|---|---|---|
+| Financial ratios | Diluted P/E | `priceToEarningsDilutedRatio` | `FinancialRatios.price_to_earnings_diluted_ratio` |
+| Financial ratios | Diluted PEG | `priceToEarningsDilutedGrowthRatio` | `FinancialRatios.price_to_earnings_diluted_growth_ratio` |
+| Ratios TTM (+ `ratios-ttm-bulk`) | Diluted P/E TTM | `priceToEarningsDilutedRatioTTM` | `FinancialRatiosTTM.price_to_earnings_diluted_ratio_ttm` |
+| Ratios TTM (+ `ratios-ttm-bulk`) | Diluted PEG TTM | `priceToEarningsDilutedGrowthRatioTTM` | `FinancialRatiosTTM.price_to_earnings_diluted_growth_ratio_ttm` |
+| Company screener | Pagination | `page` (optional, omitted when unset) | `market.get_company_screener(..., page=None)` |
+| Senate / House trades | Entity id | `senateID` (same key on House rows) | `SenateTrade.senate_id` / `HouseDisclosure.senate_id` |
+| Ratings bulk | Score columns | `discountedCashFlowScore`, `returnOnEquityScore`, `returnOnAssetsScore`, `debtToEquityScore`, `priceToEarningsScore`, `priceToBookScore` | `CompanyRating.*_score` |
+
+#### Updated (path or contract still matches; no caller change)
+
+| FMP note | Path probed | Result |
+|---|---|---|
+| Delisted companies architecture (2025-10) | `/stable/delisted-companies` | 200. Slim row `{symbol, companyName, exchange, ipoDate, delistedDate}`. Path unchanged. No Python client method — the endpoint declaration still uses `CompanyProfile`, which is the wrong shape (pre-existing; not wired). |
+| Exchange directory taxonomy (2025-06) | `/stable/available-exchanges` | 200. Keys `exchange`, `name`, `countryName`, `countryCode`, `delay`, `symbolSuffix` — already on `ExchangeSymbol`. |
+| Exchange variants (2025-05/06) | `/stable/search-exchange-variants?query=Apple` | 200. Profile-shaped rows still parse as `CompanySearchResult`. |
+| DCF valuations bulk naming (2025-06) | `/stable/dcf-bulk` | 200. Headers `symbol,date,dcf,Stock Price`. Client still remaps `Stock Price` → `stockPrice`. |
+| Historical S&P 500 symbol naming (2025-06) | `/stable/historical-sp500-constituent` | 200. `symbol` present; `HistoricalIndexConstituent` still parses. |
+| Stock ratings bulk field standardization (2025-06) | `/stable/rating-bulk` | 200. Score columns now typed on `CompanyRating` (see New). |
+| CUSIP on fund disclosure holders (2025-10) | `/stable/funds/disclosure-holders-latest` | Only `securityCusip`. Already modeled; no second key. |
+| ETF `isActivelyTrading` (2025-12) | `/stable/etf/info` | Present. Already modeled. |
+| Splits calendar `splitType` (2025-11) | `/stable/splits-calendar` | Present (may be `null`). Already modeled. |
+| Earnings `includeReportTimes` (2026-06) | `/stable/earnings-calendar?includeReportTimes=true` | Extra fields `confirmed`, `fiscalPeriod`, `fiscalYear`, `periodEnding`, `time`, `lastUpdated` already modeled. |
+| Profile bulk `part=0..3` (2024-10) | `/stable/profile-bulk?part=0` | 200. Multi-part scheme unchanged. |
+| Legacy route auth-gate (2025-08) | `/api/v3/profile/AAPL` | 403. No remaining live client path uses `APIVersion.V3`. The one leftover `V4` declaration is the already-withdrawn `stock-news-sentiments`. |
+
+#### Deprecated / withdrawn in this pass
+
+None. No FMP path we ship was newly retired by this changelog window.
+
+### Added
+
+- **FMP changelog alignment (#229).** Three confirmed 2026 wire gaps plus the
+  older-note re-probe above. Live `/stable` checks used the current API key
+  on 2026-08-12.
+
+  - **Diluted P/E on ratios.** `FinancialRatios` and `FinancialRatiosTTM` now
+    declare the diluted PE / diluted PEG pair FMP added on 2026-07-30
+    (`priceToEarningsDilutedRatio`, `priceToEarningsDilutedGrowthRatio`, and
+    the `*TTM` names on TTM + `ratios-ttm-bulk`). They previously landed only
+    in `__pydantic_extra__` and could warn under `FMP_VALIDATION_MODE=warn`.
+  - **Screener `page`.** `market.get_company_screener` / async accept optional
+    `page: int | None = None`. Unset is omitted from the request (existing
+    callers keep the same wire). `page=0` is sent. Live: `limit=2&page=0`
+    and `limit=2&page=1` return distinct first rows.
+  - **`senateID` on Senate and House trades.** `SenateTrade.senate_id` and
+    `HouseDisclosure.senate_id` alias `senateID`. The wire name is kept on
+    House rows (Pelosi → `P000197`); we do not invent `house_id`.
+  - **`CompanyRating` score columns.** `rating-bulk` headers
+    `discountedCashFlowScore` / `returnOnEquityScore` / `returnOnAssetsScore`
+    / `debtToEquityScore` / `priceToEarningsScore` / `priceToBookScore` are
+    now typed attributes.
+
 ### Fixed
 
 - **CI: post-release main→dev sync auto-merges and no longer needs admin bypass.**

--- a/fmp_data/fundamental/models.py
+++ b/fmp_data/fundamental/models.py
@@ -1099,10 +1099,20 @@ class FinancialRatios(BaseModel):
         alias="priceToEarningsRatio",
         description="Price to earnings ratio",
     )
+    price_to_earnings_diluted_ratio: float | None = Field(
+        default=None,
+        alias="priceToEarningsDilutedRatio",
+        description="Price to diluted earnings ratio",
+    )
     price_to_earnings_growth_ratio: float | None = Field(
         default=None,
         alias="priceToEarningsGrowthRatio",
         description="Price to earnings growth ratio (PEG)",
+    )
+    price_to_earnings_diluted_growth_ratio: float | None = Field(
+        default=None,
+        alias="priceToEarningsDilutedGrowthRatio",
+        description="Price to diluted earnings growth ratio (diluted PEG)",
     )
     forward_price_to_earnings_growth_ratio: float | None = Field(
         default=None,
@@ -1365,10 +1375,20 @@ class FinancialRatiosTTM(BaseModel):
         alias="priceToEarningsRatioTTM",
         description="Price to earnings ratio TTM",
     )
+    price_to_earnings_diluted_ratio_ttm: float | None = Field(
+        default=None,
+        alias="priceToEarningsDilutedRatioTTM",
+        description="Price to diluted earnings ratio TTM",
+    )
     price_to_earnings_growth_ratio_ttm: float | None = Field(
         default=None,
         alias="priceToEarningsGrowthRatioTTM",
         description="Price to earnings growth ratio TTM",
+    )
+    price_to_earnings_diluted_growth_ratio_ttm: float | None = Field(
+        default=None,
+        alias="priceToEarningsDilutedGrowthRatioTTM",
+        description="Price to diluted earnings growth ratio TTM",
     )
     forward_price_to_earnings_growth_ratio_ttm: float | None = Field(
         default=None,
@@ -2617,7 +2637,36 @@ class CompanyRating(BaseModel):
     date: datetime = Field(description="Rating date")
     rating: str = Field(description="Overall rating")
     recommendation: str | None = Field(None, description="Investment recommendation")
-    # Add more fields as needed
+    discounted_cash_flow_score: int | None = Field(
+        default=None,
+        alias="discountedCashFlowScore",
+        description="Discounted cash flow score from rating-bulk",
+    )
+    return_on_equity_score: int | None = Field(
+        default=None,
+        alias="returnOnEquityScore",
+        description="Return on equity score from rating-bulk",
+    )
+    return_on_assets_score: int | None = Field(
+        default=None,
+        alias="returnOnAssetsScore",
+        description="Return on assets score from rating-bulk",
+    )
+    debt_to_equity_score: int | None = Field(
+        default=None,
+        alias="debtToEquityScore",
+        description="Debt to equity score from rating-bulk",
+    )
+    price_to_earnings_score: int | None = Field(
+        default=None,
+        alias="priceToEarningsScore",
+        description="Price to earnings score from rating-bulk",
+    )
+    price_to_book_score: int | None = Field(
+        default=None,
+        alias="priceToBookScore",
+        description="Price to book score from rating-bulk",
+    )
 
 
 class EnterpriseValue(BaseModel):

--- a/fmp_data/fundamental/models.py
+++ b/fmp_data/fundamental/models.py
@@ -1,8 +1,16 @@
 # fmp_data/fundamental/models.py
 from datetime import datetime
-from typing import Any
+import math
+from typing import Annotated, Any
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_validator
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    Field,
+    model_validator,
+)
 from pydantic.alias_generators import to_camel
 
 from fmp_data.models import CIK
@@ -14,6 +22,40 @@ default_model_config = ConfigDict(
     extra="allow",
     alias_generator=to_camel,
 )
+
+
+def coerce_rating_score(value: Any) -> Any:
+    """Coerce rating-bulk score cells to int.
+
+    ``rating-bulk`` CSV may emit a whole score as ``"3"`` or ``"3.0"``. A
+    strict ``int`` field rejects the latter and ``parse_csv_models`` then
+    skips the entire company row. Empty cells are already ``None``.
+    Non-numeric / non-finite values pass through so they still fail
+    validation instead of becoming ``0``.
+    """
+    if value is None:
+        return None
+    if isinstance(value, int | float):
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, float) and not math.isfinite(value):
+            return value
+        return int(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        try:
+            number = float(stripped)
+        except ValueError:
+            return value
+        if not math.isfinite(number):
+            return value
+        return int(number)
+    return value
+
+
+RatingScore = Annotated[int | None, BeforeValidator(coerce_rating_score)]
 
 
 class FinancialStatementBase(BaseModel):
@@ -2637,32 +2679,32 @@ class CompanyRating(BaseModel):
     date: datetime = Field(description="Rating date")
     rating: str = Field(description="Overall rating")
     recommendation: str | None = Field(None, description="Investment recommendation")
-    discounted_cash_flow_score: int | None = Field(
+    discounted_cash_flow_score: RatingScore = Field(
         default=None,
         alias="discountedCashFlowScore",
         description="Discounted cash flow score from rating-bulk",
     )
-    return_on_equity_score: int | None = Field(
+    return_on_equity_score: RatingScore = Field(
         default=None,
         alias="returnOnEquityScore",
         description="Return on equity score from rating-bulk",
     )
-    return_on_assets_score: int | None = Field(
+    return_on_assets_score: RatingScore = Field(
         default=None,
         alias="returnOnAssetsScore",
         description="Return on assets score from rating-bulk",
     )
-    debt_to_equity_score: int | None = Field(
+    debt_to_equity_score: RatingScore = Field(
         default=None,
         alias="debtToEquityScore",
         description="Debt to equity score from rating-bulk",
     )
-    price_to_earnings_score: int | None = Field(
+    price_to_earnings_score: RatingScore = Field(
         default=None,
         alias="priceToEarningsScore",
         description="Price to earnings score from rating-bulk",
     )
-    price_to_book_score: int | None = Field(
+    price_to_book_score: RatingScore = Field(
         default=None,
         alias="priceToBookScore",
         description="Price to book score from rating-bulk",

--- a/fmp_data/intelligence/models.py
+++ b/fmp_data/intelligence/models.py
@@ -456,6 +456,14 @@ class SenateTrade(BaseModel):
     model_config = default_model_config
 
     symbol: str | None = Field(None, description="Stock symbol")
+    senate_id: str | None = Field(
+        None,
+        alias="senateID",
+        description=(
+            "FMP entity id for the senator. The wire key is senateID even "
+            "on House rows, where FMP reused the same identifier."
+        ),
+    )
     disclosure_date: datetime | None = Field(
         None,
         validation_alias=AliasChoices("disclosureDate", "dateRecieved"),
@@ -502,6 +510,14 @@ class HouseDisclosure(BaseModel):
         None,
         validation_alias=AliasChoices("symbol", "ticker"),
         description="Stock symbol",
+    )
+    senate_id: str | None = Field(
+        None,
+        alias="senateID",
+        description=(
+            "FMP entity id for the member. The wire key is senateID on "
+            "House rows as well (e.g. Pelosi is P000197)."
+        ),
     )
     disclosure_date: datetime | None = Field(
         None, alias="disclosureDate", description="Date of disclosure"

--- a/fmp_data/intelligence/models.py
+++ b/fmp_data/intelligence/models.py
@@ -459,10 +459,7 @@ class SenateTrade(BaseModel):
     senate_id: str | None = Field(
         None,
         alias="senateID",
-        description=(
-            "FMP entity id for the senator. The wire key is senateID even "
-            "on House rows, where FMP reused the same identifier."
-        ),
+        description="FMP entity id for the senator (wire key senateID).",
     )
     disclosure_date: datetime | None = Field(
         None,

--- a/fmp_data/market/async_client.py
+++ b/fmp_data/market/async_client.py
@@ -186,9 +186,14 @@ class AsyncMarketClient(AsyncEndpointGroup):
         country: str | None = None,
         exchange: str | None = None,
         limit: int | None = None,
+        page: int | None = None,
         include_all_share_classes: bool | None = None,
     ) -> list[CompanySearchResult]:
-        """Screen companies based on various criteria"""
+        """Screen companies based on various criteria.
+
+        ``page`` is omitted from the request when unset so existing callers
+        keep the same wire shape. Pass ``0`` or a later page to paginate.
+        """
         params = {
             "market_cap_more_than": market_cap_more_than,
             "market_cap_less_than": market_cap_less_than,
@@ -208,6 +213,7 @@ class AsyncMarketClient(AsyncEndpointGroup):
             "country": country,
             "exchange": exchange,
             "limit": limit,
+            "page": page,
             "include_all_share_classes": include_all_share_classes,
         }
         params = {key: value for key, value in params.items() if value is not None}

--- a/fmp_data/market/client.py
+++ b/fmp_data/market/client.py
@@ -182,9 +182,14 @@ class MarketClient(EndpointGroup):
         country: str | None = None,
         exchange: str | None = None,
         limit: int | None = None,
+        page: int | None = None,
         include_all_share_classes: bool | None = None,
     ) -> list[CompanySearchResult]:
-        """Screen companies based on various criteria"""
+        """Screen companies based on various criteria.
+
+        ``page`` is omitted from the request when unset so existing callers
+        keep the same wire shape. Pass ``0`` or a later page to paginate.
+        """
         params = {
             "market_cap_more_than": market_cap_more_than,
             "market_cap_less_than": market_cap_less_than,
@@ -204,6 +209,7 @@ class MarketClient(EndpointGroup):
             "country": country,
             "exchange": exchange,
             "limit": limit,
+            "page": page,
             "include_all_share_classes": include_all_share_classes,
         }
         params = {key: value for key, value in params.items() if value is not None}

--- a/fmp_data/market/endpoints.py
+++ b/fmp_data/market/endpoints.py
@@ -855,6 +855,15 @@ COMPANY_SCREENER: Endpoint = Endpoint(
             description="Number of results to return",
         ),
         EndpointParam(
+            name="page",
+            location=ParamLocation.QUERY,
+            param_type=ParamType.INTEGER,
+            description=(
+                "Zero-based page of screener results. Omitted from the "
+                "request when unset so existing callers keep their wire shape."
+            ),
+        ),
+        EndpointParam(
             name="include_all_share_classes",
             location=ParamLocation.QUERY,
             param_type=ParamType.BOOLEAN,

--- a/tests/unit/test_async_clients.py
+++ b/tests/unit/test_async_clients.py
@@ -747,6 +747,12 @@ class TestAsyncMarketClient:
             COMPANY_SCREENER, limit=2, page=0
         )
 
+        mock_client.request_async.reset_mock()
+        await async_client.get_company_screener(limit=2, page=1)
+        mock_client.request_async.assert_called_once_with(
+            COMPANY_SCREENER, limit=2, page=1
+        )
+
     @pytest.mark.asyncio
     async def test_search_company_with_filters(self, mock_client):
         """Test async search_company method with optional filters."""

--- a/tests/unit/test_async_clients.py
+++ b/tests/unit/test_async_clients.py
@@ -728,6 +728,26 @@ class TestAsyncMarketClient:
         )
 
     @pytest.mark.asyncio
+    async def test_get_company_screener_forwards_page(self, mock_client):
+        """Async screener omits page when unset and forwards 0 when set."""
+        from fmp_data.market.async_client import AsyncMarketClient
+        from fmp_data.market.endpoints import COMPANY_SCREENER
+
+        mock_client.request_async.return_value = [
+            CompanySearchResult(symbol="AAPL", name="Apple Inc.")
+        ]
+        async_client = AsyncMarketClient(mock_client)
+
+        await async_client.get_company_screener(limit=2)
+        mock_client.request_async.assert_called_once_with(COMPANY_SCREENER, limit=2)
+
+        mock_client.request_async.reset_mock()
+        await async_client.get_company_screener(limit=2, page=0)
+        mock_client.request_async.assert_called_once_with(
+            COMPANY_SCREENER, limit=2, page=0
+        )
+
+    @pytest.mark.asyncio
     async def test_search_company_with_filters(self, mock_client):
         """Test async search_company method with optional filters."""
         from fmp_data.market.async_client import AsyncMarketClient

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -18,6 +18,7 @@ from fmp_data.batch.models import (
     PeersBulk,
 )
 from fmp_data.company.models import CompanyProfile
+from fmp_data.fundamental.models import CompanyRating, FinancialRatiosTTM
 
 
 class TestBatchModels:
@@ -222,6 +223,32 @@ class TestBatchClient:
         assert len(results) == 1
         assert results[0].symbol == "APPX"
         assert results[0].website is None
+
+    def test_ratios_ttm_bulk_parses_diluted_pe_headers(self):
+        """ratios-ttm-bulk CSV headers bind on FinancialRatiosTTM (#229)."""
+        csv_text = (
+            "symbol,priceToEarningsDilutedRatioTTM,"
+            "priceToEarningsDilutedGrowthRatioTTM\n"
+            "AAPL,34.64,1.07\n"
+        )
+        results = parse_csv_models(csv_text.encode("utf-8"), FinancialRatiosTTM)
+        assert len(results) == 1
+        assert results[0].price_to_earnings_diluted_ratio_ttm == 34.64
+        assert results[0].price_to_earnings_diluted_growth_ratio_ttm == 1.07
+
+    def test_rating_bulk_parses_standardized_score_headers(self):
+        """rating-bulk score columns bind on CompanyRating (#229)."""
+        csv_text = (
+            "symbol,date,rating,discountedCashFlowScore,returnOnEquityScore,"
+            "returnOnAssetsScore,debtToEquityScore,priceToEarningsScore,"
+            "priceToBookScore\n"
+            "AAPL,2026-08-12,A-,3,4,4,2,3,3\n"
+        )
+        results = parse_csv_models(csv_text.encode("utf-8"), CompanyRating)
+        assert len(results) == 1
+        assert results[0].rating == "A-"
+        assert results[0].discounted_cash_flow_score == 3
+        assert results[0].price_to_book_score == 3
 
     def test_parse_csv_rows_empty(self):
         """Empty CSV input returns no rows."""

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -242,13 +242,19 @@ class TestBatchClient:
             "symbol,date,rating,discountedCashFlowScore,returnOnEquityScore,"
             "returnOnAssetsScore,debtToEquityScore,priceToEarningsScore,"
             "priceToBookScore\n"
-            "AAPL,2026-08-12,A-,3,4,4,2,3,3\n"
+            "AAPL,2026-08-12,A-,1,2.0,3,4,5,6\n"
         )
         results = parse_csv_models(csv_text.encode("utf-8"), CompanyRating)
         assert len(results) == 1
-        assert results[0].rating == "A-"
-        assert results[0].discounted_cash_flow_score == 3
-        assert results[0].price_to_book_score == 3
+        rating = results[0]
+        assert rating.rating == "A-"
+        assert rating.discounted_cash_flow_score == 1
+        assert rating.return_on_equity_score == 2
+        assert rating.return_on_assets_score == 3
+        assert rating.debt_to_equity_score == 4
+        assert rating.price_to_earnings_score == 5
+        assert rating.price_to_book_score == 6
+        assert not rating.__pydantic_extra__
 
     def test_parse_csv_rows_empty(self):
         """Empty CSV input returns no rows."""

--- a/tests/unit/test_fundamental.py
+++ b/tests/unit/test_fundamental.py
@@ -10,7 +10,9 @@ from fmp_data.fundamental.endpoints import (
     OWNER_EARNINGS,
 )
 from fmp_data.fundamental.models import (
+    CompanyRating,
     FinancialRatios,
+    FinancialRatiosTTM,
     FinancialReportDate,
     FinancialStatementFull,
     IncomeStatement,
@@ -257,6 +259,61 @@ class TestFundamentalEndpoints(unittest.TestCase):
         self.assertIsInstance(ratio, FinancialRatios)
         assert ratio.current_ratio is not None
         self.assertAlmostEqual(ratio.current_ratio, 0.8673125765340832)
+
+    def test_financial_ratios_diluted_pe_alias_round_trip(self):
+        """Diluted PE / PEG are first-class fields, not extras (#229)."""
+        ratio = FinancialRatios.model_validate(
+            {
+                "symbol": "AAPL",
+                "priceToEarningsDilutedRatio": 34.24,
+                "priceToEarningsDilutedGrowthRatio": 1.51,
+            }
+        )
+        assert ratio.price_to_earnings_diluted_ratio is not None
+        assert ratio.price_to_earnings_diluted_growth_ratio is not None
+        self.assertAlmostEqual(ratio.price_to_earnings_diluted_ratio, 34.24)
+        self.assertAlmostEqual(ratio.price_to_earnings_diluted_growth_ratio, 1.51)
+        dumped = ratio.model_dump(by_alias=True)
+        self.assertAlmostEqual(dumped["priceToEarningsDilutedRatio"], 34.24)
+        self.assertAlmostEqual(dumped["priceToEarningsDilutedGrowthRatio"], 1.51)
+
+    def test_financial_ratios_ttm_diluted_pe_alias_round_trip(self):
+        """TTM diluted PE / PEG aliases match the 2026-07-30 wire keys."""
+        ratio = FinancialRatiosTTM.model_validate(
+            {
+                "symbol": "AAPL",
+                "priceToEarningsDilutedRatioTTM": 34.64,
+                "priceToEarningsDilutedGrowthRatioTTM": 1.07,
+            }
+        )
+        assert ratio.price_to_earnings_diluted_ratio_ttm is not None
+        assert ratio.price_to_earnings_diluted_growth_ratio_ttm is not None
+        self.assertAlmostEqual(ratio.price_to_earnings_diluted_ratio_ttm, 34.64)
+        self.assertAlmostEqual(ratio.price_to_earnings_diluted_growth_ratio_ttm, 1.07)
+        dumped = ratio.model_dump(by_alias=True)
+        self.assertAlmostEqual(dumped["priceToEarningsDilutedRatioTTM"], 34.64)
+        self.assertAlmostEqual(dumped["priceToEarningsDilutedGrowthRatioTTM"], 1.07)
+
+    def test_company_rating_bulk_score_alias_round_trip(self):
+        """rating-bulk score columns bind on CompanyRating (#229 re-probe)."""
+        rating = CompanyRating.model_validate(
+            {
+                "symbol": "AAPL",
+                "date": "2026-08-12",
+                "rating": "A-",
+                "discountedCashFlowScore": 3,
+                "returnOnEquityScore": 4,
+                "returnOnAssetsScore": 4,
+                "debtToEquityScore": 2,
+                "priceToEarningsScore": 3,
+                "priceToBookScore": 3,
+            }
+        )
+        self.assertEqual(rating.discounted_cash_flow_score, 3)
+        self.assertEqual(rating.return_on_equity_score, 4)
+        dumped = rating.model_dump(by_alias=True)
+        self.assertEqual(dumped["discountedCashFlowScore"], 3)
+        self.assertEqual(dumped["priceToBookScore"], 3)
 
     def test_get_financial_reports_dates(self):
         """Test getting financial report dates"""

--- a/tests/unit/test_fundamental.py
+++ b/tests/unit/test_fundamental.py
@@ -301,19 +301,52 @@ class TestFundamentalEndpoints(unittest.TestCase):
                 "symbol": "AAPL",
                 "date": "2026-08-12",
                 "rating": "A-",
-                "discountedCashFlowScore": 3,
-                "returnOnEquityScore": 4,
-                "returnOnAssetsScore": 4,
-                "debtToEquityScore": 2,
-                "priceToEarningsScore": 3,
-                "priceToBookScore": 3,
+                "discountedCashFlowScore": 1,
+                "returnOnEquityScore": 2,
+                "returnOnAssetsScore": 3,
+                "debtToEquityScore": 4,
+                "priceToEarningsScore": 5,
+                "priceToBookScore": 6,
+            }
+        )
+        self.assertEqual(rating.discounted_cash_flow_score, 1)
+        self.assertEqual(rating.return_on_equity_score, 2)
+        self.assertEqual(rating.return_on_assets_score, 3)
+        self.assertEqual(rating.debt_to_equity_score, 4)
+        self.assertEqual(rating.price_to_earnings_score, 5)
+        self.assertEqual(rating.price_to_book_score, 6)
+        self.assertFalse(rating.__pydantic_extra__)
+        dumped = rating.model_dump(by_alias=True)
+        self.assertEqual(dumped["discountedCashFlowScore"], 1)
+        self.assertEqual(dumped["returnOnEquityScore"], 2)
+        self.assertEqual(dumped["returnOnAssetsScore"], 3)
+        self.assertEqual(dumped["debtToEquityScore"], 4)
+        self.assertEqual(dumped["priceToEarningsScore"], 5)
+        self.assertEqual(dumped["priceToBookScore"], 6)
+
+    def test_company_rating_scores_optional_without_bulk_columns(self):
+        """Letter-grade-only payloads leave every score unset."""
+        rating = CompanyRating.model_validate(
+            {"symbol": "AAPL", "date": "2026-08-12", "rating": "A-"}
+        )
+        self.assertIsNone(rating.discounted_cash_flow_score)
+        self.assertIsNone(rating.return_on_equity_score)
+        self.assertIsNone(rating.return_on_assets_score)
+        self.assertIsNone(rating.debt_to_equity_score)
+        self.assertIsNone(rating.price_to_earnings_score)
+        self.assertIsNone(rating.price_to_book_score)
+
+    def test_company_rating_coerces_fractional_csv_score_strings(self):
+        """\"3.0\" score cells must not drop the row (parse_csv_models skip)."""
+        rating = CompanyRating.model_validate(
+            {
+                "symbol": "AAPL",
+                "date": "2026-08-12",
+                "rating": "A-",
+                "discountedCashFlowScore": "3.0",
             }
         )
         self.assertEqual(rating.discounted_cash_flow_score, 3)
-        self.assertEqual(rating.return_on_equity_score, 4)
-        dumped = rating.model_dump(by_alias=True)
-        self.assertEqual(dumped["discountedCashFlowScore"], 3)
-        self.assertEqual(dumped["priceToBookScore"], 3)
 
     def test_get_financial_reports_dates(self):
         """Test getting financial report dates"""

--- a/tests/unit/test_intelligence.py
+++ b/tests/unit/test_intelligence.py
@@ -882,6 +882,7 @@ class TestMarketIntelligenceClientGovernment:
         """Test get_senate_latest"""
         mock_data = {
             "symbol": "AAPL",
+            "senateID": "W000802",
             "disclosureDate": "2025-01-08",
             "transactionDate": "2024-12-19",
             "firstName": "Sheldon",
@@ -899,12 +900,14 @@ class TestMarketIntelligenceClientGovernment:
         }
         mock_client.request.return_value = [SenateTrade(**mock_data)]
 
-        _ = fmp_client.intelligence.get_senate_latest(page=0, limit=100)
+        result = fmp_client.intelligence.get_senate_latest(page=0, limit=100)
 
         mock_client.request.assert_called_once()
         _args, kwargs = mock_client.request.call_args
         assert kwargs["page"] == 0
         assert kwargs["limit"] == 100
+        assert result[0].senate_id == "W000802"
+        assert result[0].model_dump(by_alias=True)["senateID"] == "W000802"
 
     def test_get_senate_trading(self, fmp_client, mock_client):
         """Test get_senate_trading"""
@@ -953,6 +956,7 @@ class TestMarketIntelligenceClientGovernment:
         """Test get_house_latest"""
         mock_data = {
             "symbol": "AAPL",
+            "senateID": "P000197",
             "disclosureDate": "2025-02-03",
             "transactionDate": "2025-01-03",
             "firstName": "Michael",
@@ -970,12 +974,14 @@ class TestMarketIntelligenceClientGovernment:
         }
         mock_client.request.return_value = [HouseDisclosure(**mock_data)]
 
-        _ = fmp_client.intelligence.get_house_latest(page=0, limit=100)
+        result = fmp_client.intelligence.get_house_latest(page=0, limit=100)
 
         mock_client.request.assert_called_once()
         _args, kwargs = mock_client.request.call_args
         assert kwargs["page"] == 0
         assert kwargs["limit"] == 100
+        assert result[0].senate_id == "P000197"
+        assert result[0].model_dump(by_alias=True)["senateID"] == "P000197"
 
     def test_get_house_disclosure(self, fmp_client, mock_client):
         """Test get_house_disclosure"""
@@ -1011,6 +1017,34 @@ class TestMarketIntelligenceClientGovernment:
         mock_client.request.assert_called_once()
         _args, kwargs = mock_client.request.call_args
         assert kwargs["name"] == "James"
+
+    def test_senate_trade_senate_id_alias_round_trip(self):
+        """senateID is a first-class SenateTrade field (#229)."""
+        trade = SenateTrade.model_validate(
+            {
+                "symbol": "AAPL",
+                "senateID": "T000278",
+                "firstName": "Tommy",
+                "lastName": "Tuberville",
+                "link": "https://example.com/filing",
+            }
+        )
+        assert trade.senate_id == "T000278"
+        assert trade.model_dump(by_alias=True)["senateID"] == "T000278"
+
+    def test_house_disclosure_keeps_wire_senate_id(self):
+        """House rows keep FMP's senateID key, not a house_id rename (#229)."""
+        row = HouseDisclosure.model_validate(
+            {
+                "symbol": "INTC",
+                "senateID": "P000197",
+                "firstName": "Nancy",
+                "lastName": "Pelosi",
+                "link": "https://example.com/filing",
+            }
+        )
+        assert row.senate_id == "P000197"
+        assert row.model_dump(by_alias=True)["senateID"] == "P000197"
 
 
 class TestMarketIntelligenceClientFundraising:

--- a/tests/unit/test_market.py
+++ b/tests/unit/test_market.py
@@ -536,6 +536,25 @@ def test_get_company_screener(mock_request, fmp_client, mock_response):
     assert params["isEtf"] is False
     assert params["sector"] == "Technology"
     assert params["limit"] == 5
+    assert "page" not in params
+
+
+@patch("httpx.Client.request")
+def test_get_company_screener_forwards_page(mock_request, fmp_client, mock_response):
+    """Screener page is forwarded only when set, including page=0 (#229)."""
+    response_data = [{"symbol": "AAPL", "name": "Apple Inc.", "currency": "USD"}]
+    mock_request.return_value = mock_response(status_code=200, json_data=response_data)
+
+    fmp_client.market.get_company_screener(limit=2, page=0)
+    params = mock_request.call_args[1]["params"]
+    assert params["limit"] == 2
+    assert params["page"] == 0
+
+    mock_request.reset_mock()
+    mock_request.return_value = mock_response(status_code=200, json_data=response_data)
+    fmp_client.market.get_company_screener(limit=2, page=1)
+    params = mock_request.call_args[1]["params"]
+    assert params["page"] == 1
 
 
 class TestIPOEndpoints:


### PR DESCRIPTION
Closes #229.

Aligns the client with FMP's public changelog ([docs/changelog](https://site.financialmodelingprep.com/developer/docs/changelog)) after a live `/stable` probe on 2026-08-12.

## What changed

**New (first-class)**

| Surface | Wire | Client |
|---|---|---|
| Ratios / Ratios TTM / `ratios-ttm-bulk` | `priceToEarningsDilutedRatio`, `priceToEarningsDilutedGrowthRatio` (+ `*TTM`) | `FinancialRatios` / `FinancialRatiosTTM` |
| Company screener | optional `page` | `market.get_company_screener(..., page=None)` — omitted when unset, including so `page=0` is sent |
| Senate + House trades | `senateID` | `SenateTrade.senate_id` / `HouseDisclosure.senate_id` (wire name kept on House rows) |
| `rating-bulk` | six score columns | `CompanyRating.*_score` |

**Not new endpoints.** FMP did not add paths in this window that we do not already ship. No path we ship was newly withdrawn.

## Older-changelog re-probe

Recorded on #229 and at the top of `CHANGELOG.md` Unreleased (`### FMP API surface`). Summary: delisted / exchange / DCF bulk / historical S&P / CUSIP / ETF flag / splitType / `includeReportTimes` / profile-bulk `part` all still match. Legacy `/api/v3` is 403; we have no live V3 client path.

The one leftover finding: `DELISTED_COMPANIES` is still declared with `response_model=CompanyProfile` (slim live row is `{symbol, companyName, exchange, ipoDate, delistedDate}`) and has no Python client method. Pre-existing, not wired — left alone rather than inventing `get_delisted_companies` in this PR.

## Tests

- alias round-trip for diluted PE/PEG and `senateID`
- screener `page` omitted when unset, forwarded at `0` and `1` (sync + async)
- `parse_csv_models` for `ratios-ttm-bulk` and `rating-bulk` headers

`CHANGELOG.md` Unreleased now opens with scan tables for **New / Updated / Deprecated** so the next reader does not have to reconstruct this from prose.