### PR TITLE
docs(mcp): position FMP hosted MCP vs fmp-mcp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,13 @@ None. No FMP path we ship was newly retired by this changelog window.
 
 ### Added
 
+- **FMP hosted MCP vs `fmp-mcp` positioning (#230).** Docs-only: we are not
+  wrapping FMP's remote MCP URL. README + `docs/mcp/index.md` point at
+  `docs/mcp/hosted.md`, which records the 2026-08-12 decision (A+D: position
+  + coverage matrix), a live `tools/list` of **28** dataset tools (changelog
+  said 27; `tipranks` is a paid add-on), and when to use hosted MCP vs this
+  package. No runtime helper, no FastMCP dependency, no CI smoke.
+
 - **FMP changelog alignment (#229).** Three confirmed 2026 wire gaps, the
   leftover 2025-10 delisted-companies wiring (#233), plus the older-note
   re-probe above. Live `/stable` checks used the current API key on

--- a/LLM.md
+++ b/LLM.md
@@ -96,6 +96,8 @@ or call `model_dump()` / `model_dump_json()` for raw data.
   - CLI: `fmp-mcp setup` or `fmp-mcp`
   - Server API: `from fmp_data.mcp.server import create_app`
   - Tool catalog: `fmp-mcp list` (MCP tools are the endpoints with tool semantics)
+  - FMP also hosts a remote MCP (28 dataset tools). That is not this package;
+    see `docs/mcp/hosted.md`.
 
 ## Pointers
 - Examples: `examples/`

--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ our typed client as stdio tools for Claude Desktop and other MCP hosts.
 FMP also ships a **hosted** MCP server at
 `https://financialmodelingprep.com/mcp` (28 dataset-oriented tools, API key in
 the URL). That is a different product. Use hosted MCP for a zero-install
-agent connector; use `fmp-mcp` for the full catalog, manifests, and typed
-local control. Comparison and coverage matrix:
+agent connector; use `fmp-mcp` for the broader MCP tool catalog, manifests,
+and typed local control. Comparison and coverage matrix:
 [docs/mcp/hosted.md](docs/mcp/hosted.md).
 
 ### Quick Setup for Claude Desktop

--- a/README.md
+++ b/README.md
@@ -129,7 +129,15 @@ export FMP_CACHE_REDIS_URL=redis://localhost:6379/0
 
 ## MCP Server (Claude Desktop Integration)
 
-Model Context Protocol (MCP) server provides financial data access through a standardized protocol, enabling Claude Desktop to query FMP data seamlessly.
+`fmp-mcp` is this package's **local** Model Context Protocol server. It exposes
+our typed client as stdio tools for Claude Desktop and other MCP hosts.
+
+FMP also ships a **hosted** MCP server at
+`https://financialmodelingprep.com/mcp` (28 dataset-oriented tools, API key in
+the URL). That is a different product. Use hosted MCP for a zero-install
+agent connector; use `fmp-mcp` for the full catalog, manifests, and typed
+local control. Comparison and coverage matrix:
+[docs/mcp/hosted.md](docs/mcp/hosted.md).
 
 ### Quick Setup for Claude Desktop
 

--- a/docs/mcp/hosted.md
+++ b/docs/mcp/hosted.md
@@ -40,13 +40,19 @@ They are complementary. Hosted MCP is the "plug the URL into an agent" path.
 Their Python example (from [their docs](https://site.financialmodelingprep.com/developer/docs/mcp-server)):
 
 ```python
+import asyncio
 import os
 from fastmcp import Client
 
-url = "https://financialmodelingprep.com/mcp?apikey=" + os.environ["FMP_API_KEY"]
-async with Client(url) as client:
-    print(await client.list_tools())
-    print(await client.call_tool("quote", {"endpoint": "quote", "symbol": "AAPL"}))
+
+async def main() -> None:
+    url = "https://financialmodelingprep.com/mcp?apikey=" + os.environ["FMP_API_KEY"]
+    async with Client(url) as client:
+        print(await client.list_tools())
+        print(await client.call_tool("quote", {"endpoint": "quote", "symbol": "AAPL"}))
+
+
+asyncio.run(main())
 ```
 
 `fastmcp` is **their** snippet, not a dependency of this package. Their

--- a/docs/mcp/hosted.md
+++ b/docs/mcp/hosted.md
@@ -18,7 +18,7 @@ Always say **FMP hosted MCP** vs **`fmp-mcp` (this package)**. Do not write
 | Zero-install agent in Claude Connectors, Cursor, or Cloudflare Workers AI | **FMP hosted MCP** |
 | Small tool list (one tool per dataset, ~28 tools) | **FMP hosted MCP** |
 | Typed Python models, offline/local process, manifests, LangChain | **`fmp-mcp` / this client** |
-| Broad catalog (~223 tools, 137 default) and method-shaped arguments | **`fmp-mcp`** |
+| Broad catalog (current counts in [tools.md](tools.md)) and method-shaped arguments | **`fmp-mcp`** |
 | Bulk CSV, cache backends, validation modes, rate limits | **this Python client** (not either MCP) |
 
 They are complementary. Hosted MCP is the "plug the URL into an agent" path.
@@ -31,7 +31,7 @@ They are complementary. Hosted MCP is the "plug the URL into an agent" path.
 |---|---|---|
 | Where it runs | Local process (`fmp-mcp` CLI, stdio) | `https://financialmodelingprep.com/mcp` |
 | Auth | `FMP_API_KEY` in env / config | API key in the query string (`?apikey=`) |
-| Tool surface | ~223 catalog / 137 default, one tool per endpoint | **28** dataset tools (live 2026-08-12; changelog 2026-03-27 said 27) |
+| Tool surface | One tool per endpoint; current catalog/default counts in [tools.md](tools.md) | **28** dataset tools (live 2026-08-12; changelog 2026-03-27 said 27) |
 | How a call is shaped | Python method args (`symbol`, `from_date`, …) | `endpoint` enum + shared params (`symbol`, `from_date`, …) |
 | Data path | Our client + Pydantic models | Their server → their REST (opaque) |
 | Billing | Caller's FMP key / plan | Same |
@@ -49,9 +49,11 @@ async with Client(url) as client:
     print(await client.call_tool("quote", {"endpoint": "quote", "symbol": "AAPL"}))
 ```
 
-`fastmcp` is **their** snippet, not a dependency of this package. Prefer env
-interpolation over pasting the key into a committed URL. A key in the query
-string will appear in proxy and access logs.
+`fastmcp` is **their** snippet, not a dependency of this package. Their
+published example omits `endpoint` and pastes a literal key; the live
+inputSchema requires `endpoint`, and a key in the query string will appear
+in proxy and access logs and in any connector config that stores the URL.
+Prefer env interpolation. Do not commit the keyed URL.
 
 ## Decision (#230)
 
@@ -108,7 +110,7 @@ Hosted `endpoint` values are FMP path slugs, not our `client.method` specs.
 | `form13F` | 8 | `institutional.form_13f*` / holdings-by-quarter | Hosted marks Ultimate/Enterprise |
 | `insiderTrades` | 6 | `institutional` insider tools | |
 | `secFilings` | 12 | `sec` / `intelligence` filings tools | |
-| `earningsTranscript` | 4 | `intelligence` transcript tools | Hosted marks Ultimate/Enterprise |
+| `earningsTranscript` | 4 | `transcripts.*` (`latest_transcripts`, `transcript`, `transcript_dates`, `transcript_symbols`) | 4 catalog / 0 default — large payloads, load via manifest. Hosted marks Ultimate/Enterprise |
 | `etfAndMutualFunds` | 9 | `investment.*` | |
 | `indexes` | 15 | `index.*` + historical constituents | |
 | `marketPerformance` | 11 | `market` gainers/losers/actives, sector/industry performance | |

--- a/docs/mcp/hosted.md
+++ b/docs/mcp/hosted.md
@@ -1,0 +1,145 @@
+# FMP hosted MCP vs `fmp-mcp` (this package)
+
+FMP ships a **hosted MCP server** on their infrastructure. This package ships
+**`fmp-mcp`**, a local stdio server over our typed Python client. They are
+different products that both talk to the same REST API and the same API key.
+
+This page records the posture from [#230](https://github.com/MehdiZare/fmp-data/issues/230)
+(2026-08-12): **docs + coverage matrix only**. There is no runtime helper, no
+FastMCP dependency, and no CI smoke against their URL.
+
+Always say **FMP hosted MCP** vs **`fmp-mcp` (this package)**. Do not write
+"FMP MCP" unqualified.
+
+## When to use which
+
+| Need | Use |
+|---|---|
+| Zero-install agent in Claude Connectors, Cursor, or Cloudflare Workers AI | **FMP hosted MCP** |
+| Small tool list (one tool per dataset, ~28 tools) | **FMP hosted MCP** |
+| Typed Python models, offline/local process, manifests, LangChain | **`fmp-mcp` / this client** |
+| Broad catalog (~223 tools, 137 default) and method-shaped arguments | **`fmp-mcp`** |
+| Bulk CSV, cache backends, validation modes, rate limits | **this Python client** (not either MCP) |
+
+They are complementary. Hosted MCP is the "plug the URL into an agent" path.
+`fmp-mcp` is the "full catalog, local, typed" path. We are **not** deprecating
+`fmp-mcp` and we are **not** proxying our tool names onto theirs.
+
+## Comparison
+
+| | **`fmp-mcp` (this package)** | **FMP hosted MCP** |
+|---|---|---|
+| Where it runs | Local process (`fmp-mcp` CLI, stdio) | `https://financialmodelingprep.com/mcp` |
+| Auth | `FMP_API_KEY` in env / config | API key in the query string (`?apikey=`) |
+| Tool surface | ~223 catalog / 137 default, one tool per endpoint | **28** dataset tools (live 2026-08-12; changelog 2026-03-27 said 27) |
+| How a call is shaped | Python method args (`symbol`, `from_date`, …) | `endpoint` enum + shared params (`symbol`, `from_date`, …) |
+| Data path | Our client + Pydantic models | Their server → their REST (opaque) |
+| Billing | Caller's FMP key / plan | Same |
+| Transport | stdio | Remote MCP (JSON-RPC after `initialize`; `mcp-session-id` header) |
+
+Their Python example (from [their docs](https://site.financialmodelingprep.com/developer/docs/mcp-server)):
+
+```python
+import os
+from fastmcp import Client
+
+url = "https://financialmodelingprep.com/mcp?apikey=" + os.environ["FMP_API_KEY"]
+async with Client(url) as client:
+    print(await client.list_tools())
+    print(await client.call_tool("quote", {"endpoint": "quote", "symbol": "AAPL"}))
+```
+
+`fastmcp` is **their** snippet, not a dependency of this package. Prefer env
+interpolation over pasting the key into a committed URL. A key in the query
+string will appear in proxy and access logs.
+
+## Decision (#230)
+
+Recorded 2026-08-12:
+
+- **A — docs-only positioning.** This page + the README / `docs/mcp/index.md`
+  pointers.
+- **D — coverage matrix.** The table below is from a live `tools/list` on
+  2026-08-12 (redacted; no key stored). Refresh it when FMP's changelog notes
+  another MCP consolidation.
+- **Not B.** No `fmp_data.mcp.remote` helper. A supported snippet would imply
+  we own their session/auth story.
+- **Not C.** No proxy that maps our names onto their 28 tools.
+- **Not E.** `fmp-mcp` stays. Their catalog is smaller and dataset-shaped;
+  ours is typed and endpoint-shaped.
+
+Deferred: runtime dependency on their URL, dual CI, header-only auth (their
+docs only show `?apikey=`).
+
+## Live probe (2026-08-12)
+
+- `POST /mcp?apikey=…` `initialize` → 200, `serverInfo.name = "FMP MCP Server"`,
+  protocol `2025-03-26`.
+- Subsequent `tools/list` needs the `mcp-session-id` response header. A bare
+  GET without a session is rejected (as their docs warn).
+- **28 tools**, not 27. The extra relative to the 2026-03-27 changelog note is
+  `tipranks` (a paid add-on, not part of any FMP plan).
+- Each tool takes a required `endpoint` enum that selects the underlying REST
+  path. One hosted tool covers many of our client methods.
+
+## Coverage matrix
+
+Closest `fmp-mcp` / client surface for each hosted tool. "Closest" is the
+module or default tools that answer the same questions — not a 1:1 rename.
+Hosted `endpoint` values are FMP path slugs, not our `client.method` specs.
+
+| Hosted tool | Hosted `endpoint` count | Closest here | Notes |
+|---|---:|---|---|
+| `quote` | 16 | `company.quote`, `company.simple_quote`, aftermarket + `batch.*_quotes` | Hosted also folds exchange/ETF/crypto/forex/index full-market quotes into this one tool |
+| `search` | 7 | `market.search`, `market.search_name`, screener, CIK/ISIN/CUSIP search | Hosted `search-company-screener` is our `market.get_company_screener` |
+| `company` | 17 | `company.*` (profile, executives, float, M&A, peers, …) | Includes `delisted-companies` (wired in #233 / PR #234) |
+| `chart` | 10 | `company.historical_prices`, `company.intraday_prices` | Hosted splits EOD variants (`full` / `light` / dividend / non-split) as separate endpoints |
+| `statements` | 27 | `fundamental.*` + revenue segmentation | Broadest hosted tool; includes as-reported and TTM variants |
+| `analyst` | 8 | `intelligence.grades*`, `company.price_target_*`, `company.analyst_estimates` | |
+| `calendar` | 9 | `intelligence` earnings/dividends/splits/IPO calendars | |
+| `news` | 10 | `intelligence` news / press-release tools | |
+| `senate` | 6 | `intelligence` senate/house trade tools | |
+| `directory` | 11 | `market` lists / `company.symbol_changes` | |
+| `discountedCashFlow` | 4 | `fundamental.discounted_cash_flow`, levered + custom DCF | |
+| `economics` | 4 | `economics.*` | |
+| `commitmentOfTraders` | 3 | `economics.commitment_of_traders_*` | Hosted marks Premium+ |
+| `ESG` | 3 | `intelligence` ESG tools | Hosted marks Ultimate/Enterprise |
+| `Fundraisers` | 6 | `intelligence` crowdfunding / equity-offering tools | |
+| `form13F` | 8 | `institutional.form_13f*` / holdings-by-quarter | Hosted marks Ultimate/Enterprise |
+| `insiderTrades` | 6 | `institutional` insider tools | |
+| `secFilings` | 12 | `sec` / `intelligence` filings tools | |
+| `earningsTranscript` | 4 | `intelligence` transcript tools | Hosted marks Ultimate/Enterprise |
+| `etfAndMutualFunds` | 9 | `investment.*` | |
+| `indexes` | 15 | `index.*` + historical constituents | |
+| `marketPerformance` | 11 | `market` gainers/losers/actives, sector/industry performance | |
+| `marketHours` | 3 | `market` hours / holidays | |
+| `technicalIndicators` | 9 | `technical.*` | Hosted marks Starter+ |
+| `commodity` | 9 | `alternative.commodity_*` + `batch.commodity_quotes` | |
+| `crypto` | 9 | `alternative.crypto_*` + `batch.crypto_quotes` | |
+| `forex` | 9 | `alternative.forex_*` + `batch.forex_quotes` | |
+| `tipranks` | 7 | **none** | Paid TipRanks add-on. Not in this client. |
+
+### What hosted MCP does not replace
+
+- **Bulk CSV** (`profile-bulk`, `rating-bulk`, …) lives on our `batch` client
+  and is intentionally **0 default** MCP tools (large payloads).
+- **Typed models, `FMP_VALIDATION_MODE`, cache, rate limits** exist only on
+  this client.
+- **Manifests / `FMP_MCP_TOOL_NAME_STYLE`** exist only on `fmp-mcp`.
+
+### What we do not ship that they do
+
+- `tipranks` (paid add-on).
+- A single dataset tool that internally multiplexes dozens of REST paths.
+  Our tools stay one-endpoint-each so LangChain / MCP argument schemas stay
+  honest.
+
+## Refreshing the matrix
+
+When FMP's changelog mentions MCP again, call `tools/list` on their URL (key
+in env, never committed) and update the table. Do not add a live CI job: it
+needs a session, burns quota, and their 27→28 drift already shows the set
+moves.
+
+See also: [MCP index](index.md), [tools reference](tools.md),
+[FMP MCP docs](https://site.financialmodelingprep.com/developer/docs/mcp-server).

--- a/docs/mcp/index.md
+++ b/docs/mcp/index.md
@@ -1,8 +1,12 @@
 # MCP Integration
 
-FMP Data ships an MCP server for Claude Desktop and other MCP clients.
-The MCP tool catalog covers endpoints with MCP tool semantics; for full endpoint
-coverage, use the Python client.
+FMP Data ships **`fmp-mcp`**, a local MCP server for Claude Desktop and other
+MCP clients. The MCP tool catalog covers endpoints with MCP tool semantics;
+for full endpoint coverage, use the Python client.
+
+FMP also hosts their own remote MCP server. That is a different product.
+See [FMP hosted MCP vs `fmp-mcp`](hosted.md) for when to use which
+(decision recorded in [#230](https://github.com/MehdiZare/fmp-data/issues/230)).
 
 Tool naming defaults to semantic keys (e.g., `profile`). For collision-free tool
 names, set `FMP_MCP_TOOL_NAME_STYLE=spec` to expose fully qualified names like
@@ -48,3 +52,4 @@ names on MCP, wire names on LangChain.
 - Configuration profiles and manifests: [Configuration Profiles](configurations.md)
 - Troubleshooting: [Troubleshooting](troubleshooting.md)
 - Tools reference: [Tools Reference](tools.md)
+- FMP hosted MCP vs this package: [Hosted MCP](hosted.md)

--- a/tests/unit/test_hosted_mcp_docs.py
+++ b/tests/unit/test_hosted_mcp_docs.py
@@ -50,5 +50,14 @@ def test_hosted_doc_lists_every_probed_tool() -> None:
 
 def test_hosted_doc_records_twenty_eight_tools() -> None:
     text = DOC_PATH.read_text()
-    assert "28" in text
+    assert "**28** dataset tools" in text
     assert len(HOSTED_MCP_TOOLS) == 28
+    matrix_rows = [
+        line
+        for line in text.splitlines()
+        if line.startswith("| `")
+        and any(f"`{name}`" in line for name in HOSTED_MCP_TOOLS)
+    ]
+    assert len(matrix_rows) == 28, (
+        f"hosted.md matrix rows {len(matrix_rows)} != probed tool count 28"
+    )

--- a/tests/unit/test_hosted_mcp_docs.py
+++ b/tests/unit/test_hosted_mcp_docs.py
@@ -52,12 +52,14 @@ def test_hosted_doc_records_twenty_eight_tools() -> None:
     text = DOC_PATH.read_text()
     assert "**28** dataset tools" in text
     assert len(HOSTED_MCP_TOOLS) == 28
-    matrix_rows = [
-        line
+    matrix_names = [
+        line.split("|", 2)[1].strip().strip("`")
         for line in text.splitlines()
         if line.startswith("| `")
-        and any(f"`{name}`" in line for name in HOSTED_MCP_TOOLS)
     ]
-    assert len(matrix_rows) == 28, (
-        f"hosted.md matrix rows {len(matrix_rows)} != probed tool count 28"
+    assert len(matrix_names) == len(set(matrix_names)), (
+        f"hosted.md matrix has duplicate tool rows: {matrix_names}"
+    )
+    assert set(matrix_names) == set(HOSTED_MCP_TOOLS), (
+        f"hosted.md matrix {sorted(matrix_names)} != probed {sorted(HOSTED_MCP_TOOLS)}"
     )

--- a/tests/unit/test_hosted_mcp_docs.py
+++ b/tests/unit/test_hosted_mcp_docs.py
@@ -1,0 +1,54 @@
+"""Guard: docs/mcp/hosted.md must name every FMP hosted MCP tool we probed.
+
+The 2026-08-12 live ``tools/list`` returned 28 dataset tools. The matrix is
+the only place we record that set; if a row is deleted the decision page
+silently lies.
+"""
+
+from pathlib import Path
+
+DOC_PATH = Path(__file__).resolve().parents[2] / "docs" / "mcp" / "hosted.md"
+
+# Live tools/list, 2026-08-12. Refresh with the probe notes in hosted.md.
+HOSTED_MCP_TOOLS = (
+    "ESG",
+    "Fundraisers",
+    "analyst",
+    "calendar",
+    "chart",
+    "commitmentOfTraders",
+    "commodity",
+    "company",
+    "crypto",
+    "directory",
+    "discountedCashFlow",
+    "earningsTranscript",
+    "economics",
+    "etfAndMutualFunds",
+    "forex",
+    "form13F",
+    "indexes",
+    "insiderTrades",
+    "marketHours",
+    "marketPerformance",
+    "news",
+    "quote",
+    "search",
+    "secFilings",
+    "senate",
+    "statements",
+    "technicalIndicators",
+    "tipranks",
+)
+
+
+def test_hosted_doc_lists_every_probed_tool() -> None:
+    text = DOC_PATH.read_text()
+    missing = [name for name in HOSTED_MCP_TOOLS if f"`{name}`" not in text]
+    assert missing == [], f"docs/mcp/hosted.md missing hosted tools: {missing}"
+
+
+def test_hosted_doc_records_twenty_eight_tools() -> None:
+    text = DOC_PATH.read_text()
+    assert "28" in text
+    assert len(HOSTED_MCP_TOOLS) == 28


### PR DESCRIPTION
Closes #230.

Docs-only decision for FMP's hosted MCP vs our local `fmp-mcp`.

## Decision (A + D)

- **A.** Position hosted MCP as the zero-install agent connector; `fmp-mcp` as the full catalog / local / typed option.
- **D.** Coverage matrix from a live `tools/list` on 2026-08-12 (**28** dataset tools; the 2026-03-27 changelog said 27 — the extra is `tipranks`, a paid add-on).
- **Not B/C/E.** No runtime helper, no FastMCP dependency, no proxy, no deprecation of `fmp-mcp`, no CI smoke against their URL.

New page: `docs/mcp/hosted.md`. Pointers from README, `docs/mcp/index.md`, `LLM.md`. Guard test asserts the 28 probed tool names stay in the matrix.

Auth note recorded: their docs use `?apikey=` (leaks into logs); `initialize` returns `mcp-session-id`; a bare GET without a session is rejected.

Isolated from #234 in worktree `fmp-data--docs-hosted-mcp-posture-230` off `origin/dev`.