### PR TITLE
fix(logger): route leftover entry points through FMPLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,15 @@ None. No FMP path we ship was newly retired by this changelog window.
   (`fmp_data.fmp_data.*`), switch to `fmp_data.*`. Handler and filter
   attachment is unchanged.
 
+- **Remaining logging entry points go through `FMPLogger` (#241).**
+  Production `logging.getLogger(__name__)` call sites (CSV extras, secure
+  log-file chmod, cache backends, rate limiter, investment async) now use
+  `FMPLogger().get_logger(__name__)`. LangChain class-name loggers use
+  `__name__` + `.getChild(class)` so `ValidationRule` lands on
+  `fmp_data.lc.validation.ValidationRule` rather than `fmp_data.ValidationRule`.
+  Extras tests listen on `fmp_data.base` via `caplog`. Handler and filter
+  attachment is unchanged.
+
 - **CSV bulk parsing now honors `FMP_VALIDATION_MODE` (#232).** `parse_csv_models`
   used `model.model_validate` directly, so unknown bulk headers (`overallScore`
   on `rating-bulk`, a misspelled diluted-PE column) landed in

--- a/fmp_data/batch/_csv_utils.py
+++ b/fmp_data/batch/_csv_utils.py
@@ -2,7 +2,6 @@
 
 import csv
 import io
-import logging
 from typing import Any, TypeVar, get_args, get_origin
 
 from pydantic import AnyHttpUrl, BaseModel, HttpUrl
@@ -10,8 +9,9 @@ from pydantic import ValidationError as PydanticValidationError
 
 from fmp_data.base import BaseClient, ValidationMode
 from fmp_data.exceptions import ValidationError
+from fmp_data.logger import FMPLogger
 
-logger = logging.getLogger(__name__)
+logger = FMPLogger().get_logger(__name__)
 ModelT = TypeVar("ModelT", bound=BaseModel)
 
 

--- a/fmp_data/cache/file.py
+++ b/fmp_data/cache/file.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import logging
 import os
 from pathlib import Path
 import tempfile
@@ -12,8 +11,9 @@ import time
 from typing import Any
 
 from fmp_data.cache.base import CacheBackend
+from fmp_data.logger import FMPLogger
 
-logger = logging.getLogger(__name__)
+logger = FMPLogger().get_logger(__name__)
 
 
 class FileCache(CacheBackend):

--- a/fmp_data/cache/redis_backend.py
+++ b/fmp_data/cache/redis_backend.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import json
-import logging
 from typing import Any, cast
 
 from fmp_data.cache.base import CacheBackend
+from fmp_data.logger import FMPLogger
 
-logger = logging.getLogger(__name__)
+logger = FMPLogger().get_logger(__name__)
 
 
 class RedisCache(CacheBackend):

--- a/fmp_data/investment/async_client.py
+++ b/fmp_data/investment/async_client.py
@@ -2,7 +2,6 @@
 """Async client for investment products endpoints."""
 
 from datetime import date
-import logging
 import warnings
 
 from fmp_data.base import AsyncEndpointGroup
@@ -32,8 +31,9 @@ from fmp_data.investment.models import (
     MutualFundHolder,
     MutualFundHolding,
 )
+from fmp_data.logger import FMPLogger
 
-logger = logging.getLogger(__name__)
+logger = FMPLogger().get_logger(__name__)
 
 
 class AsyncInvestmentClient(AsyncEndpointGroup):

--- a/fmp_data/lc/registry.py
+++ b/fmp_data/lc/registry.py
@@ -293,7 +293,7 @@ class ValidationRule(ABC):
     """Abstract base class for validation rules."""
 
     def __init__(self) -> None:
-        self.logger = FMPLogger().get_logger(self.__class__.__name__)
+        self.logger = FMPLogger().get_logger(__name__).getChild(self.__class__.__name__)
 
     @property
     @abstractmethod
@@ -490,7 +490,7 @@ class ValidationRuleRegistry:
     def __init__(self) -> None:
         """Initialize the registry."""
         self._rules: list[ValidationRule] = []
-        self.logger = FMPLogger().get_logger(self.__class__.__name__)
+        self.logger = FMPLogger().get_logger(__name__).getChild(self.__class__.__name__)
 
     def register_rule(self, rule: ValidationRule) -> None:
         """Register a validation rule."""

--- a/fmp_data/lc/validation.py
+++ b/fmp_data/lc/validation.py
@@ -87,7 +87,7 @@ class CommonValidationRule(ValidationRule):
 
     def __init__(self) -> None:
         super().__init__()
-        self.logger = FMPLogger().get_logger(self.__class__.__name__)
+        self.logger = FMPLogger().get_logger(__name__).getChild(self.__class__.__name__)
 
     @property
     @abstractmethod
@@ -185,7 +185,7 @@ class ValidationRuleRegistry:
     def __init__(self) -> None:
         """Initialize the registry."""
         self._rules: list[ValidationRule] = []
-        self.logger = FMPLogger().get_logger(self.__class__.__name__)
+        self.logger = FMPLogger().get_logger(__name__).getChild(self.__class__.__name__)
 
     def register_rule(self, rule: ValidationRule) -> None:
         """Register a validation rule"""

--- a/fmp_data/logger.py
+++ b/fmp_data/logger.py
@@ -258,7 +258,7 @@ class SecureRotatingFileHandler(RotatingFileHandler):
                 os.chmod(self.baseFilename, 0o600)
                 self._permissions_set = True
             except OSError as e:
-                logging.getLogger(__name__).warning(
+                FMPLogger().get_logger(__name__).warning(
                     f"Could not set secure permissions on log file: {e}"
                 )
 

--- a/fmp_data/rate_limit.py
+++ b/fmp_data/rate_limit.py
@@ -7,10 +7,11 @@ from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from email.utils import parsedate_to_datetime
 import json
-import logging
 import time
 
-logger = logging.getLogger(__name__)
+from fmp_data.logger import FMPLogger
+
+logger = FMPLogger().get_logger(__name__)
 
 
 @dataclass

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import traceback
 from unittest.mock import MagicMock, Mock, patch
 
@@ -738,7 +739,7 @@ def test_process_response_strict_mode_rejects_unknown_fields() -> None:
         )
 
 
-def test_process_response_warn_mode_logs_unknown_fields() -> None:
+def test_process_response_warn_mode_logs_unknown_fields(caplog) -> None:
     """Warn mode should log unknown fields on extra-allow models."""
 
     class ExtraAllowModel(BaseModel):
@@ -749,14 +750,15 @@ def test_process_response_warn_mode_logs_unknown_fields() -> None:
     endpoint.name = "warn_extra_endpoint"
     endpoint.response_model = ExtraAllowModel
 
-    with patch("fmp_data.base.logger.warning") as mock_warning:
+    with caplog.at_level(logging.WARNING, logger="fmp_data.base"):
         result: ExtraAllowModel | list[ExtraAllowModel] = BaseClient._process_response(
             endpoint, {"value": 1, "unexpected": 2}, validation_mode="warn"
         )
 
     assert isinstance(result, ExtraAllowModel)
     assert result.value == 1
-    mock_warning.assert_called()
+    extras = [record for record in caplog.records if record.name == "fmp_data.base"]
+    assert extras
 
 
 def test_client_cleanup(base_client):

--- a/tests/unit/test_base_coverage.py
+++ b/tests/unit/test_base_coverage.py
@@ -1,5 +1,6 @@
 """Additional tests for base.py to improve coverage"""
 
+import logging
 from typing import cast
 from unittest.mock import Mock, patch
 
@@ -168,17 +169,23 @@ class TestValidateModel:
         with pytest.raises(ValidationError, match=r"\.\.\.$"):
             BaseClient._validate_model("test_ep", _SampleModel, payload, "strict")
 
-    def test_warn_logs_once_per_endpoint(self):
+    def test_warn_logs_once_per_endpoint(self, caplog):
         _extra_field_warnings_seen.discard(("dedup_ep", ("bonus",)))
         payload = {"name": "x", "value": 1, "bonus": True}
 
-        with patch("fmp_data.base.logger") as mock_logger:
+        with caplog.at_level(logging.WARNING, logger="fmp_data.base"):
             BaseClient._validate_model("dedup_ep", _SampleModel, payload, "warn")
-            assert mock_logger.warning.call_count == 1
+            extras = [
+                record for record in caplog.records if record.name == "fmp_data.base"
+            ]
+            assert len(extras) == 1
 
             # Second call with same endpoint+fields should NOT log again
             BaseClient._validate_model("dedup_ep", _SampleModel, payload, "warn")
-            assert mock_logger.warning.call_count == 1
+            extras = [
+                record for record in caplog.records if record.name == "fmp_data.base"
+            ]
+            assert len(extras) == 1
 
         # Cleanup
         _extra_field_warnings_seen.discard(("dedup_ep", ("bonus",)))

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -290,22 +290,24 @@ class TestSecureRotatingFileHandler:
             permissions = stat_info.st_mode & 0o777
             assert permissions == 0o600
 
-    def test_permission_error_handling(self, tmp_path):
-        """Test handling of permission errors"""
+    def test_permission_error_handling(self, tmp_path, caplog):
+        """chmod failures log on fmp_data.logger, not a stdlib-only logger (#241)."""
         log_file = tmp_path / "test.log"
 
-        with patch("os.chmod", side_effect=OSError("Permission denied")):
-            with patch("logging.getLogger") as mock_get_logger:
-                mock_logger = Mock()
-                mock_get_logger.return_value = mock_logger
+        with (
+            patch("os.chmod", side_effect=OSError("Permission denied")),
+            caplog.at_level(logging.WARNING, logger="fmp_data.logger"),
+        ):
+            _ = SecureRotatingFileHandler(filename=str(log_file))
 
-                _ = SecureRotatingFileHandler(filename=str(log_file))
-
-                # Should have logged a warning (possibly called once during init)
-                assert mock_logger.warning.called
-                assert "Could not set secure permissions" in str(
-                    mock_logger.warning.call_args_list
-                )
+        extras = [
+            record
+            for record in caplog.records
+            if "Could not set secure permissions" in record.getMessage()
+        ]
+        # __init__ and _open both try chmod when the file is first used.
+        assert extras
+        assert all(record.name == "fmp_data.logger" for record in extras)
 
     def test_windows_skip_permissions(self, tmp_path):
         """Test that permission setting is skipped on Windows"""
@@ -394,6 +396,97 @@ class TestFMPLogger:
         from fmp_data.base import logger as base_logger
 
         assert base_logger.name == "fmp_data.base"
+
+    def test_csv_utils_logger_is_package_child(self):
+        """batch._csv_utils must go through FMPLogger, not stdlib getLogger (#241)."""
+        from fmp_data.batch._csv_utils import logger as csv_logger
+
+        assert csv_logger.name == "fmp_data.batch._csv_utils"
+        assert csv_logger is FMPLogger().get_logger("fmp_data.batch._csv_utils")
+
+    def test_remaining_stdlib_module_loggers_are_package_children(self):
+        """Leftover fmp_data.* module loggers must sit on the package tree (#241)."""
+        from fmp_data.cache.file import logger as file_logger
+        from fmp_data.cache.redis_backend import logger as redis_logger
+        from fmp_data.investment.async_client import logger as investment_logger
+        from fmp_data.rate_limit import logger as rate_logger
+
+        expected = {
+            file_logger: "fmp_data.cache.file",
+            redis_logger: "fmp_data.cache.redis_backend",
+            investment_logger: "fmp_data.investment.async_client",
+            rate_logger: "fmp_data.rate_limit",
+        }
+        for log, name in expected.items():
+            assert log.name == name
+            assert log is FMPLogger().get_logger(name)
+
+    def test_lc_class_loggers_use_module_tree(self):
+        """Class-name loggers must land on fmp_data.lc.*, not fmp_data.Class (#241)."""
+        from fmp_data.lc.models import SemanticCategory
+        from fmp_data.lc.registry import EndpointBasedRule, EndpointRegistry
+        from fmp_data.lc.registry import ValidationRuleRegistry as RegistryRules
+        from fmp_data.lc.validation import CommonValidationRule
+        from fmp_data.lc.validation import ValidationRuleRegistry as ValidationRules
+
+        class _StubRule(CommonValidationRule):
+            @property
+            def expected_category(self) -> SemanticCategory:
+                return SemanticCategory.COMPANY_INFO
+
+        rule = _StubRule()
+        assert rule.logger.name == "fmp_data.lc.validation._StubRule"
+
+        validation_registry = ValidationRules()
+        assert validation_registry.logger.name == (
+            "fmp_data.lc.validation.ValidationRuleRegistry"
+        )
+
+        registry_rules = RegistryRules()
+        assert registry_rules.logger.name == (
+            "fmp_data.lc.registry.ValidationRuleRegistry"
+        )
+
+        endpoint_rule = EndpointBasedRule({}, SemanticCategory.COMPANY_INFO)
+        assert endpoint_rule.logger.name == "fmp_data.lc.registry.EndpointBasedRule"
+
+        endpoint_registry = EndpointRegistry()
+        assert endpoint_registry.logger.name == "fmp_data.lc.registry.EndpointRegistry"
+
+    def test_package_modules_do_not_call_stdlib_getlogger_name(self):
+        """Production fmp_data modules must enter via FMPLogger (#241)."""
+        import ast
+        from pathlib import Path
+
+        root = Path(__file__).resolve().parents[2] / "fmp_data"
+        offenders: list[str] = []
+        for path in root.rglob("*.py"):
+            tree = ast.parse(path.read_text(), filename=str(path))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                if not (
+                    isinstance(func, ast.Attribute)
+                    and func.attr == "getLogger"
+                    and isinstance(func.value, ast.Name)
+                    and func.value.id == "logging"
+                ):
+                    continue
+                if len(node.args) != 1:
+                    continue
+                arg = node.args[0]
+                # Root construction in FMPLogger stays stdlib.
+                if (
+                    isinstance(arg, ast.Constant)
+                    and arg.value == "fmp_data"
+                    and path.name == "logger.py"
+                ):
+                    continue
+                if isinstance(arg, ast.Name) and arg.id == "__name__":
+                    offenders.append(f"{path.relative_to(root.parent)}:{node.lineno}")
+
+        assert offenders == []
 
     def test_get_logger_without_name(self):
         """Test getting logger without name"""


### PR DESCRIPTION
Closes #241.

#238 / #240 stopped `get_logger(__name__)` from emitting `fmp_data.fmp_data.*`. Two leftover styles still produced names operators will not expect.

## What this does

1. Route remaining production `logging.getLogger(__name__)` sites through `FMPLogger`:
   - `fmp_data.batch._csv_utils`
   - `SecureRotatingFileHandler` chmod warning
   - cache backends, rate limiter, investment async (same leftover style)
2. Change LC class-name loggers to `__name__` + `.getChild(class)` so `ValidationRule` lands on `fmp_data.lc.validation.ValidationRule` rather than `fmp_data.ValidationRule`. `EndpointRegistry` already used this pattern.
3. Convert extras tests from `patch("fmp_data.base.logger")` to `caplog` on `fmp_data.base`.

Handler and filter attachment is unchanged.

## Tests

- Guard: production modules do not call `logging.getLogger(__name__)` (root `fmp_data` construction stays stdlib).
- LC class loggers pin the module-tree names.
- chmod failures are visible on `fmp_data.logger` via caplog.
- CSV / cache / rate-limit / investment async loggers are `FMPLogger` children.

Isolated worktree `fmp-data--fix-logger-entry-points-241` off `origin/dev`.