### PR TITLE
feat(client): type list endpoints via request_list and _unwrap_list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,16 @@ out of scope.
 
 None. No FMP path we ship was newly retired by this changelog window.
 
+### Changed
+
+- **List-returning requests are `list[T]` without collapsing `request()` (#235).**
+  `BaseClient.request` stays `Endpoint[T] -> T | list[T]`. List endpoints
+  (company delisted / symbol-changes / M&A and the rest of the company list
+  surface) are now `Endpoint[T]` for the row type and go through
+  `request_list` / `EndpointGroup._unwrap_list` instead of copying the
+  `PROFILE_CIK` single-object pattern. A lone object from FMP becomes
+  `[row]`; an empty list stays empty.
+
 ### Added
 
 - **FMP hosted MCP vs `fmp-mcp` positioning (#230).** Docs-only: we are not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,12 +51,12 @@ None. No FMP path we ship was newly retired by this changelog window.
 ### Changed
 
 - **List-returning requests are `list[T]` without collapsing `request()` (#235).**
-  `BaseClient.request` stays `Endpoint[T] -> T | list[T]`. List endpoints
-  (company delisted / symbol-changes / M&A and the rest of the company list
-  surface) are now `Endpoint[T]` for the row type and go through
-  `request_list` / `EndpointGroup._unwrap_list` instead of copying the
-  `PROFILE_CIK` single-object pattern. A lone object from FMP becomes
-  `[row]`; an empty list stays empty.
+  `BaseClient.request` stays `Endpoint[T] -> T | list[T]`. Company list
+  methods stay on `request()` (so existing mocks still work) and normalize
+  through `EndpointGroup._unwrap_list`. `request_list` / `request_async_list`
+  are the typed `Endpoint[T] -> list[T]` façade for callers that do not
+  need to mock `request`. A lone object becomes `[row]`; an empty list
+  stays empty.
 
 ### Added
 

--- a/fmp_data/base.py
+++ b/fmp_data/base.py
@@ -39,6 +39,22 @@ from fmp_data.rate_limit import AsyncFMPRateLimiter, FMPRateLimiter, QuotaConfig
 T = TypeVar("T")
 ValidationMode = Literal["lenient", "warn", "strict"]
 
+
+def _unwrap_list_result(result: T | list[T], _model: type[T]) -> list[T]:
+    """Normalize ``request()`` output to ``list[T]``.
+
+    List endpoints are declared ``Endpoint[T]`` (the row type). ``request``
+    remains ``T | list[T]`` so single-item callers can still use
+    ``_unwrap_single``. Wrapping a lone ``T`` as ``[T]`` matches FMP
+    payloads that return one object instead of a one-element array (#235).
+
+    ``_model`` is the row type, kept so callers match ``_unwrap_single``.
+    """
+    if isinstance(result, list):
+        return result
+    return [result]
+
+
 logger = FMPLogger().get_logger(__name__)
 
 # Context variable for request-scoped rate limit retry tracking.
@@ -364,6 +380,20 @@ class BaseClient:
 
         # This should never be reached due to reraise=True, but satisfies type checker
         raise FMPError("Request failed after all retry attempts")
+
+    def request_list(self, endpoint: Endpoint[T], **kwargs: Any) -> list[T]:
+        """Request a list-returning endpoint as ``list[T]``.
+
+        ``request`` stays ``Endpoint[T] -> T | list[T]`` so single-item
+        callers can keep ``_unwrap_single``. List endpoints should be
+        declared ``Endpoint[T]`` (the row type) and go through this
+        helper or ``EndpointGroup._unwrap_list`` instead of copying the
+        ``PROFILE_CIK`` single-object pattern (#235).
+        """
+        return _unwrap_list_result(
+            self.request(endpoint, **kwargs),
+            endpoint.response_model,
+        )
 
     def _execute_request(self, endpoint: Endpoint[T], **kwargs: Any) -> T | list[T]:
         """
@@ -908,6 +938,13 @@ class BaseClient:
         # This should never be reached due to reraise=True
         raise FMPError("Async request failed after all retry attempts")
 
+    async def request_async_list(self, endpoint: Endpoint[T], **kwargs: Any) -> list[T]:
+        """Async counterpart of :meth:`request_list` (#235)."""
+        return _unwrap_list_result(
+            await self.request_async(endpoint, **kwargs),
+            endpoint.response_model,
+        )
+
     async def _execute_request_async(
         self, endpoint: Endpoint[T], **kwargs: Any
     ) -> T | list[T]:
@@ -1104,6 +1141,11 @@ class EndpointGroup:
             return cast(T, result[0])
         return cast(T, result)
 
+    @staticmethod
+    def _unwrap_list(result: T | list[T], model: type[T]) -> list[T]:
+        """Normalize a ``request()`` result to ``list[T]`` (#235)."""
+        return _unwrap_list_result(result, model)
+
 
 class AsyncEndpointGroup:
     """Abstract base class for async endpoint groups.
@@ -1182,3 +1224,8 @@ class AsyncEndpointGroup:
                 )
             return cast(T, result[0])
         return cast(T, result)
+
+    @staticmethod
+    def _unwrap_list(result: T | list[T], model: type[T]) -> list[T]:
+        """Normalize a ``request_async()`` result to ``list[T]`` (#235)."""
+        return _unwrap_list_result(result, model)

--- a/fmp_data/base.py
+++ b/fmp_data/base.py
@@ -40,16 +40,20 @@ T = TypeVar("T")
 ValidationMode = Literal["lenient", "warn", "strict"]
 
 
-def _unwrap_list_result(result: T | list[T], _model: type[T]) -> list[T]:
+def _unwrap_list_result(result: T | list[T], model: type[T]) -> list[T]:
     """Normalize ``request()`` output to ``list[T]``.
 
     List endpoints are declared ``Endpoint[T]`` (the row type). ``request``
     remains ``T | list[T]`` so single-item callers can still use
-    ``_unwrap_single``. Wrapping a lone ``T`` as ``[T]`` matches FMP
-    payloads that return one object instead of a one-element array (#235).
+    ``_unwrap_single``. A lone row becomes ``[row]``. An empty list stays
+    empty (unlike ``_unwrap_single``, which raises).
 
-    ``_model`` is the row type, kept so callers match ``_unwrap_single``.
+    ``model`` is a type witness for ``T``. A value that is already an
+    instance of ``model`` is wrapped first so a list-like row type is
+    not treated as an already-unwrapped ``list[T]``.
     """
+    if isinstance(result, model):
+        return [result]
     if isinstance(result, list):
         return result
     return [result]
@@ -384,11 +388,11 @@ class BaseClient:
     def request_list(self, endpoint: Endpoint[T], **kwargs: Any) -> list[T]:
         """Request a list-returning endpoint as ``list[T]``.
 
-        ``request`` stays ``Endpoint[T] -> T | list[T]`` so single-item
-        callers can keep ``_unwrap_single``. List endpoints should be
-        declared ``Endpoint[T]`` (the row type) and go through this
-        helper or ``EndpointGroup._unwrap_list`` instead of copying the
-        ``PROFILE_CIK`` single-object pattern (#235).
+        ``request`` stays ``Endpoint[T] -> T | list[T]``. Use this helper
+        when the caller wants ``list[T]`` directly. Client methods that
+        still call ``request()`` (so tests can mock it) should normalize
+        with ``EndpointGroup._unwrap_list`` instead of ``_unwrap_single``.
+        An empty list stays empty.
         """
         return _unwrap_list_result(
             self.request(endpoint, **kwargs),
@@ -939,7 +943,7 @@ class BaseClient:
         raise FMPError("Async request failed after all retry attempts")
 
     async def request_async_list(self, endpoint: Endpoint[T], **kwargs: Any) -> list[T]:
-        """Async counterpart of :meth:`request_list` (#235)."""
+        """Async counterpart of :meth:`request_list`."""
         return _unwrap_list_result(
             await self.request_async(endpoint, **kwargs),
             endpoint.response_model,
@@ -1143,7 +1147,12 @@ class EndpointGroup:
 
     @staticmethod
     def _unwrap_list(result: T | list[T], model: type[T]) -> list[T]:
-        """Normalize a ``request()`` result to ``list[T]`` (#235)."""
+        """Normalize a ``request()`` result to ``list[T]``.
+
+        A lone row becomes ``[row]``. An empty list stays empty.
+        ``model`` is the row type (type witness; also used to recognize a
+        lone row).
+        """
         return _unwrap_list_result(result, model)
 
 
@@ -1227,5 +1236,10 @@ class AsyncEndpointGroup:
 
     @staticmethod
     def _unwrap_list(result: T | list[T], model: type[T]) -> list[T]:
-        """Normalize a ``request_async()`` result to ``list[T]`` (#235)."""
+        """Normalize a ``request_async()`` result to ``list[T]``.
+
+        A lone row becomes ``[row]``. An empty list stays empty.
+        ``model`` is the row type (type witness; also used to recognize a
+        lone row).
+        """
         return _unwrap_list_result(result, model)

--- a/fmp_data/company/async_client.py
+++ b/fmp_data/company/async_client.py
@@ -169,15 +169,23 @@ class AsyncCompanyClient(AsyncEndpointGroup):
 
     async def get_executives(self, symbol: str) -> list[CompanyExecutive]:
         """Get company executives information"""
-        return await self.client.request_async(KEY_EXECUTIVES, symbol=symbol)
+        return self._unwrap_list(
+            await self.client.request_async(KEY_EXECUTIVES, symbol=symbol),
+            CompanyExecutive,
+        )
 
     async def get_employee_count(self, symbol: str) -> list[EmployeeCount]:
         """Get company employee count history"""
-        return await self.client.request_async(EMPLOYEE_COUNT, symbol=symbol)
+        return self._unwrap_list(
+            await self.client.request_async(EMPLOYEE_COUNT, symbol=symbol),
+            EmployeeCount,
+        )
 
     async def get_company_notes(self, symbol: str) -> list[CompanyNote]:
         """Get company financial notes"""
-        return await self.client.request_async(COMPANY_NOTES, symbol=symbol)
+        return self._unwrap_list(
+            await self.client.request_async(COMPANY_NOTES, symbol=symbol), CompanyNote
+        )
 
     def get_company_logo_url(self, symbol: str) -> str:
         """Get the company logo URL (sync, no API call needed)"""
@@ -261,20 +269,26 @@ class AsyncCompanyClient(AsyncEndpointGroup):
         """
         start_date = _format_date(from_date)
         end_date = _format_date(to_date)
-        return await self.client.request_async(
-            INTRADAY_PRICE,
-            symbol=symbol,
-            interval=interval,
-            start_date=start_date,
-            end_date=end_date,
-            nonadjusted=nonadjusted,
+        return self._unwrap_list(
+            await self.client.request_async(
+                INTRADAY_PRICE,
+                symbol=symbol,
+                interval=interval,
+                start_date=start_date,
+                end_date=end_date,
+                nonadjusted=nonadjusted,
+            ),
+            IntradayPrice,
         )
 
     async def get_executive_compensation(
         self, symbol: str
     ) -> list[ExecutiveCompensation]:
         """Get executive compensation data for a company"""
-        return await self.client.request_async(EXECUTIVE_COMPENSATION, symbol=symbol)
+        return self._unwrap_list(
+            await self.client.request_async(EXECUTIVE_COMPENSATION, symbol=symbol),
+            ExecutiveCompensation,
+        )
 
     @deprecated(
         "historical/shares-float is dead. The live path shares-float is "
@@ -310,11 +324,14 @@ class AsyncCompanyClient(AsyncEndpointGroup):
         Returns:
             List of product revenue segments by fiscal year
         """
-        return await self.client.request_async(
-            PRODUCT_REVENUE_SEGMENTATION,
-            symbol=symbol,
-            structure="flat",
-            period=period,
+        return self._unwrap_list(
+            await self.client.request_async(
+                PRODUCT_REVENUE_SEGMENTATION,
+                symbol=symbol,
+                structure="flat",
+                period=period,
+            ),
+            ProductRevenueSegment,
         )
 
     async def get_geographic_revenue_segmentation(
@@ -329,16 +346,21 @@ class AsyncCompanyClient(AsyncEndpointGroup):
         Returns:
             List of geographic revenue segments by fiscal year
         """
-        return await self.client.request_async(
-            GEOGRAPHIC_REVENUE_SEGMENTATION,
-            symbol=symbol,
-            structure="flat",
-            period=period,
+        return self._unwrap_list(
+            await self.client.request_async(
+                GEOGRAPHIC_REVENUE_SEGMENTATION,
+                symbol=symbol,
+                structure="flat",
+                period=period,
+            ),
+            GeographicRevenueSegment,
         )
 
     async def get_symbol_changes(self) -> list[SymbolChange]:
         """Get symbol change history"""
-        return await self.client.request_async(SYMBOL_CHANGES)
+        return self._unwrap_list(
+            await self.client.request_async(SYMBOL_CHANGES), SymbolChange
+        )
 
     async def get_delisted_companies(
         self, page: int = 0, limit: int = 100
@@ -353,8 +375,9 @@ class AsyncCompanyClient(AsyncEndpointGroup):
             List of slim delisted rows (symbol, companyName, exchange,
             IPO and delist dates).
         """
-        return await self.client.request_async(
-            DELISTED_COMPANIES, page=page, limit=limit
+        return self._unwrap_list(
+            await self.client.request_async(DELISTED_COMPANIES, page=page, limit=limit),
+            DelistedCompany,
         )
 
     async def get_share_float(self, symbol: str) -> ShareFloat:
@@ -371,7 +394,10 @@ class AsyncCompanyClient(AsyncEndpointGroup):
         self, symbol: str
     ) -> list[MarketCapitalization]:
         """Get historical market capitalization data"""
-        return await self.client.request_async(HISTORICAL_MARKET_CAP, symbol=symbol)
+        return self._unwrap_list(
+            await self.client.request_async(HISTORICAL_MARKET_CAP, symbol=symbol),
+            MarketCapitalization,
+        )
 
     @deprecated(
         "The FMP API no longer serves the price-target series. Use "
@@ -410,12 +436,15 @@ class AsyncCompanyClient(AsyncEndpointGroup):
         limit: int = 10,
     ) -> list[AnalystEstimate]:
         """Get analyst estimates"""
-        return await self.client.request_async(
-            ANALYST_ESTIMATES,
-            symbol=symbol,
-            period=period,
-            page=page,
-            limit=limit,
+        return self._unwrap_list(
+            await self.client.request_async(
+                ANALYST_ESTIMATES,
+                symbol=symbol,
+                period=period,
+                page=page,
+                limit=limit,
+            ),
+            AnalystEstimate,
         )
 
     @deprecated(
@@ -483,7 +512,9 @@ class AsyncCompanyClient(AsyncEndpointGroup):
 
     async def get_company_peers(self, symbol: str) -> list[CompanyPeer]:
         """Get company peers"""
-        return await self.client.request_async(COMPANY_PEERS, symbol=symbol)
+        return self._unwrap_list(
+            await self.client.request_async(COMPANY_PEERS, symbol=symbol), CompanyPeer
+        )
 
     async def get_mergers_acquisitions_latest(
         self, page: int = 0, limit: int = 100
@@ -497,8 +528,11 @@ class AsyncCompanyClient(AsyncEndpointGroup):
         Returns:
             List of recent M&A transactions
         """
-        return await self.client.request_async(
-            MERGERS_ACQUISITIONS_LATEST, page=page, limit=limit
+        return self._unwrap_list(
+            await self.client.request_async(
+                MERGERS_ACQUISITIONS_LATEST, page=page, limit=limit
+            ),
+            MergerAcquisition,
         )
 
     async def get_mergers_acquisitions_search(
@@ -514,8 +548,11 @@ class AsyncCompanyClient(AsyncEndpointGroup):
         Returns:
             List of M&A transactions matching the search
         """
-        return await self.client.request_async(
-            MERGERS_ACQUISITIONS_SEARCH, name=name, page=page, limit=limit
+        return self._unwrap_list(
+            await self.client.request_async(
+                MERGERS_ACQUISITIONS_SEARCH, name=name, page=page, limit=limit
+            ),
+            MergerAcquisition,
         )
 
     async def get_executive_compensation_benchmark(
@@ -529,8 +566,11 @@ class AsyncCompanyClient(AsyncEndpointGroup):
         Returns:
             List of executive compensation benchmarks by industry
         """
-        return await self.client.request_async(
-            EXECUTIVE_COMPENSATION_BENCHMARK, year=year
+        return self._unwrap_list(
+            await self.client.request_async(
+                EXECUTIVE_COMPENSATION_BENCHMARK, year=year
+            ),
+            ExecutiveCompensationBenchmark,
         )
 
     async def get_historical_prices_light(
@@ -657,7 +697,9 @@ class AsyncCompanyClient(AsyncEndpointGroup):
             params["to_date"] = end_date
         if limit is not None:
             params["limit"] = limit
-        return await self.client.request_async(COMPANY_DIVIDENDS, **params)
+        return self._unwrap_list(
+            await self.client.request_async(COMPANY_DIVIDENDS, **params), DividendEvent
+        )
 
     async def get_earnings(self, symbol: str, limit: int = 20) -> list[EarningEvent]:
         """Get historical earnings reports for a specific company
@@ -669,8 +711,11 @@ class AsyncCompanyClient(AsyncEndpointGroup):
         Returns:
             List of EarningEvent objects containing earnings history
         """
-        return await self.client.request_async(
-            COMPANY_EARNINGS, symbol=symbol, limit=limit
+        return self._unwrap_list(
+            await self.client.request_async(
+                COMPANY_EARNINGS, symbol=symbol, limit=limit
+            ),
+            EarningEvent,
         )
 
     async def get_stock_splits(
@@ -700,7 +745,9 @@ class AsyncCompanyClient(AsyncEndpointGroup):
             params["to_date"] = end_date
         if limit is not None:
             params["limit"] = limit
-        return await self.client.request_async(COMPANY_SPLITS, **params)
+        return self._unwrap_list(
+            await self.client.request_async(COMPANY_SPLITS, **params), StockSplitEvent
+        )
 
     # Financial Statement Methods
     async def get_income_statement_ttm(
@@ -715,8 +762,11 @@ class AsyncCompanyClient(AsyncEndpointGroup):
         Returns:
             List of TTM income statement data
         """
-        return await self.client.request_async(
-            INCOME_STATEMENT_TTM, symbol=symbol, limit=limit
+        return self._unwrap_list(
+            await self.client.request_async(
+                INCOME_STATEMENT_TTM, symbol=symbol, limit=limit
+            ),
+            IncomeStatement,
         )
 
     async def get_balance_sheet_ttm(
@@ -731,8 +781,11 @@ class AsyncCompanyClient(AsyncEndpointGroup):
         Returns:
             List of TTM balance sheet data
         """
-        return await self.client.request_async(
-            BALANCE_SHEET_TTM, symbol=symbol, limit=limit
+        return self._unwrap_list(
+            await self.client.request_async(
+                BALANCE_SHEET_TTM, symbol=symbol, limit=limit
+            ),
+            BalanceSheet,
         )
 
     async def get_cash_flow_ttm(
@@ -747,8 +800,9 @@ class AsyncCompanyClient(AsyncEndpointGroup):
         Returns:
             List of TTM cash flow data
         """
-        return await self.client.request_async(
-            CASH_FLOW_TTM, symbol=symbol, limit=limit
+        return self._unwrap_list(
+            await self.client.request_async(CASH_FLOW_TTM, symbol=symbol, limit=limit),
+            CashFlowStatement,
         )
 
     async def get_key_metrics_ttm(self, symbol: str) -> list[KeyMetricsTTM]:
@@ -760,7 +814,10 @@ class AsyncCompanyClient(AsyncEndpointGroup):
         Returns:
             List of TTM key metrics
         """
-        return await self.client.request_async(KEY_METRICS_TTM, symbol=symbol)
+        return self._unwrap_list(
+            await self.client.request_async(KEY_METRICS_TTM, symbol=symbol),
+            KeyMetricsTTM,
+        )
 
     async def get_financial_ratios_ttm(self, symbol: str) -> list[FinancialRatiosTTM]:
         """Get trailing twelve months (TTM) financial ratios
@@ -771,7 +828,10 @@ class AsyncCompanyClient(AsyncEndpointGroup):
         Returns:
             List of TTM financial ratios
         """
-        return await self.client.request_async(FINANCIAL_RATIOS_TTM, symbol=symbol)
+        return self._unwrap_list(
+            await self.client.request_async(FINANCIAL_RATIOS_TTM, symbol=symbol),
+            FinancialRatiosTTM,
+        )
 
     async def get_financial_scores(self, symbol: str) -> list[FinancialScore]:
         """Get comprehensive financial health scores
@@ -782,7 +842,10 @@ class AsyncCompanyClient(AsyncEndpointGroup):
         Returns:
             List of financial scores including Altman Z-Score and Piotroski Score
         """
-        return await self.client.request_async(FINANCIAL_SCORES, symbol=symbol)
+        return self._unwrap_list(
+            await self.client.request_async(FINANCIAL_SCORES, symbol=symbol),
+            FinancialScore,
+        )
 
     async def get_enterprise_values(
         self, symbol: str, period: str = "annual", limit: int = 20
@@ -797,8 +860,11 @@ class AsyncCompanyClient(AsyncEndpointGroup):
         Returns:
             List of enterprise value data
         """
-        return await self.client.request_async(
-            ENTERPRISE_VALUES, symbol=symbol, period=period, limit=limit
+        return self._unwrap_list(
+            await self.client.request_async(
+                ENTERPRISE_VALUES, symbol=symbol, period=period, limit=limit
+            ),
+            EnterpriseValue,
         )
 
     async def get_income_statement_growth(
@@ -814,8 +880,11 @@ class AsyncCompanyClient(AsyncEndpointGroup):
         Returns:
             List of income statement growth data
         """
-        return await self.client.request_async(
-            INCOME_STATEMENT_GROWTH, symbol=symbol, period=period, limit=limit
+        return self._unwrap_list(
+            await self.client.request_async(
+                INCOME_STATEMENT_GROWTH, symbol=symbol, period=period, limit=limit
+            ),
+            FinancialGrowth,
         )
 
     async def get_balance_sheet_growth(
@@ -831,8 +900,11 @@ class AsyncCompanyClient(AsyncEndpointGroup):
         Returns:
             List of balance sheet growth data
         """
-        return await self.client.request_async(
-            BALANCE_SHEET_GROWTH, symbol=symbol, period=period, limit=limit
+        return self._unwrap_list(
+            await self.client.request_async(
+                BALANCE_SHEET_GROWTH, symbol=symbol, period=period, limit=limit
+            ),
+            FinancialGrowth,
         )
 
     async def get_cash_flow_growth(
@@ -848,8 +920,11 @@ class AsyncCompanyClient(AsyncEndpointGroup):
         Returns:
             List of cash flow growth data
         """
-        return await self.client.request_async(
-            CASH_FLOW_GROWTH, symbol=symbol, period=period, limit=limit
+        return self._unwrap_list(
+            await self.client.request_async(
+                CASH_FLOW_GROWTH, symbol=symbol, period=period, limit=limit
+            ),
+            FinancialGrowth,
         )
 
     async def get_financial_growth(
@@ -865,8 +940,11 @@ class AsyncCompanyClient(AsyncEndpointGroup):
         Returns:
             List of comprehensive financial growth data
         """
-        return await self.client.request_async(
-            FINANCIAL_GROWTH, symbol=symbol, period=period, limit=limit
+        return self._unwrap_list(
+            await self.client.request_async(
+                FINANCIAL_GROWTH, symbol=symbol, period=period, limit=limit
+            ),
+            FinancialGrowth,
         )
 
     async def get_financial_reports_json(
@@ -938,8 +1016,11 @@ class AsyncCompanyClient(AsyncEndpointGroup):
         Returns:
             List of as-reported income statements
         """
-        return await self.client.request_async(
-            INCOME_STATEMENT_AS_REPORTED, symbol=symbol, period=period, limit=limit
+        return self._unwrap_list(
+            await self.client.request_async(
+                INCOME_STATEMENT_AS_REPORTED, symbol=symbol, period=period, limit=limit
+            ),
+            AsReportedIncomeStatement,
         )
 
     async def get_balance_sheet_as_reported(
@@ -955,8 +1036,11 @@ class AsyncCompanyClient(AsyncEndpointGroup):
         Returns:
             List of as-reported balance sheets
         """
-        return await self.client.request_async(
-            BALANCE_SHEET_AS_REPORTED, symbol=symbol, period=period, limit=limit
+        return self._unwrap_list(
+            await self.client.request_async(
+                BALANCE_SHEET_AS_REPORTED, symbol=symbol, period=period, limit=limit
+            ),
+            AsReportedBalanceSheet,
         )
 
     async def get_cash_flow_as_reported(
@@ -972,6 +1056,9 @@ class AsyncCompanyClient(AsyncEndpointGroup):
         Returns:
             List of as-reported cash flow statements
         """
-        return await self.client.request_async(
-            CASH_FLOW_AS_REPORTED, symbol=symbol, period=period, limit=limit
+        return self._unwrap_list(
+            await self.client.request_async(
+                CASH_FLOW_AS_REPORTED, symbol=symbol, period=period, limit=limit
+            ),
+            AsReportedCashFlowStatement,
         )

--- a/fmp_data/company/client.py
+++ b/fmp_data/company/client.py
@@ -160,15 +160,21 @@ class CompanyClient(EndpointGroup):
 
     def get_executives(self, symbol: str) -> list[CompanyExecutive]:
         """Get company executives information"""
-        return self.client.request(KEY_EXECUTIVES, symbol=symbol)
+        return self._unwrap_list(
+            self.client.request(KEY_EXECUTIVES, symbol=symbol), CompanyExecutive
+        )
 
     def get_employee_count(self, symbol: str) -> list[EmployeeCount]:
         """Get company employee count history"""
-        return self.client.request(EMPLOYEE_COUNT, symbol=symbol)
+        return self._unwrap_list(
+            self.client.request(EMPLOYEE_COUNT, symbol=symbol), EmployeeCount
+        )
 
     def get_company_notes(self, symbol: str) -> list[CompanyNote]:
         """Get company financial notes"""
-        return self.client.request(COMPANY_NOTES, symbol=symbol)
+        return self._unwrap_list(
+            self.client.request(COMPANY_NOTES, symbol=symbol), CompanyNote
+        )
 
     def get_company_logo_url(self, symbol: str) -> str:
         """Get the company logo URL"""
@@ -259,18 +265,24 @@ class CompanyClient(EndpointGroup):
         """
         start_date = _format_date(from_date)
         end_date = _format_date(to_date)
-        return self.client.request(
-            INTRADAY_PRICE,
-            symbol=symbol,
-            interval=interval,
-            start_date=start_date,
-            end_date=end_date,
-            nonadjusted=nonadjusted,
+        return self._unwrap_list(
+            self.client.request(
+                INTRADAY_PRICE,
+                symbol=symbol,
+                interval=interval,
+                start_date=start_date,
+                end_date=end_date,
+                nonadjusted=nonadjusted,
+            ),
+            IntradayPrice,
         )
 
     def get_executive_compensation(self, symbol: str) -> list[ExecutiveCompensation]:
         """Get executive compensation data for a company"""
-        return self.client.request(EXECUTIVE_COMPENSATION, symbol=symbol)
+        return self._unwrap_list(
+            self.client.request(EXECUTIVE_COMPENSATION, symbol=symbol),
+            ExecutiveCompensation,
+        )
 
     @deprecated(
         "historical/shares-float is dead. The live path shares-float is "
@@ -304,11 +316,14 @@ class CompanyClient(EndpointGroup):
         Returns:
             List of product revenue segments by fiscal year
         """
-        return self.client.request(
-            PRODUCT_REVENUE_SEGMENTATION,
-            symbol=symbol,
-            structure="flat",
-            period=period,
+        return self._unwrap_list(
+            self.client.request(
+                PRODUCT_REVENUE_SEGMENTATION,
+                symbol=symbol,
+                structure="flat",
+                period=period,
+            ),
+            ProductRevenueSegment,
         )
 
     def get_geographic_revenue_segmentation(
@@ -323,16 +338,19 @@ class CompanyClient(EndpointGroup):
         Returns:
             List of geographic revenue segments by fiscal year
         """
-        return self.client.request(
-            GEOGRAPHIC_REVENUE_SEGMENTATION,
-            symbol=symbol,
-            structure="flat",
-            period=period,
+        return self._unwrap_list(
+            self.client.request(
+                GEOGRAPHIC_REVENUE_SEGMENTATION,
+                symbol=symbol,
+                structure="flat",
+                period=period,
+            ),
+            GeographicRevenueSegment,
         )
 
     def get_symbol_changes(self) -> list[SymbolChange]:
         """Get symbol change history"""
-        return self.client.request(SYMBOL_CHANGES)
+        return self._unwrap_list(self.client.request(SYMBOL_CHANGES), SymbolChange)
 
     def get_delisted_companies(
         self, page: int = 0, limit: int = 100
@@ -347,7 +365,10 @@ class CompanyClient(EndpointGroup):
             List of slim delisted rows (symbol, companyName, exchange,
             IPO and delist dates).
         """
-        return self.client.request(DELISTED_COMPANIES, page=page, limit=limit)
+        return self._unwrap_list(
+            self.client.request(DELISTED_COMPANIES, page=page, limit=limit),
+            DelistedCompany,
+        )
 
     def get_share_float(self, symbol: str) -> ShareFloat:
         """Get current share float data for a company"""
@@ -361,7 +382,10 @@ class CompanyClient(EndpointGroup):
 
     def get_historical_market_cap(self, symbol: str) -> list[MarketCapitalization]:
         """Get historical market capitalization data"""
-        return self.client.request(HISTORICAL_MARKET_CAP, symbol=symbol)
+        return self._unwrap_list(
+            self.client.request(HISTORICAL_MARKET_CAP, symbol=symbol),
+            MarketCapitalization,
+        )
 
     @deprecated(
         "The FMP API no longer serves the price-target series. Use "
@@ -400,12 +424,15 @@ class CompanyClient(EndpointGroup):
         limit: int = 10,
     ) -> list[AnalystEstimate]:
         """Get analyst estimates"""
-        return self.client.request(
-            ANALYST_ESTIMATES,
-            symbol=symbol,
-            period=period,
-            page=page,
-            limit=limit,
+        return self._unwrap_list(
+            self.client.request(
+                ANALYST_ESTIMATES,
+                symbol=symbol,
+                period=period,
+                page=page,
+                limit=limit,
+            ),
+            AnalystEstimate,
         )
 
     @deprecated(
@@ -471,7 +498,9 @@ class CompanyClient(EndpointGroup):
 
     def get_company_peers(self, symbol: str) -> list[CompanyPeer]:
         """Get company peers"""
-        return self.client.request(COMPANY_PEERS, symbol=symbol)
+        return self._unwrap_list(
+            self.client.request(COMPANY_PEERS, symbol=symbol), CompanyPeer
+        )
 
     def get_mergers_acquisitions_latest(
         self, page: int = 0, limit: int = 100
@@ -485,7 +514,10 @@ class CompanyClient(EndpointGroup):
         Returns:
             List of recent M&A transactions
         """
-        return self.client.request(MERGERS_ACQUISITIONS_LATEST, page=page, limit=limit)
+        return self._unwrap_list(
+            self.client.request(MERGERS_ACQUISITIONS_LATEST, page=page, limit=limit),
+            MergerAcquisition,
+        )
 
     def get_mergers_acquisitions_search(
         self, name: str, page: int = 0, limit: int = 100
@@ -500,8 +532,11 @@ class CompanyClient(EndpointGroup):
         Returns:
             List of M&A transactions matching the search
         """
-        return self.client.request(
-            MERGERS_ACQUISITIONS_SEARCH, name=name, page=page, limit=limit
+        return self._unwrap_list(
+            self.client.request(
+                MERGERS_ACQUISITIONS_SEARCH, name=name, page=page, limit=limit
+            ),
+            MergerAcquisition,
         )
 
     def get_executive_compensation_benchmark(
@@ -515,7 +550,10 @@ class CompanyClient(EndpointGroup):
         Returns:
             List of executive compensation benchmarks by industry
         """
-        return self.client.request(EXECUTIVE_COMPENSATION_BENCHMARK, year=year)
+        return self._unwrap_list(
+            self.client.request(EXECUTIVE_COMPENSATION_BENCHMARK, year=year),
+            ExecutiveCompensationBenchmark,
+        )
 
     def get_historical_prices_light(
         self,
@@ -637,7 +675,9 @@ class CompanyClient(EndpointGroup):
             params["to_date"] = end_date
         if limit is not None:
             params["limit"] = limit
-        return self.client.request(COMPANY_DIVIDENDS, **params)
+        return self._unwrap_list(
+            self.client.request(COMPANY_DIVIDENDS, **params), DividendEvent
+        )
 
     def get_earnings(self, symbol: str, limit: int = 20) -> list[EarningEvent]:
         """Get historical earnings reports for a specific company
@@ -649,7 +689,10 @@ class CompanyClient(EndpointGroup):
         Returns:
             List of EarningEvent objects containing earnings history
         """
-        return self.client.request(COMPANY_EARNINGS, symbol=symbol, limit=limit)
+        return self._unwrap_list(
+            self.client.request(COMPANY_EARNINGS, symbol=symbol, limit=limit),
+            EarningEvent,
+        )
 
     def get_stock_splits(
         self,
@@ -678,7 +721,9 @@ class CompanyClient(EndpointGroup):
             params["to_date"] = end_date
         if limit is not None:
             params["limit"] = limit
-        return self.client.request(COMPANY_SPLITS, **params)
+        return self._unwrap_list(
+            self.client.request(COMPANY_SPLITS, **params), StockSplitEvent
+        )
 
     # Financial Statement Methods
     def get_income_statement_ttm(
@@ -693,7 +738,10 @@ class CompanyClient(EndpointGroup):
         Returns:
             List of TTM income statement data
         """
-        return self.client.request(INCOME_STATEMENT_TTM, symbol=symbol, limit=limit)
+        return self._unwrap_list(
+            self.client.request(INCOME_STATEMENT_TTM, symbol=symbol, limit=limit),
+            IncomeStatement,
+        )
 
     def get_balance_sheet_ttm(
         self, symbol: str, limit: int | None = None
@@ -707,7 +755,10 @@ class CompanyClient(EndpointGroup):
         Returns:
             List of TTM balance sheet data
         """
-        return self.client.request(BALANCE_SHEET_TTM, symbol=symbol, limit=limit)
+        return self._unwrap_list(
+            self.client.request(BALANCE_SHEET_TTM, symbol=symbol, limit=limit),
+            BalanceSheet,
+        )
 
     def get_cash_flow_ttm(
         self, symbol: str, limit: int | None = None
@@ -721,7 +772,10 @@ class CompanyClient(EndpointGroup):
         Returns:
             List of TTM cash flow data
         """
-        return self.client.request(CASH_FLOW_TTM, symbol=symbol, limit=limit)
+        return self._unwrap_list(
+            self.client.request(CASH_FLOW_TTM, symbol=symbol, limit=limit),
+            CashFlowStatement,
+        )
 
     def get_key_metrics_ttm(self, symbol: str) -> list[KeyMetricsTTM]:
         """Get trailing twelve months (TTM) key financial metrics
@@ -732,7 +786,9 @@ class CompanyClient(EndpointGroup):
         Returns:
             List of TTM key metrics
         """
-        return self.client.request(KEY_METRICS_TTM, symbol=symbol)
+        return self._unwrap_list(
+            self.client.request(KEY_METRICS_TTM, symbol=symbol), KeyMetricsTTM
+        )
 
     def get_financial_ratios_ttm(self, symbol: str) -> list[FinancialRatiosTTM]:
         """Get trailing twelve months (TTM) financial ratios
@@ -743,7 +799,9 @@ class CompanyClient(EndpointGroup):
         Returns:
             List of TTM financial ratios
         """
-        return self.client.request(FINANCIAL_RATIOS_TTM, symbol=symbol)
+        return self._unwrap_list(
+            self.client.request(FINANCIAL_RATIOS_TTM, symbol=symbol), FinancialRatiosTTM
+        )
 
     def get_financial_scores(self, symbol: str) -> list[FinancialScore]:
         """Get comprehensive financial health scores
@@ -754,7 +812,9 @@ class CompanyClient(EndpointGroup):
         Returns:
             List of financial scores including Altman Z-Score and Piotroski Score
         """
-        return self.client.request(FINANCIAL_SCORES, symbol=symbol)
+        return self._unwrap_list(
+            self.client.request(FINANCIAL_SCORES, symbol=symbol), FinancialScore
+        )
 
     def get_enterprise_values(
         self, symbol: str, period: str = "annual", limit: int = 20
@@ -769,8 +829,11 @@ class CompanyClient(EndpointGroup):
         Returns:
             List of enterprise value data
         """
-        return self.client.request(
-            ENTERPRISE_VALUES, symbol=symbol, period=period, limit=limit
+        return self._unwrap_list(
+            self.client.request(
+                ENTERPRISE_VALUES, symbol=symbol, period=period, limit=limit
+            ),
+            EnterpriseValue,
         )
 
     def get_income_statement_growth(
@@ -786,8 +849,11 @@ class CompanyClient(EndpointGroup):
         Returns:
             List of income statement growth data
         """
-        return self.client.request(
-            INCOME_STATEMENT_GROWTH, symbol=symbol, period=period, limit=limit
+        return self._unwrap_list(
+            self.client.request(
+                INCOME_STATEMENT_GROWTH, symbol=symbol, period=period, limit=limit
+            ),
+            FinancialGrowth,
         )
 
     def get_balance_sheet_growth(
@@ -803,8 +869,11 @@ class CompanyClient(EndpointGroup):
         Returns:
             List of balance sheet growth data
         """
-        return self.client.request(
-            BALANCE_SHEET_GROWTH, symbol=symbol, period=period, limit=limit
+        return self._unwrap_list(
+            self.client.request(
+                BALANCE_SHEET_GROWTH, symbol=symbol, period=period, limit=limit
+            ),
+            FinancialGrowth,
         )
 
     def get_cash_flow_growth(
@@ -820,8 +889,11 @@ class CompanyClient(EndpointGroup):
         Returns:
             List of cash flow growth data
         """
-        return self.client.request(
-            CASH_FLOW_GROWTH, symbol=symbol, period=period, limit=limit
+        return self._unwrap_list(
+            self.client.request(
+                CASH_FLOW_GROWTH, symbol=symbol, period=period, limit=limit
+            ),
+            FinancialGrowth,
         )
 
     def get_financial_growth(
@@ -837,8 +909,11 @@ class CompanyClient(EndpointGroup):
         Returns:
             List of comprehensive financial growth data
         """
-        return self.client.request(
-            FINANCIAL_GROWTH, symbol=symbol, period=period, limit=limit
+        return self._unwrap_list(
+            self.client.request(
+                FINANCIAL_GROWTH, symbol=symbol, period=period, limit=limit
+            ),
+            FinancialGrowth,
         )
 
     def get_financial_reports_json(
@@ -910,8 +985,11 @@ class CompanyClient(EndpointGroup):
         Returns:
             List of as-reported income statements
         """
-        return self.client.request(
-            INCOME_STATEMENT_AS_REPORTED, symbol=symbol, period=period, limit=limit
+        return self._unwrap_list(
+            self.client.request(
+                INCOME_STATEMENT_AS_REPORTED, symbol=symbol, period=period, limit=limit
+            ),
+            AsReportedIncomeStatement,
         )
 
     def get_balance_sheet_as_reported(
@@ -927,8 +1005,11 @@ class CompanyClient(EndpointGroup):
         Returns:
             List of as-reported balance sheets
         """
-        return self.client.request(
-            BALANCE_SHEET_AS_REPORTED, symbol=symbol, period=period, limit=limit
+        return self._unwrap_list(
+            self.client.request(
+                BALANCE_SHEET_AS_REPORTED, symbol=symbol, period=period, limit=limit
+            ),
+            AsReportedBalanceSheet,
         )
 
     def get_cash_flow_as_reported(
@@ -944,6 +1025,9 @@ class CompanyClient(EndpointGroup):
         Returns:
             List of as-reported cash flow statements
         """
-        return self.client.request(
-            CASH_FLOW_AS_REPORTED, symbol=symbol, period=period, limit=limit
+        return self._unwrap_list(
+            self.client.request(
+                CASH_FLOW_AS_REPORTED, symbol=symbol, period=period, limit=limit
+            ),
+            AsReportedCashFlowStatement,
         )

--- a/fmp_data/company/endpoints.py
+++ b/fmp_data/company/endpoints.py
@@ -272,7 +272,7 @@ HISTORICAL_PRICE_DIVIDEND_ADJUSTED: Endpoint = Endpoint(
     response_model=HistoricalPrice,
 )
 
-INTRADAY_PRICE: Endpoint = Endpoint(
+INTRADAY_PRICE: Endpoint[IntradayPrice] = Endpoint(
     name="intraday_price",
     path="historical-chart/{interval}",
     version=APIVersion.STABLE,
@@ -381,7 +381,7 @@ CORE_INFORMATION: Endpoint[CompanyCoreInformation] = Endpoint(
 # Search Endpoints
 
 # Executive Information Endpoints
-KEY_EXECUTIVES: Endpoint = Endpoint(
+KEY_EXECUTIVES: Endpoint[CompanyExecutive] = Endpoint(
     name="key_executives",
     path="key-executives",
     version=APIVersion.STABLE,
@@ -411,7 +411,7 @@ KEY_EXECUTIVES: Endpoint = Endpoint(
     ],
 )
 
-EXECUTIVE_COMPENSATION: Endpoint = Endpoint(
+EXECUTIVE_COMPENSATION: Endpoint[ExecutiveCompensation] = Endpoint(
     name="executive_compensation",
     path="governance-executive-compensation",
     version=APIVersion.STABLE,
@@ -439,7 +439,7 @@ EXECUTIVE_COMPENSATION: Endpoint = Endpoint(
     ],
 )
 
-EMPLOYEE_COUNT: Endpoint = Endpoint(
+EMPLOYEE_COUNT: Endpoint[EmployeeCount] = Endpoint(
     name="employee_count",
     path="employee-count",
     version=APIVersion.STABLE,
@@ -478,7 +478,7 @@ EMPLOYEE_COUNT: Endpoint = Endpoint(
 
 # Symbol Related Endpoints
 # Company Operational Data
-COMPANY_NOTES: Endpoint = Endpoint(
+COMPANY_NOTES: Endpoint[CompanyNote] = Endpoint(
     name="company_notes",
     path="company-notes",
     version=APIVersion.STABLE,
@@ -537,7 +537,7 @@ HISTORICAL_SHARE_FLOAT: Endpoint = Endpoint(
 )
 
 # Revenue Analysis Endpoints
-PRODUCT_REVENUE_SEGMENTATION: Endpoint = Endpoint(
+PRODUCT_REVENUE_SEGMENTATION: Endpoint[ProductRevenueSegment] = Endpoint(
     name="product_revenue_segmentation",
     path="revenue-product-segmentation",
     version=APIVersion.STABLE,
@@ -580,7 +580,7 @@ PRODUCT_REVENUE_SEGMENTATION: Endpoint = Endpoint(
     ],
 )
 
-GEOGRAPHIC_REVENUE_SEGMENTATION: Endpoint = Endpoint(
+GEOGRAPHIC_REVENUE_SEGMENTATION: Endpoint[GeographicRevenueSegment] = Endpoint(
     name="geographic_revenue_segmentation",
     path="revenue-geographic-segmentation",
     version=APIVersion.STABLE,
@@ -623,7 +623,7 @@ GEOGRAPHIC_REVENUE_SEGMENTATION: Endpoint = Endpoint(
     ],
 )
 
-SYMBOL_CHANGES: Endpoint = Endpoint(
+SYMBOL_CHANGES: Endpoint[SymbolChange] = Endpoint(
     name="symbol_changes",
     path="symbol-change",
     version=APIVersion.STABLE,
@@ -689,7 +689,7 @@ MARKET_CAP: Endpoint[MarketCapitalization] = Endpoint(
     response_model=MarketCapitalization,
 )
 
-HISTORICAL_MARKET_CAP: Endpoint = Endpoint(
+HISTORICAL_MARKET_CAP: Endpoint[MarketCapitalization] = Endpoint(
     name="historical_market_cap",
     path="historical-market-capitalization",
     version=APIVersion.STABLE,
@@ -767,7 +767,7 @@ PRICE_TARGET_CONSENSUS: Endpoint[PriceTargetConsensus] = Endpoint(
     response_model=PriceTargetConsensus,
 )
 
-ANALYST_ESTIMATES: Endpoint = Endpoint(
+ANALYST_ESTIMATES: Endpoint[AnalystEstimate] = Endpoint(
     name="analyst_estimates",
     path="analyst-estimates",
     version=APIVersion.STABLE,
@@ -880,7 +880,7 @@ UPGRADES_DOWNGRADES_CONSENSUS: Endpoint[UpgradeDowngradeConsensus] = Endpoint(
     response_model=UpgradeDowngradeConsensus,
 )
 
-COMPANY_PEERS: Endpoint = Endpoint(
+COMPANY_PEERS: Endpoint[CompanyPeer] = Endpoint(
     name="stock_peers",
     path="stock-peers",
     version=APIVersion.STABLE,
@@ -915,7 +915,7 @@ PROFILE_CIK: Endpoint[CompanyProfile] = Endpoint(
     response_model=CompanyProfile,
 )
 
-DELISTED_COMPANIES: Endpoint = Endpoint(
+DELISTED_COMPANIES: Endpoint[DelistedCompany] = Endpoint(
     name="delisted_companies",
     path="delisted-companies",
     version=APIVersion.STABLE,
@@ -1110,7 +1110,7 @@ STOCK_SCREENER: Endpoint = Endpoint(
     response_model=CompanyProfile,
 )
 
-MERGERS_ACQUISITIONS_LATEST: Endpoint = Endpoint(
+MERGERS_ACQUISITIONS_LATEST: Endpoint[MergerAcquisition] = Endpoint(
     name="mergers_acquisitions_latest",
     path="mergers-acquisitions-latest",
     version=APIVersion.STABLE,
@@ -1135,7 +1135,7 @@ MERGERS_ACQUISITIONS_LATEST: Endpoint = Endpoint(
     response_model=MergerAcquisition,
 )
 
-MERGERS_ACQUISITIONS_SEARCH: Endpoint = Endpoint(
+MERGERS_ACQUISITIONS_SEARCH: Endpoint[MergerAcquisition] = Endpoint(
     name="mergers_acquisitions_search",
     path="mergers-acquisitions-search",
     version=APIVersion.STABLE,
@@ -1167,7 +1167,7 @@ MERGERS_ACQUISITIONS_SEARCH: Endpoint = Endpoint(
     response_model=MergerAcquisition,
 )
 
-EXECUTIVE_COMPENSATION_BENCHMARK: Endpoint = Endpoint(
+EXECUTIVE_COMPENSATION_BENCHMARK: Endpoint[ExecutiveCompensationBenchmark] = Endpoint(
     name="executive_compensation_benchmark",
     path="executive-compensation-benchmark",
     version=APIVersion.STABLE,
@@ -1184,7 +1184,7 @@ EXECUTIVE_COMPENSATION_BENCHMARK: Endpoint = Endpoint(
     response_model=ExecutiveCompensationBenchmark,
 )
 
-COMPANY_DIVIDENDS: Endpoint = Endpoint(
+COMPANY_DIVIDENDS: Endpoint[DividendEvent] = Endpoint(
     name="company_dividends",
     path="dividends",
     version=APIVersion.STABLE,
@@ -1234,7 +1234,7 @@ COMPANY_DIVIDENDS: Endpoint = Endpoint(
     ],
 )
 
-COMPANY_EARNINGS: Endpoint = Endpoint(
+COMPANY_EARNINGS: Endpoint[EarningEvent] = Endpoint(
     name="company_earnings",
     path="earnings",
     version=APIVersion.STABLE,
@@ -1271,7 +1271,7 @@ COMPANY_EARNINGS: Endpoint = Endpoint(
     ],
 )
 
-COMPANY_SPLITS: Endpoint = Endpoint(
+COMPANY_SPLITS: Endpoint[StockSplitEvent] = Endpoint(
     name="company_splits",
     path="splits",
     version=APIVersion.STABLE,
@@ -1321,7 +1321,7 @@ COMPANY_SPLITS: Endpoint = Endpoint(
     ],
 )
 
-INCOME_STATEMENT_TTM: Endpoint = Endpoint(
+INCOME_STATEMENT_TTM: Endpoint[IncomeStatement] = Endpoint(
     name="income_statement_ttm",
     path="income-statement-ttm",
     version=APIVersion.STABLE,
@@ -1350,7 +1350,7 @@ INCOME_STATEMENT_TTM: Endpoint = Endpoint(
     response_model=IncomeStatement,
 )
 
-BALANCE_SHEET_TTM: Endpoint = Endpoint(
+BALANCE_SHEET_TTM: Endpoint[BalanceSheet] = Endpoint(
     name="balance_sheet_ttm",
     path="balance-sheet-statement-ttm",
     version=APIVersion.STABLE,
@@ -1379,7 +1379,7 @@ BALANCE_SHEET_TTM: Endpoint = Endpoint(
     response_model=BalanceSheet,
 )
 
-CASH_FLOW_TTM: Endpoint = Endpoint(
+CASH_FLOW_TTM: Endpoint[CashFlowStatement] = Endpoint(
     name="cash_flow_ttm",
     path="cash-flow-statement-ttm",
     version=APIVersion.STABLE,
@@ -1408,7 +1408,7 @@ CASH_FLOW_TTM: Endpoint = Endpoint(
     response_model=CashFlowStatement,
 )
 
-KEY_METRICS_TTM: Endpoint = Endpoint(
+KEY_METRICS_TTM: Endpoint[KeyMetricsTTM] = Endpoint(
     name="key_metrics_ttm",
     path="key-metrics-ttm",
     version=APIVersion.STABLE,
@@ -1430,7 +1430,7 @@ KEY_METRICS_TTM: Endpoint = Endpoint(
     response_model=KeyMetricsTTM,
 )
 
-FINANCIAL_RATIOS_TTM: Endpoint = Endpoint(
+FINANCIAL_RATIOS_TTM: Endpoint[FinancialRatiosTTM] = Endpoint(
     name="financial_ratios_ttm",
     path="ratios-ttm",
     version=APIVersion.STABLE,
@@ -1452,7 +1452,7 @@ FINANCIAL_RATIOS_TTM: Endpoint = Endpoint(
     response_model=FinancialRatiosTTM,
 )
 
-FINANCIAL_SCORES: Endpoint = Endpoint(
+FINANCIAL_SCORES: Endpoint[FinancialScore] = Endpoint(
     name="financial_scores",
     path="financial-scores",
     version=APIVersion.STABLE,
@@ -1474,7 +1474,7 @@ FINANCIAL_SCORES: Endpoint = Endpoint(
     response_model=FinancialScore,
 )
 
-ENTERPRISE_VALUES: Endpoint = Endpoint(
+ENTERPRISE_VALUES: Endpoint[EnterpriseValue] = Endpoint(
     name="enterprise_values",
     path="enterprise-values",
     version=APIVersion.STABLE,
@@ -1512,7 +1512,7 @@ ENTERPRISE_VALUES: Endpoint = Endpoint(
     response_model=EnterpriseValue,
 )
 
-INCOME_STATEMENT_GROWTH: Endpoint = Endpoint(
+INCOME_STATEMENT_GROWTH: Endpoint[FinancialGrowth] = Endpoint(
     name="income_statement_growth",
     path="income-statement-growth",
     version=APIVersion.STABLE,
@@ -1550,7 +1550,7 @@ INCOME_STATEMENT_GROWTH: Endpoint = Endpoint(
     response_model=FinancialGrowth,
 )
 
-BALANCE_SHEET_GROWTH: Endpoint = Endpoint(
+BALANCE_SHEET_GROWTH: Endpoint[FinancialGrowth] = Endpoint(
     name="balance_sheet_growth",
     path="balance-sheet-statement-growth",
     version=APIVersion.STABLE,
@@ -1588,7 +1588,7 @@ BALANCE_SHEET_GROWTH: Endpoint = Endpoint(
     response_model=FinancialGrowth,
 )
 
-CASH_FLOW_GROWTH: Endpoint = Endpoint(
+CASH_FLOW_GROWTH: Endpoint[FinancialGrowth] = Endpoint(
     name="cash_flow_growth",
     path="cash-flow-statement-growth",
     version=APIVersion.STABLE,
@@ -1626,7 +1626,7 @@ CASH_FLOW_GROWTH: Endpoint = Endpoint(
     response_model=FinancialGrowth,
 )
 
-FINANCIAL_GROWTH: Endpoint = Endpoint(
+FINANCIAL_GROWTH: Endpoint[FinancialGrowth] = Endpoint(
     name="financial_growth",
     path="financial-growth",
     version=APIVersion.STABLE,
@@ -1736,7 +1736,7 @@ FINANCIAL_REPORTS_XLSX: Endpoint = Endpoint(
     response_model=bytes,  # Binary data
 )
 
-INCOME_STATEMENT_AS_REPORTED: Endpoint = Endpoint(
+INCOME_STATEMENT_AS_REPORTED: Endpoint[AsReportedIncomeStatement] = Endpoint(
     name="income_statement_as_reported",
     path="income-statement-as-reported",
     version=APIVersion.STABLE,
@@ -1774,7 +1774,7 @@ INCOME_STATEMENT_AS_REPORTED: Endpoint = Endpoint(
     response_model=AsReportedIncomeStatement,
 )
 
-BALANCE_SHEET_AS_REPORTED: Endpoint = Endpoint(
+BALANCE_SHEET_AS_REPORTED: Endpoint[AsReportedBalanceSheet] = Endpoint(
     name="balance_sheet_as_reported",
     path="balance-sheet-statement-as-reported",
     version=APIVersion.STABLE,
@@ -1812,7 +1812,7 @@ BALANCE_SHEET_AS_REPORTED: Endpoint = Endpoint(
     response_model=AsReportedBalanceSheet,
 )
 
-CASH_FLOW_AS_REPORTED: Endpoint = Endpoint(
+CASH_FLOW_AS_REPORTED: Endpoint[AsReportedCashFlowStatement] = Endpoint(
     name="cash_flow_as_reported",
     path="cash-flow-statement-as-reported",
     version=APIVersion.STABLE,

--- a/tests/unit/test_async_clients.py
+++ b/tests/unit/test_async_clients.py
@@ -288,6 +288,70 @@ class TestAsyncCompanyClient:
         )
 
     @pytest.mark.asyncio
+    async def test_get_delisted_companies_wraps_single_row(self, mock_client):
+        """A lone object from request_async() is still list[DelistedCompany]."""
+        from fmp_data.company.async_client import AsyncCompanyClient
+
+        row = object()
+        mock_client.request_async.return_value = row
+        result = await AsyncCompanyClient(mock_client).get_delisted_companies()
+        assert result == [row]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "method_name,kwargs",
+        [
+            ("get_executives", {"symbol": "AAPL"}),
+            ("get_employee_count", {"symbol": "AAPL"}),
+            ("get_company_notes", {"symbol": "AAPL"}),
+            ("get_intraday_prices", {"symbol": "AAPL"}),
+            ("get_executive_compensation", {"symbol": "AAPL"}),
+            ("get_product_revenue_segmentation", {"symbol": "AAPL"}),
+            ("get_geographic_revenue_segmentation", {"symbol": "AAPL"}),
+            ("get_symbol_changes", {}),
+            ("get_delisted_companies", {}),
+            ("get_historical_market_cap", {"symbol": "AAPL"}),
+            ("get_analyst_estimates", {"symbol": "AAPL"}),
+            ("get_company_peers", {"symbol": "AAPL"}),
+            ("get_mergers_acquisitions_latest", {}),
+            ("get_mergers_acquisitions_search", {"name": "Apple"}),
+            ("get_executive_compensation_benchmark", {"year": 2023}),
+            ("get_dividends", {"symbol": "AAPL"}),
+            ("get_earnings", {"symbol": "AAPL"}),
+            ("get_stock_splits", {"symbol": "AAPL"}),
+            ("get_income_statement_ttm", {"symbol": "AAPL"}),
+            ("get_balance_sheet_ttm", {"symbol": "AAPL"}),
+            ("get_cash_flow_ttm", {"symbol": "AAPL"}),
+            ("get_key_metrics_ttm", {"symbol": "AAPL"}),
+            ("get_financial_ratios_ttm", {"symbol": "AAPL"}),
+            ("get_financial_scores", {"symbol": "AAPL"}),
+            ("get_enterprise_values", {"symbol": "AAPL"}),
+            ("get_income_statement_growth", {"symbol": "AAPL"}),
+            ("get_balance_sheet_growth", {"symbol": "AAPL"}),
+            ("get_cash_flow_growth", {"symbol": "AAPL"}),
+            ("get_financial_growth", {"symbol": "AAPL"}),
+            ("get_income_statement_as_reported", {"symbol": "AAPL"}),
+            ("get_balance_sheet_as_reported", {"symbol": "AAPL"}),
+            ("get_cash_flow_as_reported", {"symbol": "AAPL"}),
+        ],
+    )
+    async def test_list_methods_wrap_single_and_keep_empty(
+        self, mock_client, method_name, kwargs
+    ):
+        from fmp_data.company.async_client import AsyncCompanyClient
+
+        async_client = AsyncCompanyClient(mock_client)
+        method = getattr(async_client, method_name)
+        row = object()
+
+        mock_client.request_async.return_value = row
+        assert await method(**kwargs) == [row]
+
+        mock_client.request_async.return_value = []
+        assert await method(**kwargs) == []
+        mock_client.request_async.assert_called()
+
+    @pytest.mark.asyncio
     async def test_get_dividends_with_limit(self, mock_client):
         """Test async get_dividends with limit."""
         from fmp_data.company import endpoints as company_endpoints

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, ConfigDict
 import pytest
 
 from fmp_data.base import (
+    AsyncEndpointGroup,
     BaseClient,
     EndpointGroup,
     _sanitize_error_details,
@@ -1106,3 +1107,53 @@ class TestUnwrapSingle:
         result = EndpointGroup._unwrap_single(items, SampleResponse)
         assert isinstance(result, SampleResponse)
         assert result.test == "first"
+
+
+class TestUnwrapList:
+    """List counterpart of _unwrap_single (#235)."""
+
+    def test_unwrap_list_passes_through_list(self):
+        items = [SampleResponse(test="first"), SampleResponse(test="second")]
+        assert EndpointGroup._unwrap_list(items, SampleResponse) is items
+
+    def test_unwrap_list_wraps_single_item(self):
+        item = SampleResponse(test="data")
+        result = EndpointGroup._unwrap_list(item, SampleResponse)
+        assert result == [item]
+
+    def test_unwrap_list_empty_list_stays_empty(self):
+        assert EndpointGroup._unwrap_list([], SampleResponse) == []
+
+    def test_async_group_matches_sync(self):
+        item = SampleResponse(test="data")
+        assert AsyncEndpointGroup._unwrap_list(item, SampleResponse) == [item]
+
+
+class TestRequestList:
+    """BaseClient.request_list is Endpoint[T] -> list[T] (#235)."""
+
+    def test_request_list_wraps_single_object(self, base_client, test_endpoint):
+        item = SampleResponse(test="data")
+        with patch.object(base_client, "request", return_value=item) as request:
+            result = base_client.request_list(test_endpoint, symbol="AAPL")
+
+        assert result == [item]
+        request.assert_called_once_with(test_endpoint, symbol="AAPL")
+
+    def test_request_list_keeps_list(self, base_client, test_endpoint):
+        items = [SampleResponse(test="a"), SampleResponse(test="b")]
+        with patch.object(base_client, "request", return_value=items):
+            assert base_client.request_list(test_endpoint, symbol="AAPL") is items
+
+    @pytest.mark.asyncio
+    async def test_request_async_list_wraps_single_object(
+        self, base_client, test_endpoint
+    ):
+        item = SampleResponse(test="data")
+        with patch.object(
+            base_client, "request_async", return_value=item
+        ) as request_async:
+            result = await base_client.request_async_list(test_endpoint, symbol="AAPL")
+
+        assert result == [item]
+        request_async.assert_called_once_with(test_endpoint, symbol="AAPL")

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -1121,6 +1121,13 @@ class TestUnwrapList:
         result = EndpointGroup._unwrap_list(item, SampleResponse)
         assert result == [item]
 
+    def test_unwrap_list_recognizes_row_type_before_list(self):
+        """A lone row is wrapped even though the fallback is list-shaped."""
+        item = SampleResponse(test="data")
+        assert EndpointGroup._unwrap_list(item, SampleResponse) == [item]
+        items = [item]
+        assert EndpointGroup._unwrap_list(items, SampleResponse) is items
+
     def test_unwrap_list_empty_list_stays_empty(self):
         assert EndpointGroup._unwrap_list([], SampleResponse) == []
 
@@ -1157,3 +1164,12 @@ class TestRequestList:
 
         assert result == [item]
         request_async.assert_called_once_with(test_endpoint, symbol="AAPL")
+
+    @pytest.mark.asyncio
+    async def test_request_async_list_keeps_list(self, base_client, test_endpoint):
+        items = [SampleResponse(test="a"), SampleResponse(test="b")]
+        with patch.object(base_client, "request_async", return_value=items):
+            assert (
+                await base_client.request_async_list(test_endpoint, symbol="AAPL")
+                is items
+            )

--- a/tests/unit/test_company.py
+++ b/tests/unit/test_company.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 from pydantic import ValidationError
 import pytest
 
-from fmp_data.base import BaseClient
+from fmp_data.base import BaseClient, EndpointGroup
 from fmp_data.company import CompanyClient
 from fmp_data.company.endpoints import DELISTED_COMPANIES
 from fmp_data.company.models import (
@@ -829,7 +829,10 @@ class TestDelistedCompanies:
         }
 
         assert DELISTED_COMPANIES.response_model is DelistedCompany
-        rows = BaseClient._process_response(DELISTED_COMPANIES, [slim])
+        rows = EndpointGroup._unwrap_list(
+            BaseClient._process_response(DELISTED_COMPANIES, [slim]),
+            DelistedCompany,
+        )
 
         assert len(rows) == 1
         row = rows[0]
@@ -886,6 +889,27 @@ class TestDelistedCompanies:
         mock_client.request.assert_called_once_with(
             DELISTED_COMPANIES, page=0, limit=100
         )
+
+    def test_get_delisted_companies_wraps_single_row(self, fmp_client, mock_client):
+        """A lone object from request() is still list[DelistedCompany] (#235)."""
+        row = DelistedCompany.model_validate(
+            {
+                "symbol": "2958.HK",
+                "companyName": "Vision Values Holdings Limited",
+                "exchange": "HKSE",
+                "ipoDate": "2026-05-27",
+                "delistedDate": "2026-08-17",
+            }
+        )
+        mock_client.request.return_value = row
+
+        result = fmp_client.get_delisted_companies()
+
+        assert result == [row]
+
+    def test_delisted_endpoint_is_parameterized_row_type(self):
+        """List endpoints bind T as the row, not list[T] (#235)."""
+        assert DELISTED_COMPANIES.response_model is DelistedCompany
 
 
 class TestExecutiveCompensationBenchmark:

--- a/tests/unit/test_company.py
+++ b/tests/unit/test_company.py
@@ -7,10 +7,18 @@ import pytest
 
 from fmp_data.base import BaseClient, EndpointGroup
 from fmp_data.company import CompanyClient
-from fmp_data.company.endpoints import DELISTED_COMPANIES
+from fmp_data.company.endpoints import (
+    COMPANY_PEERS,
+    DELISTED_COMPANIES,
+    INCOME_STATEMENT_TTM,
+    KEY_EXECUTIVES,
+    MERGERS_ACQUISITIONS_LATEST,
+    SYMBOL_CHANGES,
+)
 from fmp_data.company.models import (
     AnalystEstimate,
     CompanyExecutive,
+    CompanyPeer,
     CompanyProfile,
     DelistedCompany,
     ExecutiveCompensationBenchmark,
@@ -21,7 +29,9 @@ from fmp_data.company.models import (
     PriceTargetSummary,
     Quote,
     SimpleQuote,
+    SymbolChange,
 )
+from fmp_data.fundamental.models import IncomeStatement
 from fmp_data.intelligence.models import DividendEvent, EarningEvent, StockSplitEvent
 from fmp_data.models import CompanySymbol
 
@@ -1451,3 +1461,75 @@ class TestCompanyCalendarEndpoints:
         assert all(isinstance(div, DividendEvent) for div in result)
         assert result[0].dividend == 0.25
         assert result[1].dividend == 0.24
+
+
+# Company list methods that go through _unwrap_list. Keep this table in
+# lockstep with new list-returning company methods so patch coverage and
+# wrap-single stay on the mechanical wrappers.
+_COMPANY_LIST_UNWRAP_CASES = [
+    ("get_executives", {"symbol": "AAPL"}),
+    ("get_employee_count", {"symbol": "AAPL"}),
+    ("get_company_notes", {"symbol": "AAPL"}),
+    ("get_intraday_prices", {"symbol": "AAPL"}),
+    ("get_executive_compensation", {"symbol": "AAPL"}),
+    ("get_product_revenue_segmentation", {"symbol": "AAPL"}),
+    ("get_geographic_revenue_segmentation", {"symbol": "AAPL"}),
+    ("get_symbol_changes", {}),
+    ("get_delisted_companies", {}),
+    ("get_historical_market_cap", {"symbol": "AAPL"}),
+    ("get_analyst_estimates", {"symbol": "AAPL"}),
+    ("get_company_peers", {"symbol": "AAPL"}),
+    ("get_mergers_acquisitions_latest", {}),
+    ("get_mergers_acquisitions_search", {"name": "Apple"}),
+    ("get_executive_compensation_benchmark", {"year": 2023}),
+    ("get_dividends", {"symbol": "AAPL"}),
+    ("get_earnings", {"symbol": "AAPL"}),
+    ("get_stock_splits", {"symbol": "AAPL"}),
+    ("get_income_statement_ttm", {"symbol": "AAPL"}),
+    ("get_balance_sheet_ttm", {"symbol": "AAPL"}),
+    ("get_cash_flow_ttm", {"symbol": "AAPL"}),
+    ("get_key_metrics_ttm", {"symbol": "AAPL"}),
+    ("get_financial_ratios_ttm", {"symbol": "AAPL"}),
+    ("get_financial_scores", {"symbol": "AAPL"}),
+    ("get_enterprise_values", {"symbol": "AAPL"}),
+    ("get_income_statement_growth", {"symbol": "AAPL"}),
+    ("get_balance_sheet_growth", {"symbol": "AAPL"}),
+    ("get_cash_flow_growth", {"symbol": "AAPL"}),
+    ("get_financial_growth", {"symbol": "AAPL"}),
+    ("get_income_statement_as_reported", {"symbol": "AAPL"}),
+    ("get_balance_sheet_as_reported", {"symbol": "AAPL"}),
+    ("get_cash_flow_as_reported", {"symbol": "AAPL"}),
+]
+
+
+class TestCompanyListUnwrap:
+    """Mechanical _unwrap_list wrappers on CompanyClient (#235)."""
+
+    @pytest.mark.parametrize("method_name,kwargs", _COMPANY_LIST_UNWRAP_CASES)
+    def test_list_methods_wrap_single_and_keep_empty(
+        self, fmp_client, mock_client, method_name, kwargs
+    ):
+        row = object()
+        method = getattr(fmp_client, method_name)
+
+        mock_client.request.return_value = row
+        assert method(**kwargs) == [row]
+
+        mock_client.request.return_value = []
+        assert method(**kwargs) == []
+        mock_client.request.assert_called()
+
+    @pytest.mark.parametrize(
+        "endpoint,row_type",
+        [
+            (DELISTED_COMPANIES, DelistedCompany),
+            (SYMBOL_CHANGES, SymbolChange),
+            (MERGERS_ACQUISITIONS_LATEST, MergerAcquisition),
+            (COMPANY_PEERS, CompanyPeer),
+            (KEY_EXECUTIVES, CompanyExecutive),
+            (INCOME_STATEMENT_TTM, IncomeStatement),
+        ],
+    )
+    def test_list_endpoints_bind_row_type(self, endpoint, row_type):
+        """List endpoints bind T as the row, not list[T]."""
+        assert endpoint.response_model is row_type


### PR DESCRIPTION
Closes #235.

`BaseClient.request` is `Endpoint[T] -> T | list[T]`. Annotating a list endpoint as `Endpoint[DelistedCompany]` (the row type) made `get_delisted_companies` unable to return `list[DelistedCompany]` without a cast. Copying the `PROFILE_CIK` pattern onto list endpoints is wrong: that one is unwrapped to a single object.

## What this does

Picks the helper option from the issue, not Endpoint cardinality and not a local `cast`:

- `request()` stays `T | list[T]`.
- New `BaseClient.request_list` / `request_async_list` are `Endpoint[T] -> list[T]`.
- `EndpointGroup._unwrap_list` (and the async twin) is the list counterpart of `_unwrap_single`. Client methods keep calling `request()` so existing mocks still work.
- A lone object from FMP becomes `[row]`. An empty list stays empty.

Company list endpoints (delisted, symbol-changes, M&A, peers, statements, …) are now `Endpoint[T]` for the row type, and the sync/async company methods go through `_unwrap_list`.

Other domains can migrate the same way; this PR does not drive-by-annotate the other ~200 untyped list endpoints.

## Tests

- `_unwrap_list` pass-through / wrap-single / empty list.
- `request_list` and `request_async_list` call through `request` / `request_async`.
- `get_delisted_companies` still asserts `request(...)` and now also wraps a lone row.
- `DELISTED_COMPANIES.response_model is DelistedCompany`.

Isolated worktree `fmp-data--fix-request-list-cardinality-235` off `origin/dev`.

Out of scope (per the issue): `extra="allow"` house style, empty-string date coercers, VCR cassettes.