### PR TITLE
fix(logger): stop doubling fmp_data. in get_logger(__name__)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,12 @@ None. No FMP path we ship was newly retired by this changelog window.
 
 ### Fixed
 
+- **`FMPLogger.get_logger(__name__)` no longer doubles `fmp_data.` (#238).**
+  The root logger is already `fmp_data`; `getChild(__name__)` was emitting
+  `fmp_data.fmp_data.base`, so `caplog` and log aggregators filtering
+  `fmp_data.base` missed extras / HTTP warnings. Qualified `fmp_data.*`
+  names are now used as-is. Handler and filter attachment is unchanged.
+
 - **CSV bulk parsing now honors `FMP_VALIDATION_MODE` (#232).** `parse_csv_models`
   used `model.model_validate` directly, so unknown bulk headers (`overallScore`
   on `rating-bulk`, a misspelled diluted-PE column) landed in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,9 @@ None. No FMP path we ship was newly retired by this changelog window.
   The root logger is already `fmp_data`; `getChild(__name__)` was emitting
   `fmp_data.fmp_data.base`, so `caplog` and log aggregators filtering
   `fmp_data.base` missed extras / HTTP warnings. Qualified `fmp_data.*`
-  names are now used as-is. Handler and filter attachment is unchanged.
+  names are now used as-is. If you already filtered the doubled name
+  (`fmp_data.fmp_data.*`), switch to `fmp_data.*`. Handler and filter
+  attachment is unchanged.
 
 - **CSV bulk parsing now honors `FMP_VALIDATION_MODE` (#232).** `parse_csv_models`
   used `model.model_validate` directly, so unknown bulk headers (`overallScore`

--- a/fmp_data/logger.py
+++ b/fmp_data/logger.py
@@ -298,18 +298,30 @@ class FMPLogger:
             self._add_default_console_handler()
 
     def get_logger(self, name: str | None = None) -> logging.Logger:
-        """
-        Get a logger instance with the given name
+        """Return a child of the package logger.
+
+        ``get_logger(__name__)`` must land on ``fmp_data.base``, not
+        ``fmp_data.fmp_data.base``. The root is already
+        ``logging.getLogger("fmp_data")``; ``getChild("fmp_data.base")``
+        would prefix an already-qualified module name (#238).
+
+        Handlers and filters stay on the root logger. Children propagate
+        to it unchanged.
 
         Args:
-            name: Optional name for the logger
+            name: Optional logger name. A fully-qualified ``fmp_data.*``
+                name (or ``"fmp_data"`` itself) is used as-is. Any other
+                name is added as a child of ``fmp_data``.
 
         Returns:
             logging.Logger: Logger instance
         """
-        if name:
-            return self._logger.getChild(name)
-        return self._logger
+        if not name or name == "fmp_data":
+            return self._logger
+        prefix = "fmp_data."
+        if name.startswith(prefix):
+            return self._logger.getChild(name[len(prefix) :])
+        return self._logger.getChild(name)
 
     def _add_default_console_handler(self) -> None:
         """Add default console handler with a reasonable format"""

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -256,17 +256,17 @@ class TestBatchClient:
         assert rating.price_to_book_score == 6
         assert not rating.__pydantic_extra__
 
-    def test_parse_csv_models_unknown_header_warns_once(self):
+    def test_parse_csv_models_unknown_header_warns_once(self, caplog):
         """Unknown bulk headers honor FMP_VALIDATION_MODE=warn (#232)."""
+        import logging
+
         from fmp_data.base import _extra_field_warnings_seen
 
         warning_key = ("rating-bulk", ("overallScore",))
         _extra_field_warnings_seen.discard(warning_key)
         csv_text = "symbol,date,rating,overallScore\nAAPL,2026-08-12,A-,7\n"
 
-        # Patch the module logger. FMPLogger().get_logger(__name__) is not
-        # logging.getLogger("fmp_data.base") — caplog on that name stays empty.
-        with patch("fmp_data.base.logger") as mock_logger:
+        with caplog.at_level(logging.WARNING, logger="fmp_data.base"):
             first = parse_csv_models(
                 csv_text.encode("utf-8"),
                 CompanyRating,
@@ -284,10 +284,12 @@ class TestBatchClient:
         assert first[0].__pydantic_extra__ is not None
         assert first[0].__pydantic_extra__["overallScore"] == "7"
         assert len(second) == 1
-        assert mock_logger.warning.call_count == 1
-        assert mock_logger.warning.call_args.args[0] == (
-            "Unknown response fields detected"
-        )
+        extras = [
+            record
+            for record in caplog.records
+            if record.getMessage() == "Unknown response fields detected"
+        ]
+        assert len(extras) == 1
         _extra_field_warnings_seen.discard(warning_key)
 
     def test_parse_csv_models_unknown_header_strict_raises(self):
@@ -303,10 +305,12 @@ class TestBatchClient:
                 endpoint_name="rating-bulk",
             )
 
-    def test_parse_csv_models_unknown_header_lenient_silent(self):
+    def test_parse_csv_models_unknown_header_lenient_silent(self, caplog):
         """Lenient mode keeps extras without warning."""
+        import logging
+
         csv_text = "symbol,date,rating,overallScore\nAAPL,2026-08-12,A-,7\n"
-        with patch("fmp_data.base.logger") as mock_logger:
+        with caplog.at_level(logging.WARNING, logger="fmp_data.base"):
             results = parse_csv_models(
                 csv_text.encode("utf-8"),
                 CompanyRating,
@@ -317,7 +321,7 @@ class TestBatchClient:
         assert len(results) == 1
         assert results[0].__pydantic_extra__ is not None
         assert results[0].__pydantic_extra__["overallScore"] == "7"
-        mock_logger.warning.assert_not_called()
+        assert "Unknown response fields detected" not in caplog.text
 
     def test_parse_csv_models_invalid_cell_strict_raises(self):
         """A bad cell fails the request in strict mode instead of dropping a row."""

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -290,6 +290,7 @@ class TestBatchClient:
             if record.getMessage() == "Unknown response fields detected"
         ]
         assert len(extras) == 1
+        assert extras[0].name == "fmp_data.base"
         _extra_field_warnings_seen.discard(warning_key)
 
     def test_parse_csv_models_unknown_header_strict_raises(self):

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -378,7 +378,22 @@ class TestFMPLogger:
         log = FMPLogger().get_logger("fmp_data.base")
         with caplog.at_level(logging.WARNING, logger="fmp_data.base"):
             log.warning("Unknown response fields detected")
-        assert "Unknown response fields detected" in caplog.text
+        extras = [
+            record
+            for record in caplog.records
+            if record.getMessage() == "Unknown response fields detected"
+        ]
+        assert len(extras) == 1
+        assert extras[0].name == "fmp_data.base"
+
+    def test_get_logger_qualified_name_is_stdlib_logger(self):
+        """Qualified names must be the same object operators already filter."""
+        fmp_logger = FMPLogger()
+        named = fmp_logger.get_logger("fmp_data.base")
+        assert named is logging.getLogger("fmp_data.base")
+        from fmp_data.base import logger as base_logger
+
+        assert base_logger.name == "fmp_data.base"
 
     def test_get_logger_without_name(self):
         """Test getting logger without name"""

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -363,6 +363,23 @@ class TestFMPLogger:
         named_logger = fmp_logger.get_logger("test.module")
         assert named_logger.name == "fmp_data.test.module"
 
+    def test_get_logger_does_not_double_package_prefix(self):
+        """get_logger(__name__) must not emit fmp_data.fmp_data.* (#238)."""
+        fmp_logger = FMPLogger()
+
+        assert fmp_logger.get_logger("fmp_data.base").name == "fmp_data.base"
+        assert fmp_logger.get_logger("fmp_data").name == "fmp_data"
+        assert fmp_logger.get_logger("fmp_data.mcp.tool_loader").name == (
+            "fmp_data.mcp.tool_loader"
+        )
+
+    def test_get_logger_module_name_is_visible_to_caplog(self, caplog):
+        """Operators and tests filtering fmp_data.base must see extras warnings."""
+        log = FMPLogger().get_logger("fmp_data.base")
+        with caplog.at_level(logging.WARNING, logger="fmp_data.base"):
+            log.warning("Unknown response fields detected")
+        assert "Unknown response fields detected" in caplog.text
+
     def test_get_logger_without_name(self):
         """Test getting logger without name"""
         fmp_logger = FMPLogger()

--- a/tests/unit/test_mcp.py
+++ b/tests/unit/test_mcp.py
@@ -757,6 +757,7 @@ class TestToolKeyNamespace:
         )
         logged = [r.getMessage() for r in caplog.records]
         assert len(logged) == 1, f"expected exactly one log record, got {logged}"
+        assert caplog.records[0].name == "fmp_data.mcp.tool_loader"
         assert "company.historical_price" in logged[0]
         assert "company.historical_prices" in logged[0]
         assert "3.0" in logged[0]

--- a/tests/unit/test_mcp.py
+++ b/tests/unit/test_mcp.py
@@ -748,9 +748,7 @@ class TestToolKeyNamespace:
                 "default", category=DeprecationWarning, module="__main__"
             )
             warnings.filterwarnings("ignore", category=DeprecationWarning)
-            with caplog.at_level(
-                logging.WARNING, logger="fmp_data.fmp_data.mcp.tool_loader"
-            ):
+            with caplog.at_level(logging.WARNING, logger="fmp_data.mcp.tool_loader"):
                 _warn_if_deprecated("company.historical_price")
 
         assert shown == [], (
@@ -769,9 +767,7 @@ class TestToolKeyNamespace:
         """The log channel must not turn every canonical key into noise."""
         from fmp_data.mcp.tool_loader import _warn_if_deprecated
 
-        with caplog.at_level(
-            logging.WARNING, logger="fmp_data.fmp_data.mcp.tool_loader"
-        ):
+        with caplog.at_level(logging.WARNING, logger="fmp_data.mcp.tool_loader"):
             _warn_if_deprecated("company.historical_prices")
 
         assert caplog.records == [], (


### PR DESCRIPTION
Closes #238.

`FMPLogger` roots at `logging.getLogger("fmp_data")`. `get_logger(__name__)` then called `getChild(name)`, so `fmp_data.base` became `fmp_data.fmp_data.base`.

That is why `caplog.at_level(..., logger="fmp_data.base")` was deaf on #237 even though extras warnings were emitted. Operators filtering `fmp_data.base` had the same hole.

## Change

Preferred option from the issue:

- If `name` is `fmp_data` or already starts with `fmp_data.`, use it as-is (via `getChild` of the suffix).
- Any other name is still a child of `fmp_data` (`get_logger("test.module")` → `fmp_data.test.module`).
- Handler and filter attachment stay on the root logger. No drive-by there.

## Tests

- Guard: `FMPLogger().get_logger("fmp_data.base").name == "fmp_data.base"`.
- `caplog` on `fmp_data.base` now sees a warning from that logger.
- The #232 CSV extras tests listen on `fmp_data.base` instead of patching the module logger.
- MCP deprecation tests listen on `fmp_data.mcp.tool_loader` (the doubled name is gone).

Isolated worktree `fmp-data--fix-logger-child-name-238` off `origin/dev`.