### PR TITLE
fix(batch): honor FMP_VALIDATION_MODE in parse_csv_models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,16 @@ None. No FMP path we ship was newly retired by this changelog window.
 
 ### Fixed
 
+- **CSV bulk parsing now honors `FMP_VALIDATION_MODE` (#232).** `parse_csv_models`
+  used `model.model_validate` directly, so unknown bulk headers (`overallScore`
+  on `rating-bulk`, a misspelled diluted-PE column) landed in
+  `__pydantic_extra__` with no warn and no failure. They now share the JSON
+  extras policy (`warn` / `strict` / `lenient`), keyed per bulk endpoint +
+  field set. Invalid cells still retry URL fields, then **skip the row** in
+  `lenient`/`warn` (logged) or **fail the request** in `strict`. Default mode
+  is unchanged (`warn`). `rating-bulk` scores coerce only whole values
+  (`"3.0"` → `3`); `"3.5"` is no longer truncated to `3`.
+
 - **CI: post-release main→dev sync auto-merges and no longer needs admin bypass.**
   Sync-Main-to-Dev enables `gh pr merge --auto --merge` on the history-reachability
   PR so green Test-Matrix lands it without a human. Squash is never requested

--- a/fmp_data/batch/_csv_utils.py
+++ b/fmp_data/batch/_csv_utils.py
@@ -8,6 +8,9 @@ from typing import Any, TypeVar, get_args, get_origin
 from pydantic import AnyHttpUrl, BaseModel, HttpUrl
 from pydantic import ValidationError as PydanticValidationError
 
+from fmp_data.base import BaseClient, ValidationMode
+from fmp_data.exceptions import ValidationError
+
 logger = logging.getLogger(__name__)
 ModelT = TypeVar("ModelT", bound=BaseModel)
 
@@ -41,44 +44,102 @@ def parse_csv_rows(raw: bytes) -> list[dict[str, Any]]:
     return rows
 
 
-def parse_csv_models(raw: bytes, model: type[ModelT]) -> list[ModelT]:
+def parse_csv_models(
+    raw: bytes,
+    model: type[ModelT],
+    *,
+    validation_mode: ValidationMode = "warn",
+    endpoint_name: str | None = None,
+) -> list[ModelT]:
     """
     Convert CSV rows to Pydantic models.
 
-    Handles URL validation errors by retrying with None for failed URL fields.
+    Unknown headers follow the same ``FMP_VALIDATION_MODE`` policy as JSON
+    extras (``warn`` / ``strict`` / ``lenient``), keyed per endpoint + field
+    set. Invalid cells keep the existing URL-field retry, then either skip the
+    row (``lenient`` / ``warn``) or fail the request (``strict``).
 
     Args:
         raw: Raw CSV data as bytes
         model: Pydantic model class to validate against
+        validation_mode: Same policy as JSON (``FMP_VALIDATION_MODE``)
+        endpoint_name: Bulk endpoint name used to key unknown-field warnings
 
     Returns:
-        List of validated model instances (invalid rows are logged and skipped)
+        List of validated model instances
     """
+    return parse_csv_model_rows(
+        parse_csv_rows(raw),
+        model,
+        validation_mode=validation_mode,
+        endpoint_name=endpoint_name,
+    )
+
+
+def parse_csv_model_rows(
+    rows: list[dict[str, Any]],
+    model: type[ModelT],
+    *,
+    validation_mode: ValidationMode = "warn",
+    endpoint_name: str | None = None,
+) -> list[ModelT]:
+    """Validate already-parsed CSV dict rows with the JSON extras policy."""
+    source = endpoint_name or model.__name__
     results: list[ModelT] = []
     url_fields = get_url_fields(model)
-    for row in parse_csv_rows(raw):
+    for row in rows:
         try:
-            results.append(model.model_validate(row))
+            results.append(
+                _validate_csv_row(
+                    row,
+                    model,
+                    url_fields=url_fields,
+                    validation_mode=validation_mode,
+                    endpoint_name=source,
+                )
+            )
         except PydanticValidationError as exc:
-            if url_fields:
-                retry_row = dict(row)
-                for error in exc.errors():
-                    if not error.get("loc"):
-                        continue
-                    field = error["loc"][0]
-                    if isinstance(field, str) and field in url_fields:
-                        retry_row[field] = None
-                try:
-                    results.append(model.model_validate(retry_row))
-                    continue
-                except PydanticValidationError:
-                    pass
+            if validation_mode == "strict":
+                raise ValidationError(
+                    f"Invalid CSV row for endpoint '{source}': {exc}"
+                ) from exc
             logger.warning(
                 "Skipping invalid %s row: %s",
                 model.__name__,
                 exc,
             )
     return results
+
+
+def _validate_csv_row(
+    row: dict[str, Any],
+    model: type[ModelT],
+    *,
+    url_fields: set[str],
+    validation_mode: ValidationMode,
+    endpoint_name: str,
+) -> ModelT:
+    """Validate one row, retrying failed URL fields as ``None``."""
+    try:
+        parsed = BaseClient._validate_model(endpoint_name, model, row, validation_mode)
+    except PydanticValidationError as exc:
+        if not url_fields:
+            raise
+        retry_row = dict(row)
+        retried = False
+        for error in exc.errors():
+            if not error.get("loc"):
+                continue
+            field = error["loc"][0]
+            if isinstance(field, str) and field in url_fields:
+                retry_row[field] = None
+                retried = True
+        if not retried:
+            raise
+        parsed = BaseClient._validate_model(
+            endpoint_name, model, retry_row, validation_mode
+        )
+    return parsed  # type: ignore[return-value]
 
 
 def get_url_fields(model: type[BaseModel]) -> set[str]:

--- a/fmp_data/batch/async_client.py
+++ b/fmp_data/batch/async_client.py
@@ -2,14 +2,16 @@
 """Async client for batch data endpoints."""
 
 from datetime import date
-import logging
 from typing import Any, TypeVar
 
 from pydantic import BaseModel
-from pydantic import ValidationError as PydanticValidationError
 
 from fmp_data.base import AsyncEndpointGroup
-from fmp_data.batch._csv_utils import parse_csv_models, parse_csv_rows
+from fmp_data.batch._csv_utils import (
+    parse_csv_model_rows,
+    parse_csv_models,
+    parse_csv_rows,
+)
 from fmp_data.batch.endpoints import (
     BALANCE_SHEET_STATEMENT_BULK,
     BALANCE_SHEET_STATEMENT_GROWTH_BULK,
@@ -72,7 +74,6 @@ from fmp_data.fundamental.models import (
 from fmp_data.investment.models import ETFHolding
 from fmp_data.models import Endpoint
 
-logger = logging.getLogger(__name__)
 ModelT = TypeVar("ModelT", bound=BaseModel)
 
 
@@ -94,6 +95,16 @@ class AsyncBatchClient(AsyncEndpointGroup):
                 actual_type=type(result).__name__,
             )
         return result
+
+    def _parse_csv(
+        self, raw: bytes, model: type[ModelT], endpoint: Endpoint
+    ) -> list[ModelT]:
+        return parse_csv_models(
+            raw,
+            model,
+            validation_mode=self.client.config.validation_mode,
+            endpoint_name=endpoint.name,
+        )
 
     async def get_quotes(self, symbols: list[str]) -> list[BatchQuote]:
         """Get real-time quotes for multiple symbols
@@ -268,89 +279,83 @@ class AsyncBatchClient(AsyncEndpointGroup):
     async def get_profile_bulk(self, part: str) -> list[CompanyProfile]:
         """Get company profile data in bulk"""
         raw = await self._request_csv(PROFILE_BULK, part=part)
-        return parse_csv_models(raw, CompanyProfile)
+        return self._parse_csv(raw, CompanyProfile, PROFILE_BULK)
 
     async def get_dcf_bulk(self) -> list[DCF]:
         """Get discounted cash flow valuations in bulk"""
         raw = await self._request_csv(DCF_BULK)
         rows = parse_csv_rows(raw)
-        results: list[DCF] = []
         for row in rows:
             if "Stock Price" in row and "stockPrice" not in row:
                 row["stockPrice"] = row.pop("Stock Price")
-            try:
-                results.append(DCF.model_validate(row))
-            except PydanticValidationError as exc:
-                logger.warning("Skipping invalid DCF row %s: %s", row, exc)
-        return results
+        return parse_csv_model_rows(
+            rows,
+            DCF,
+            validation_mode=self.client.config.validation_mode,
+            endpoint_name=DCF_BULK.name,
+        )
 
     async def get_rating_bulk(self) -> list[CompanyRating]:
         """Get stock ratings in bulk"""
         raw = await self._request_csv(RATING_BULK)
-        return parse_csv_models(raw, CompanyRating)
+        return self._parse_csv(raw, CompanyRating, RATING_BULK)
 
     async def get_scores_bulk(self) -> list[FinancialScore]:
         """Get financial scores in bulk"""
         raw = await self._request_csv(SCORES_BULK)
-        return parse_csv_models(raw, FinancialScore)
+        return self._parse_csv(raw, FinancialScore, SCORES_BULK)
 
     async def get_ratios_ttm_bulk(self) -> list[FinancialRatiosTTM]:
         """Get trailing twelve month financial ratios in bulk"""
         raw = await self._request_csv(RATIOS_TTM_BULK)
-        return parse_csv_models(raw, FinancialRatiosTTM)
+        return self._parse_csv(raw, FinancialRatiosTTM, RATIOS_TTM_BULK)
 
     async def get_price_target_summary_bulk(self) -> list[PriceTargetSummary]:
         """Get bulk price target summaries"""
         raw = await self._request_csv(PRICE_TARGET_SUMMARY_BULK)
-        return parse_csv_models(raw, PriceTargetSummary)
+        return self._parse_csv(raw, PriceTargetSummary, PRICE_TARGET_SUMMARY_BULK)
 
     async def get_etf_holder_bulk(self, part: str) -> list[ETFHolding]:
         """Get bulk ETF holdings"""
         raw = await self._request_csv(ETF_HOLDER_BULK, part=part)
-        return parse_csv_models(raw, ETFHolding)
+        return self._parse_csv(raw, ETFHolding, ETF_HOLDER_BULK)
 
     async def get_upgrades_downgrades_consensus_bulk(
         self,
     ) -> list[UpgradeDowngradeConsensus]:
         """Get bulk upgrades/downgrades consensus data"""
         raw = await self._request_csv(UPGRADES_DOWNGRADES_CONSENSUS_BULK)
-        # Filter for rows with symbols before parsing to models
         rows = [row for row in parse_csv_rows(raw) if row.get("symbol")]
-        # Use parse_csv_models pattern for graceful error handling
-        results: list[UpgradeDowngradeConsensus] = []
-        for row in rows:
-            try:
-                results.append(UpgradeDowngradeConsensus.model_validate(row))
-            except PydanticValidationError as e:
-                symbol = row.get("symbol", "unknown")
-                self.client.logger.warning(
-                    f"Failed to parse upgrade/downgrade row for {symbol}: {e}"
-                )
-        return results
+        return parse_csv_model_rows(
+            rows,
+            UpgradeDowngradeConsensus,
+            validation_mode=self.client.config.validation_mode,
+            endpoint_name=UPGRADES_DOWNGRADES_CONSENSUS_BULK.name,
+        )
 
     async def get_key_metrics_ttm_bulk(self) -> list[KeyMetricsTTM]:
         """Get bulk trailing twelve month key metrics"""
         raw = await self._request_csv(KEY_METRICS_TTM_BULK)
-        return parse_csv_models(raw, KeyMetricsTTM)
+        return self._parse_csv(raw, KeyMetricsTTM, KEY_METRICS_TTM_BULK)
 
     async def get_peers_bulk(self) -> list[PeersBulk]:
         """Get bulk peer lists"""
         raw = await self._request_csv(PEERS_BULK)
-        return parse_csv_models(raw, PeersBulk)
+        return self._parse_csv(raw, PeersBulk, PEERS_BULK)
 
     async def get_earnings_surprises_bulk(
         self, year: int
     ) -> list[EarningsSurpriseBulk]:
         """Get bulk earnings surprises for a given year"""
         raw = await self._request_csv(EARNINGS_SURPRISES_BULK, year=year)
-        return parse_csv_models(raw, EarningsSurpriseBulk)
+        return self._parse_csv(raw, EarningsSurpriseBulk, EARNINGS_SURPRISES_BULK)
 
     async def get_income_statement_bulk(
         self, year: int, period: str
     ) -> list[IncomeStatement]:
         """Get bulk income statements"""
         raw = await self._request_csv(INCOME_STATEMENT_BULK, year=year, period=period)
-        return parse_csv_models(raw, IncomeStatement)
+        return self._parse_csv(raw, IncomeStatement, INCOME_STATEMENT_BULK)
 
     async def get_income_statement_growth_bulk(
         self, year: int, period: str
@@ -359,7 +364,7 @@ class AsyncBatchClient(AsyncEndpointGroup):
         raw = await self._request_csv(
             INCOME_STATEMENT_GROWTH_BULK, year=year, period=period
         )
-        return parse_csv_models(raw, FinancialGrowth)
+        return self._parse_csv(raw, FinancialGrowth, INCOME_STATEMENT_GROWTH_BULK)
 
     async def get_balance_sheet_bulk(
         self, year: int, period: str
@@ -368,7 +373,7 @@ class AsyncBatchClient(AsyncEndpointGroup):
         raw = await self._request_csv(
             BALANCE_SHEET_STATEMENT_BULK, year=year, period=period
         )
-        return parse_csv_models(raw, BalanceSheet)
+        return self._parse_csv(raw, BalanceSheet, BALANCE_SHEET_STATEMENT_BULK)
 
     async def get_balance_sheet_growth_bulk(
         self, year: int, period: str
@@ -377,7 +382,9 @@ class AsyncBatchClient(AsyncEndpointGroup):
         raw = await self._request_csv(
             BALANCE_SHEET_STATEMENT_GROWTH_BULK, year=year, period=period
         )
-        return parse_csv_models(raw, FinancialGrowth)
+        return self._parse_csv(
+            raw, FinancialGrowth, BALANCE_SHEET_STATEMENT_GROWTH_BULK
+        )
 
     async def get_cash_flow_bulk(
         self, year: int, period: str
@@ -386,7 +393,7 @@ class AsyncBatchClient(AsyncEndpointGroup):
         raw = await self._request_csv(
             CASH_FLOW_STATEMENT_BULK, year=year, period=period
         )
-        return parse_csv_models(raw, CashFlowStatement)
+        return self._parse_csv(raw, CashFlowStatement, CASH_FLOW_STATEMENT_BULK)
 
     async def get_cash_flow_growth_bulk(
         self, year: int, period: str
@@ -395,10 +402,10 @@ class AsyncBatchClient(AsyncEndpointGroup):
         raw = await self._request_csv(
             CASH_FLOW_STATEMENT_GROWTH_BULK, year=year, period=period
         )
-        return parse_csv_models(raw, FinancialGrowth)
+        return self._parse_csv(raw, FinancialGrowth, CASH_FLOW_STATEMENT_GROWTH_BULK)
 
     async def get_eod_bulk(self, target_date: date) -> list[EODBulk]:
         """Get bulk end-of-day prices"""
         date_param = target_date.strftime("%Y-%m-%d")
         raw = await self._request_csv(EOD_BULK, date=date_param)
-        return parse_csv_models(raw, EODBulk)
+        return self._parse_csv(raw, EODBulk, EOD_BULK)

--- a/fmp_data/batch/client.py
+++ b/fmp_data/batch/client.py
@@ -1,13 +1,15 @@
 # fmp_data/batch/client.py
 from datetime import date
-import logging
 from typing import Any, TypeVar
 
 from pydantic import BaseModel
-from pydantic import ValidationError as PydanticValidationError
 
 from fmp_data.base import EndpointGroup
-from fmp_data.batch._csv_utils import parse_csv_models, parse_csv_rows
+from fmp_data.batch._csv_utils import (
+    parse_csv_model_rows,
+    parse_csv_models,
+    parse_csv_rows,
+)
 from fmp_data.batch.endpoints import (
     BALANCE_SHEET_STATEMENT_BULK,
     BALANCE_SHEET_STATEMENT_GROWTH_BULK,
@@ -70,7 +72,6 @@ from fmp_data.fundamental.models import (
 from fmp_data.investment.models import ETFHolding
 from fmp_data.models import Endpoint
 
-logger = logging.getLogger(__name__)
 ModelT = TypeVar("ModelT", bound=BaseModel)
 
 
@@ -92,6 +93,16 @@ class BatchClient(EndpointGroup):
                 actual_type=type(result).__name__,
             )
         return result
+
+    def _parse_csv(
+        self, raw: bytes, model: type[ModelT], endpoint: Endpoint
+    ) -> list[ModelT]:
+        return parse_csv_models(
+            raw,
+            model,
+            validation_mode=self.client.config.validation_mode,
+            endpoint_name=endpoint.name,
+        )
 
     def get_quotes(self, symbols: list[str]) -> list[BatchQuote]:
         """Get real-time quotes for multiple symbols
@@ -252,46 +263,46 @@ class BatchClient(EndpointGroup):
     def get_profile_bulk(self, part: str) -> list[CompanyProfile]:
         """Get company profile data in bulk"""
         raw = self._request_csv(PROFILE_BULK, part=part)
-        return parse_csv_models(raw, CompanyProfile)
+        return self._parse_csv(raw, CompanyProfile, PROFILE_BULK)
 
     def get_dcf_bulk(self) -> list[DCF]:
         """Get discounted cash flow valuations in bulk"""
         raw = self._request_csv(DCF_BULK)
         rows = parse_csv_rows(raw)
-        results: list[DCF] = []
         for row in rows:
             if "Stock Price" in row and "stockPrice" not in row:
                 row["stockPrice"] = row.pop("Stock Price")
-            try:
-                results.append(DCF.model_validate(row))
-            except PydanticValidationError as exc:
-                logger.warning("Skipping invalid DCF row %s: %s", row, exc)
-        return results
+        return parse_csv_model_rows(
+            rows,
+            DCF,
+            validation_mode=self.client.config.validation_mode,
+            endpoint_name=DCF_BULK.name,
+        )
 
     def get_rating_bulk(self) -> list[CompanyRating]:
         """Get stock ratings in bulk"""
         raw = self._request_csv(RATING_BULK)
-        return parse_csv_models(raw, CompanyRating)
+        return self._parse_csv(raw, CompanyRating, RATING_BULK)
 
     def get_scores_bulk(self) -> list[FinancialScore]:
         """Get financial scores in bulk"""
         raw = self._request_csv(SCORES_BULK)
-        return parse_csv_models(raw, FinancialScore)
+        return self._parse_csv(raw, FinancialScore, SCORES_BULK)
 
     def get_ratios_ttm_bulk(self) -> list[FinancialRatiosTTM]:
         """Get trailing twelve month financial ratios in bulk"""
         raw = self._request_csv(RATIOS_TTM_BULK)
-        return parse_csv_models(raw, FinancialRatiosTTM)
+        return self._parse_csv(raw, FinancialRatiosTTM, RATIOS_TTM_BULK)
 
     def get_price_target_summary_bulk(self) -> list[PriceTargetSummary]:
         """Get bulk price target summaries"""
         raw = self._request_csv(PRICE_TARGET_SUMMARY_BULK)
-        return parse_csv_models(raw, PriceTargetSummary)
+        return self._parse_csv(raw, PriceTargetSummary, PRICE_TARGET_SUMMARY_BULK)
 
     def get_etf_holder_bulk(self, part: str) -> list[ETFHolding]:
         """Get bulk ETF holdings"""
         raw = self._request_csv(ETF_HOLDER_BULK, part=part)
-        return parse_csv_models(raw, ETFHolding)
+        return self._parse_csv(raw, ETFHolding, ETF_HOLDER_BULK)
 
     def get_upgrades_downgrades_consensus_bulk(
         self,
@@ -299,41 +310,46 @@ class BatchClient(EndpointGroup):
         """Get bulk upgrades/downgrades consensus data"""
         raw = self._request_csv(UPGRADES_DOWNGRADES_CONSENSUS_BULK)
         rows = [row for row in parse_csv_rows(raw) if row.get("symbol")]
-        return [UpgradeDowngradeConsensus.model_validate(row) for row in rows]
+        return parse_csv_model_rows(
+            rows,
+            UpgradeDowngradeConsensus,
+            validation_mode=self.client.config.validation_mode,
+            endpoint_name=UPGRADES_DOWNGRADES_CONSENSUS_BULK.name,
+        )
 
     def get_key_metrics_ttm_bulk(self) -> list[KeyMetricsTTM]:
         """Get bulk trailing twelve month key metrics"""
         raw = self._request_csv(KEY_METRICS_TTM_BULK)
-        return parse_csv_models(raw, KeyMetricsTTM)
+        return self._parse_csv(raw, KeyMetricsTTM, KEY_METRICS_TTM_BULK)
 
     def get_peers_bulk(self) -> list[PeersBulk]:
         """Get bulk peer lists"""
         raw = self._request_csv(PEERS_BULK)
-        return parse_csv_models(raw, PeersBulk)
+        return self._parse_csv(raw, PeersBulk, PEERS_BULK)
 
     def get_earnings_surprises_bulk(self, year: int) -> list[EarningsSurpriseBulk]:
         """Get bulk earnings surprises for a given year"""
         raw = self._request_csv(EARNINGS_SURPRISES_BULK, year=year)
-        return parse_csv_models(raw, EarningsSurpriseBulk)
+        return self._parse_csv(raw, EarningsSurpriseBulk, EARNINGS_SURPRISES_BULK)
 
     def get_income_statement_bulk(
         self, year: int, period: str
     ) -> list[IncomeStatement]:
         """Get bulk income statements"""
         raw = self._request_csv(INCOME_STATEMENT_BULK, year=year, period=period)
-        return parse_csv_models(raw, IncomeStatement)
+        return self._parse_csv(raw, IncomeStatement, INCOME_STATEMENT_BULK)
 
     def get_income_statement_growth_bulk(
         self, year: int, period: str
     ) -> list[FinancialGrowth]:
         """Get bulk income statement growth data"""
         raw = self._request_csv(INCOME_STATEMENT_GROWTH_BULK, year=year, period=period)
-        return parse_csv_models(raw, FinancialGrowth)
+        return self._parse_csv(raw, FinancialGrowth, INCOME_STATEMENT_GROWTH_BULK)
 
     def get_balance_sheet_bulk(self, year: int, period: str) -> list[BalanceSheet]:
         """Get bulk balance sheet statements"""
         raw = self._request_csv(BALANCE_SHEET_STATEMENT_BULK, year=year, period=period)
-        return parse_csv_models(raw, BalanceSheet)
+        return self._parse_csv(raw, BalanceSheet, BALANCE_SHEET_STATEMENT_BULK)
 
     def get_balance_sheet_growth_bulk(
         self, year: int, period: str
@@ -342,12 +358,14 @@ class BatchClient(EndpointGroup):
         raw = self._request_csv(
             BALANCE_SHEET_STATEMENT_GROWTH_BULK, year=year, period=period
         )
-        return parse_csv_models(raw, FinancialGrowth)
+        return self._parse_csv(
+            raw, FinancialGrowth, BALANCE_SHEET_STATEMENT_GROWTH_BULK
+        )
 
     def get_cash_flow_bulk(self, year: int, period: str) -> list[CashFlowStatement]:
         """Get bulk cash flow statements"""
         raw = self._request_csv(CASH_FLOW_STATEMENT_BULK, year=year, period=period)
-        return parse_csv_models(raw, CashFlowStatement)
+        return self._parse_csv(raw, CashFlowStatement, CASH_FLOW_STATEMENT_BULK)
 
     def get_cash_flow_growth_bulk(
         self, year: int, period: str
@@ -356,10 +374,10 @@ class BatchClient(EndpointGroup):
         raw = self._request_csv(
             CASH_FLOW_STATEMENT_GROWTH_BULK, year=year, period=period
         )
-        return parse_csv_models(raw, FinancialGrowth)
+        return self._parse_csv(raw, FinancialGrowth, CASH_FLOW_STATEMENT_GROWTH_BULK)
 
     def get_eod_bulk(self, target_date: date) -> list[EODBulk]:
         """Get bulk end-of-day prices"""
         date_param = target_date.strftime("%Y-%m-%d")
         raw = self._request_csv(EOD_BULK, date=date_param)
-        return parse_csv_models(raw, EODBulk)
+        return self._parse_csv(raw, EODBulk, EOD_BULK)

--- a/fmp_data/config.py
+++ b/fmp_data/config.py
@@ -217,9 +217,9 @@ class ClientConfig(BaseModel):
     validation_mode: Literal["lenient", "warn", "strict"] = Field(
         default="warn",
         description=(
-            "Response validation policy. "
+            "Response validation policy for JSON and bulk CSV extras. "
             "'lenient' ignores unknown fields, "
-            "'warn' logs unknown fields, "
+            "'warn' logs unknown fields once per endpoint+field set, "
             "'strict' raises on unknown fields."
         ),
     )

--- a/fmp_data/fundamental/models.py
+++ b/fmp_data/fundamental/models.py
@@ -1,5 +1,6 @@
 # fmp_data/fundamental/models.py
 from datetime import datetime
+from decimal import Decimal, InvalidOperation
 import math
 from typing import Annotated, Any
 
@@ -47,17 +48,23 @@ def coerce_rating_score(value: Any) -> Any:
         return None
     if isinstance(value, bool):
         return value
-    if isinstance(value, int | float):
-        return _integral_int(float(value), value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return _integral_int(value, value)
     if isinstance(value, str):
         stripped = value.strip()
         if not stripped:
             return None
         try:
-            number = float(stripped)
-        except ValueError:
+            number = Decimal(stripped)
+        except InvalidOperation:
             return value
-        return _integral_int(number, value)
+        if not number.is_finite():
+            return value
+        if number != number.to_integral_value():
+            raise ValueError(f"rating score must be a whole number, got {value!r}")
+        return int(number)
     return value
 
 

--- a/fmp_data/fundamental/models.py
+++ b/fmp_data/fundamental/models.py
@@ -24,23 +24,30 @@ default_model_config = ConfigDict(
 )
 
 
+def _integral_int(number: float, original: Any) -> Any:
+    """Return ``int(number)`` only when ``number`` is a finite whole value."""
+    if not math.isfinite(number):
+        return original
+    if number != int(number):
+        raise ValueError(f"rating score must be a whole number, got {original!r}")
+    return int(number)
+
+
 def coerce_rating_score(value: Any) -> Any:
     """Coerce rating-bulk score cells to int.
 
     ``rating-bulk`` CSV may emit a whole score as ``"3"`` or ``"3.0"``. A
     strict ``int`` field rejects the latter and ``parse_csv_models`` then
     skips the entire company row. Empty cells are already ``None``.
-    Non-numeric / non-finite values pass through so they still fail
-    validation instead of becoming ``0``.
+    Non-numeric, non-finite, or non-integral values (``"3.5"``) pass
+    through so they still fail validation instead of being truncated.
     """
     if value is None:
         return None
+    if isinstance(value, bool):
+        return value
     if isinstance(value, int | float):
-        if isinstance(value, bool):
-            return value
-        if isinstance(value, float) and not math.isfinite(value):
-            return value
-        return int(value)
+        return _integral_int(float(value), value)
     if isinstance(value, str):
         stripped = value.strip()
         if not stripped:
@@ -49,9 +56,7 @@ def coerce_rating_score(value: Any) -> Any:
             number = float(stripped)
         except ValueError:
             return value
-        if not math.isfinite(number):
-            return value
-        return int(number)
+        return _integral_int(number, value)
     return value
 
 

--- a/fmp_data/fundamental/models.py
+++ b/fmp_data/fundamental/models.py
@@ -39,8 +39,9 @@ def coerce_rating_score(value: Any) -> Any:
     ``rating-bulk`` CSV may emit a whole score as ``"3"`` or ``"3.0"``. A
     strict ``int`` field rejects the latter and ``parse_csv_models`` then
     skips the entire company row. Empty cells are already ``None``.
-    Non-numeric, non-finite, or non-integral values (``"3.5"``) pass
-    through so they still fail validation instead of being truncated.
+    Non-integral values (``"3.5"``) raise so they fail validation instead
+    of being truncated. Non-numeric or non-finite values pass through and
+    still fail the ``int`` field.
     """
     if value is None:
         return None

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -256,6 +256,114 @@ class TestBatchClient:
         assert rating.price_to_book_score == 6
         assert not rating.__pydantic_extra__
 
+    def test_parse_csv_models_unknown_header_warns_once(self, caplog):
+        """Unknown bulk headers honor FMP_VALIDATION_MODE=warn (#232)."""
+        import logging
+
+        from fmp_data.base import _extra_field_warnings_seen
+
+        warning_key = ("rating-bulk", ("overallScore",))
+        _extra_field_warnings_seen.discard(warning_key)
+        csv_text = "symbol,date,rating,overallScore\nAAPL,2026-08-12,A-,7\n"
+
+        with caplog.at_level(logging.WARNING, logger="fmp_data.base"):
+            first = parse_csv_models(
+                csv_text.encode("utf-8"),
+                CompanyRating,
+                validation_mode="warn",
+                endpoint_name="rating-bulk",
+            )
+            second = parse_csv_models(
+                csv_text.encode("utf-8"),
+                CompanyRating,
+                validation_mode="warn",
+                endpoint_name="rating-bulk",
+            )
+
+        assert len(first) == 1
+        assert first[0].__pydantic_extra__ is not None
+        assert first[0].__pydantic_extra__["overallScore"] == "7"
+        assert len(second) == 1
+        assert caplog.text.count("Unknown response fields detected") == 1
+        _extra_field_warnings_seen.discard(warning_key)
+
+    def test_parse_csv_models_unknown_header_strict_raises(self):
+        """Unknown bulk headers fail closed under FMP_VALIDATION_MODE=strict."""
+        from fmp_data.exceptions import ValidationError
+
+        csv_text = "symbol,date,rating,overallScore\nAAPL,2026-08-12,A-,7\n"
+        with pytest.raises(ValidationError, match="Unexpected fields"):
+            parse_csv_models(
+                csv_text.encode("utf-8"),
+                CompanyRating,
+                validation_mode="strict",
+                endpoint_name="rating-bulk",
+            )
+
+    def test_parse_csv_models_unknown_header_lenient_silent(self, caplog):
+        """Lenient mode keeps extras without warning."""
+        import logging
+
+        csv_text = "symbol,date,rating,overallScore\nAAPL,2026-08-12,A-,7\n"
+        with caplog.at_level(logging.WARNING, logger="fmp_data.base"):
+            results = parse_csv_models(
+                csv_text.encode("utf-8"),
+                CompanyRating,
+                validation_mode="lenient",
+                endpoint_name="rating-bulk",
+            )
+
+        assert len(results) == 1
+        assert results[0].__pydantic_extra__ is not None
+        assert results[0].__pydantic_extra__["overallScore"] == "7"
+        assert "Unknown response fields detected" not in caplog.text
+
+    def test_parse_csv_models_invalid_cell_strict_raises(self):
+        """A bad cell fails the request in strict mode instead of dropping a row."""
+        from pydantic import BaseModel
+
+        from fmp_data.exceptions import ValidationError
+
+        class SimpleRow(BaseModel):
+            symbol: str
+            value: int
+
+        csv_text = "symbol,value\nAAPL,not-a-number\n"
+        with pytest.raises(ValidationError, match="Invalid CSV row"):
+            parse_csv_models(
+                csv_text.encode("utf-8"),
+                SimpleRow,
+                validation_mode="strict",
+                endpoint_name="dummy-bulk",
+            )
+
+    def test_parse_csv_models_fractional_rating_score_still_yields_row(self):
+        """A coercible ``\"3.0\"`` score cell still produces a row (#232)."""
+        csv_text = (
+            "symbol,date,rating,discountedCashFlowScore\nAAPL,2026-08-12,A-,3.0\n"
+        )
+        results = parse_csv_models(csv_text.encode("utf-8"), CompanyRating)
+        assert len(results) == 1
+        assert results[0].discounted_cash_flow_score == 3
+
+    def test_parse_csv_models_non_integral_score_skips_row(self, caplog):
+        """Non-integral scores must not truncate; warn mode skips the row."""
+        import logging
+
+        csv_text = (
+            "symbol,date,rating,discountedCashFlowScore\nAAPL,2026-08-12,A-,3.5\n"
+        )
+        with caplog.at_level(logging.WARNING, logger="fmp_data.batch._csv_utils"):
+            results = parse_csv_models(
+                csv_text.encode("utf-8"),
+                CompanyRating,
+                validation_mode="warn",
+                endpoint_name="rating-bulk",
+            )
+
+        assert results == []
+        assert "Skipping invalid CompanyRating row" in caplog.text
+
     def test_parse_csv_rows_empty(self):
         """Empty CSV input returns no rows."""
         assert parse_csv_rows(b"") == []
@@ -660,28 +768,28 @@ class TestAsyncBatchClient:
     """Tests for async batch client validation error handling"""
 
     @pytest.mark.asyncio
-    async def test_upgrades_downgrades_consensus_bulk_with_invalid_rows(self):
+    async def test_upgrades_downgrades_consensus_bulk_with_invalid_rows(self, caplog):
         """Test async upgrades/downgrades consensus handles validation errors"""
+        import logging
+
         from fmp_data.batch.async_client import AsyncBatchClient
+        from fmp_data.config import ClientConfig
 
-        # Create mock client
         mock_client = Mock()
-        mock_client.logger = Mock()
+        mock_client.config = ClientConfig(api_key="test", validation_mode="warn")
+        mock_client.request_async = AsyncMock()
 
-        # Mock CSV response with one invalid row (invalid number format)
         csv_text = (
             "symbol,strongBuy,buy,hold,sell,strongSell,consensus\n"
-            "INVALID,NOT_A_NUMBER,1,1,0,0,Buy\n"  # Invalid: strongBuy should be int
+            "INVALID,NOT_A_NUMBER,1,1,0,0,Buy\n"
             "AAPL,1,29,11,4,0,Buy\n"
         )
-        # Async client expects bytes
-        mock_client.request_async = AsyncMock(return_value=csv_text.encode("utf-8"))
+        mock_client.request_async.return_value = csv_text.encode("utf-8")
 
         async_batch = AsyncBatchClient(mock_client)
-        results = await async_batch.get_upgrades_downgrades_consensus_bulk()
+        with caplog.at_level(logging.WARNING, logger="fmp_data.batch._csv_utils"):
+            results = await async_batch.get_upgrades_downgrades_consensus_bulk()
 
-        # Should skip invalid row and return only valid one
         assert len(results) == 1
         assert results[0].symbol == "AAPL"
-        # Should have logged a warning about the invalid row
-        mock_client.logger.warning.assert_called()
+        assert "Skipping invalid" in caplog.text

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -256,17 +256,17 @@ class TestBatchClient:
         assert rating.price_to_book_score == 6
         assert not rating.__pydantic_extra__
 
-    def test_parse_csv_models_unknown_header_warns_once(self, caplog):
+    def test_parse_csv_models_unknown_header_warns_once(self):
         """Unknown bulk headers honor FMP_VALIDATION_MODE=warn (#232)."""
-        import logging
-
         from fmp_data.base import _extra_field_warnings_seen
 
         warning_key = ("rating-bulk", ("overallScore",))
         _extra_field_warnings_seen.discard(warning_key)
         csv_text = "symbol,date,rating,overallScore\nAAPL,2026-08-12,A-,7\n"
 
-        with caplog.at_level(logging.WARNING, logger="fmp_data.base"):
+        # Patch the module logger. FMPLogger().get_logger(__name__) is not
+        # logging.getLogger("fmp_data.base") — caplog on that name stays empty.
+        with patch("fmp_data.base.logger") as mock_logger:
             first = parse_csv_models(
                 csv_text.encode("utf-8"),
                 CompanyRating,
@@ -284,7 +284,10 @@ class TestBatchClient:
         assert first[0].__pydantic_extra__ is not None
         assert first[0].__pydantic_extra__["overallScore"] == "7"
         assert len(second) == 1
-        assert caplog.text.count("Unknown response fields detected") == 1
+        assert mock_logger.warning.call_count == 1
+        assert mock_logger.warning.call_args.args[0] == (
+            "Unknown response fields detected"
+        )
         _extra_field_warnings_seen.discard(warning_key)
 
     def test_parse_csv_models_unknown_header_strict_raises(self):
@@ -300,12 +303,10 @@ class TestBatchClient:
                 endpoint_name="rating-bulk",
             )
 
-    def test_parse_csv_models_unknown_header_lenient_silent(self, caplog):
+    def test_parse_csv_models_unknown_header_lenient_silent(self):
         """Lenient mode keeps extras without warning."""
-        import logging
-
         csv_text = "symbol,date,rating,overallScore\nAAPL,2026-08-12,A-,7\n"
-        with caplog.at_level(logging.WARNING, logger="fmp_data.base"):
+        with patch("fmp_data.base.logger") as mock_logger:
             results = parse_csv_models(
                 csv_text.encode("utf-8"),
                 CompanyRating,
@@ -316,7 +317,7 @@ class TestBatchClient:
         assert len(results) == 1
         assert results[0].__pydantic_extra__ is not None
         assert results[0].__pydantic_extra__["overallScore"] == "7"
-        assert "Unknown response fields detected" not in caplog.text
+        mock_logger.warning.assert_not_called()
 
     def test_parse_csv_models_invalid_cell_strict_raises(self):
         """A bad cell fails the request in strict mode instead of dropping a row."""

--- a/tests/unit/test_fundamental.py
+++ b/tests/unit/test_fundamental.py
@@ -371,6 +371,20 @@ class TestFundamentalEndpoints(unittest.TestCase):
                 }
             )
 
+    def test_company_rating_rejects_high_precision_fractional_score_text(self):
+        """float() would round this to 3.0; Decimal must still reject it."""
+        from pydantic import ValidationError as PydanticValidationError
+
+        with self.assertRaises(PydanticValidationError):
+            CompanyRating.model_validate(
+                {
+                    "symbol": "AAPL",
+                    "date": "2026-08-12",
+                    "rating": "A-",
+                    "discountedCashFlowScore": "3.0000000000000001",
+                }
+            )
+
     def test_get_financial_reports_dates(self):
         """Test getting financial report dates"""
         # Configure mock to return model instances

--- a/tests/unit/test_fundamental.py
+++ b/tests/unit/test_fundamental.py
@@ -348,6 +348,29 @@ class TestFundamentalEndpoints(unittest.TestCase):
         )
         self.assertEqual(rating.discounted_cash_flow_score, 3)
 
+    def test_company_rating_rejects_non_integral_score(self):
+        """\"3.5\" must not silently become 3 (#231 review / #232)."""
+        from pydantic import ValidationError as PydanticValidationError
+
+        with self.assertRaises(PydanticValidationError):
+            CompanyRating.model_validate(
+                {
+                    "symbol": "AAPL",
+                    "date": "2026-08-12",
+                    "rating": "A-",
+                    "discountedCashFlowScore": "3.5",
+                }
+            )
+        with self.assertRaises(PydanticValidationError):
+            CompanyRating.model_validate(
+                {
+                    "symbol": "AAPL",
+                    "date": "2026-08-12",
+                    "rating": "A-",
+                    "discountedCashFlowScore": 3.5,
+                }
+            )
+
     def test_get_financial_reports_dates(self):
         """Test getting financial report dates"""
         # Configure mock to return model instances


### PR DESCRIPTION
Closes #232.

Follow-up from the #231 review: CSV extras were invisible to `FMP_VALIDATION_MODE` because `parse_csv_models` called `model.model_validate` directly.

## Policy (explicit)

| Kind | `lenient` | `warn` (default) | `strict` |
|---|---|---|---|
| Unknown header / extra column | keep on the model (`extra="allow"`) | keep + log once per `(endpoint, fields)` | raise `ValidationError` |
| Invalid cell (after URL-field retry) | skip row + warning | skip row + warning | fail the request |

Skip-the-row stays the non-strict policy so one bad cell does not drop a 10k-row bulk download. Strict is fail-closed.

## Also

- Sync + async batch clients pass `client.config.validation_mode` and the bulk `Endpoint.name`.
- DCF and upgrades-consensus bulk go through the same helper (they had private `model_validate` loops).
- `coerce_rating_score` accepts only whole values (`"3.0"` → `3`). `"3.5"` is no longer truncated to `3`.

Default validation mode is unchanged (`warn`). `CompanyRating` is not folded into `RatingsSnapshot`.

Isolated from #234 in worktree `fmp-data--fix-csv-validation-mode-232` off `origin/dev`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable validation modes for bulk CSV data: warn, strict, and lenient.
  * Unknown headers and invalid cells are now handled according to the selected mode.
  * URL fields receive an additional validation attempt before invalid rows are skipped or rejected.

* **Bug Fixes**
  * Fractional rating scores are no longer truncated and are correctly rejected.
  * Warning messages are deduplicated by endpoint and field set.

* **Documentation**
  * Clarified that validation applies to JSON responses and bulk CSV data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->