### PR TITLE
feat(client): migrate remaining list endpoints through _unwrap_list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ None. No FMP path we ship was newly retired by this changelog window.
   `request()` / `request_async()` with `_unwrap_list`. Company historical
   EOD helpers unwrap rows then wrap `HistoricalData`. `request()` stays
   `T | list[T]`. Methods are not switched to `request_list`.
+  `get_mutual_fund_dates` / `get_fund_disclosure_dates` are annotated
+  `list[PortfolioDate]` (runtime already returned `PortfolioDate` rows).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,14 @@ None. No FMP path we ship was newly retired by this changelog window.
   need to mock `request`. A lone object becomes `[row]`; an empty list
   stays empty.
 
+- **Remaining list endpoints and methods now go through `_unwrap_list` /
+  `Endpoint[T]` (#242).** Market, fundamental, investment, intelligence,
+  institutional, alternative, economics, and technical list surfaces bind
+  the row type (`Endpoint[T]`, not `Endpoint[list[T]]`) and normalize
+  `request()` / `request_async()` with `_unwrap_list`. Company historical
+  EOD helpers unwrap rows then wrap `HistoricalData`. `request()` stays
+  `T | list[T]`. Methods are not switched to `request_list`.
+
 ### Added
 
 - **FMP hosted MCP vs `fmp-mcp` positioning (#230).** Docs-only: we are not

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -135,7 +135,10 @@ class ExampleClient(EndpointGroup):
             RateLimitError: If rate limit is exceeded
         """
         endpoint = self._endpoints.example_data
-        return self._client.request(endpoint, symbol=symbol)
+        return self._unwrap_list(
+            self._client.request(endpoint, symbol=symbol),
+            ExampleModel,
+        )
 ```
 
 ### Documentation Standards

--- a/fmp_data/alternative/async_client.py
+++ b/fmp_data/alternative/async_client.py
@@ -22,19 +22,22 @@ from fmp_data.alternative.endpoints import (
 )
 from fmp_data.alternative.models import (
     Commodity,
+    CommodityHistoricalPrice,
     CommodityIntradayPrice,
     CommodityPriceHistory,
     CommodityQuote,
     CryptoHistoricalData,
+    CryptoHistoricalPrice,
     CryptoIntradayPrice,
     CryptoPair,
     CryptoQuote,
+    ForexHistoricalPrice,
     ForexIntradayPrice,
     ForexPair,
     ForexPriceHistory,
     ForexQuote,
 )
-from fmp_data.base import AsyncEndpointGroup
+from fmp_data.base import AsyncEndpointGroup, EndpointGroup
 from fmp_data.helpers import deprecated
 
 ModelT = TypeVar("ModelT", bound=BaseModel)
@@ -44,15 +47,18 @@ class AsyncAlternativeMarketsClient(AsyncEndpointGroup):
     """Async client for alternative markets endpoints."""
 
     @staticmethod
-    def _wrap_history(symbol: str, result: object, model: type[ModelT]) -> ModelT:
-        if isinstance(result, list):
-            return model.model_validate({"symbol": symbol, "historical": result})
-        return model.model_validate(result)
+    def _wrap_history(
+        symbol: str, result: object, container: type[ModelT], row_type: type
+    ) -> ModelT:
+        rows = EndpointGroup._unwrap_list(result, row_type)
+        return container.model_validate({"symbol": symbol, "historical": rows})
 
     # Cryptocurrency methods
     async def get_crypto_list(self) -> list[CryptoPair]:
         """Get list of available cryptocurrencies"""
-        return await self.client.request_async(CRYPTO_LIST)
+        return self._unwrap_list(
+            await self.client.request_async(CRYPTO_LIST), CryptoPair
+        )
 
     @deprecated(
         "quotes/crypto is dead. The live path batch-crypto-quotes is already "
@@ -93,20 +99,25 @@ class AsyncAlternativeMarketsClient(AsyncEndpointGroup):
             params["end_date"] = end_date.strftime("%Y-%m-%d")
 
         result = await self.client.request_async(CRYPTO_HISTORICAL, **params)
-        return self._wrap_history(symbol, result, CryptoHistoricalData)
+        return self._wrap_history(
+            symbol, result, CryptoHistoricalData, CryptoHistoricalPrice
+        )
 
     async def get_crypto_intraday(
         self, symbol: str, interval: str = "5min"
     ) -> list[CryptoIntradayPrice]:
         """Get cryptocurrency intraday prices"""
-        return await self.client.request_async(
-            CRYPTO_INTRADAY, symbol=symbol, interval=interval
+        return self._unwrap_list(
+            await self.client.request_async(
+                CRYPTO_INTRADAY, symbol=symbol, interval=interval
+            ),
+            CryptoIntradayPrice,
         )
 
     # Forex methods
     async def get_forex_list(self) -> list[ForexPair]:
         """Get list of available forex pairs"""
-        return await self.client.request_async(FOREX_LIST)
+        return self._unwrap_list(await self.client.request_async(FOREX_LIST), ForexPair)
 
     @deprecated(
         "quotes/forex is dead. The live path batch-forex-quotes is already "
@@ -145,20 +156,27 @@ class AsyncAlternativeMarketsClient(AsyncEndpointGroup):
             params["end_date"] = end_date.strftime("%Y-%m-%d")
 
         result = await self.client.request_async(FOREX_HISTORICAL, **params)
-        return self._wrap_history(symbol, result, ForexPriceHistory)
+        return self._wrap_history(
+            symbol, result, ForexPriceHistory, ForexHistoricalPrice
+        )
 
     async def get_forex_intraday(
         self, symbol: str, interval: str = "5min"
     ) -> list[ForexIntradayPrice]:
         """Get forex intraday prices"""
-        return await self.client.request_async(
-            FOREX_INTRADAY, symbol=symbol, interval=interval
+        return self._unwrap_list(
+            await self.client.request_async(
+                FOREX_INTRADAY, symbol=symbol, interval=interval
+            ),
+            ForexIntradayPrice,
         )
 
     # Commodities methods
     async def get_commodities_list(self) -> list[Commodity]:
         """Get list of available commodities"""
-        return await self.client.request_async(COMMODITIES_LIST)
+        return self._unwrap_list(
+            await self.client.request_async(COMMODITIES_LIST), Commodity
+        )
 
     @deprecated(
         "quotes/commodity is dead. The live path batch-commodity-quotes is "
@@ -197,12 +215,17 @@ class AsyncAlternativeMarketsClient(AsyncEndpointGroup):
             params["end_date"] = end_date.strftime("%Y-%m-%d")
 
         result = await self.client.request_async(COMMODITY_HISTORICAL, **params)
-        return self._wrap_history(symbol, result, CommodityPriceHistory)
+        return self._wrap_history(
+            symbol, result, CommodityPriceHistory, CommodityHistoricalPrice
+        )
 
     async def get_commodity_intraday(
         self, symbol: str, interval: str = "5min"
     ) -> list[CommodityIntradayPrice]:
         """Get commodity intraday prices"""
-        return await self.client.request_async(
-            COMMODITY_INTRADAY, symbol=symbol, interval=interval
+        return self._unwrap_list(
+            await self.client.request_async(
+                COMMODITY_INTRADAY, symbol=symbol, interval=interval
+            ),
+            CommodityIntradayPrice,
         )

--- a/fmp_data/alternative/async_client.py
+++ b/fmp_data/alternative/async_client.py
@@ -37,7 +37,7 @@ from fmp_data.alternative.models import (
     ForexPriceHistory,
     ForexQuote,
 )
-from fmp_data.base import AsyncEndpointGroup, EndpointGroup
+from fmp_data.base import AsyncEndpointGroup
 from fmp_data.helpers import deprecated
 
 ModelT = TypeVar("ModelT", bound=BaseModel)
@@ -50,7 +50,7 @@ class AsyncAlternativeMarketsClient(AsyncEndpointGroup):
     def _wrap_history(
         symbol: str, result: object, container: type[ModelT], row_type: type
     ) -> ModelT:
-        rows = EndpointGroup._unwrap_list(result, row_type)
+        rows = AsyncEndpointGroup._unwrap_list(result, row_type)
         return container.model_validate({"symbol": symbol, "historical": rows})
 
     # Cryptocurrency methods

--- a/fmp_data/alternative/client.py
+++ b/fmp_data/alternative/client.py
@@ -20,13 +20,16 @@ from fmp_data.alternative.endpoints import (
 )
 from fmp_data.alternative.models import (
     Commodity,
+    CommodityHistoricalPrice,
     CommodityIntradayPrice,
     CommodityPriceHistory,
     CommodityQuote,
     CryptoHistoricalData,
+    CryptoHistoricalPrice,
     CryptoIntradayPrice,
     CryptoPair,
     CryptoQuote,
+    ForexHistoricalPrice,
     ForexIntradayPrice,
     ForexPair,
     ForexPriceHistory,
@@ -42,15 +45,16 @@ class AlternativeMarketsClient(EndpointGroup):
     """Client for alternative markets endpoints"""
 
     @staticmethod
-    def _wrap_history(symbol: str, result: object, model: type[ModelT]) -> ModelT:
-        if isinstance(result, list):
-            return model.model_validate({"symbol": symbol, "historical": result})
-        return model.model_validate(result)
+    def _wrap_history(
+        symbol: str, result: object, container: type[ModelT], row_type: type
+    ) -> ModelT:
+        rows = EndpointGroup._unwrap_list(result, row_type)
+        return container.model_validate({"symbol": symbol, "historical": rows})
 
     # Cryptocurrency methods
     def get_crypto_list(self) -> list[CryptoPair]:
         """Get list of available cryptocurrencies"""
-        return self.client.request(CRYPTO_LIST)
+        return self._unwrap_list(self.client.request(CRYPTO_LIST), CryptoPair)
 
     @deprecated(
         "quotes/crypto is dead. The live path batch-crypto-quotes is already "
@@ -91,18 +95,23 @@ class AlternativeMarketsClient(EndpointGroup):
             params["end_date"] = end_date.strftime("%Y-%m-%d")
 
         result = self.client.request(CRYPTO_HISTORICAL, **params)
-        return self._wrap_history(symbol, result, CryptoHistoricalData)
+        return self._wrap_history(
+            symbol, result, CryptoHistoricalData, CryptoHistoricalPrice
+        )
 
     def get_crypto_intraday(
         self, symbol: str, interval: str = "5min"
     ) -> list[CryptoIntradayPrice]:
         """Get cryptocurrency intraday prices"""
-        return self.client.request(CRYPTO_INTRADAY, symbol=symbol, interval=interval)
+        return self._unwrap_list(
+            self.client.request(CRYPTO_INTRADAY, symbol=symbol, interval=interval),
+            CryptoIntradayPrice,
+        )
 
     # Forex methods
     def get_forex_list(self) -> list[ForexPair]:
         """Get list of available forex pairs"""
-        return self.client.request(FOREX_LIST)
+        return self._unwrap_list(self.client.request(FOREX_LIST), ForexPair)
 
     @deprecated(
         "quotes/forex is dead. The live path batch-forex-quotes is already "
@@ -141,18 +150,23 @@ class AlternativeMarketsClient(EndpointGroup):
             params["end_date"] = end_date.strftime("%Y-%m-%d")
 
         result = self.client.request(FOREX_HISTORICAL, **params)
-        return self._wrap_history(symbol, result, ForexPriceHistory)
+        return self._wrap_history(
+            symbol, result, ForexPriceHistory, ForexHistoricalPrice
+        )
 
     def get_forex_intraday(
         self, symbol: str, interval: str = "5min"
     ) -> list[ForexIntradayPrice]:
         """Get forex intraday prices"""
-        return self.client.request(FOREX_INTRADAY, symbol=symbol, interval=interval)
+        return self._unwrap_list(
+            self.client.request(FOREX_INTRADAY, symbol=symbol, interval=interval),
+            ForexIntradayPrice,
+        )
 
     # Commodities methods
     def get_commodities_list(self) -> list[Commodity]:
         """Get list of available commodities"""
-        return self.client.request(COMMODITIES_LIST)
+        return self._unwrap_list(self.client.request(COMMODITIES_LIST), Commodity)
 
     @deprecated(
         "quotes/commodity is dead. The live path batch-commodity-quotes is "
@@ -191,10 +205,15 @@ class AlternativeMarketsClient(EndpointGroup):
             params["end_date"] = end_date.strftime("%Y-%m-%d")
 
         result = self.client.request(COMMODITY_HISTORICAL, **params)
-        return self._wrap_history(symbol, result, CommodityPriceHistory)
+        return self._wrap_history(
+            symbol, result, CommodityPriceHistory, CommodityHistoricalPrice
+        )
 
     def get_commodity_intraday(
         self, symbol: str, interval: str = "5min"
     ) -> list[CommodityIntradayPrice]:
         """Get commodity intraday prices"""
-        return self.client.request(COMMODITY_INTRADAY, symbol=symbol, interval=interval)
+        return self._unwrap_list(
+            self.client.request(COMMODITY_INTRADAY, symbol=symbol, interval=interval),
+            CommodityIntradayPrice,
+        )

--- a/fmp_data/alternative/endpoints.py
+++ b/fmp_data/alternative/endpoints.py
@@ -27,7 +27,7 @@ from fmp_data.models import (
 # Validation constants
 VALID_INTERVALS = ["1min", "5min", "15min", "30min", "1hour", "4hour"]
 
-CRYPTO_LIST: Endpoint = Endpoint(
+CRYPTO_LIST: Endpoint[CryptoPair] = Endpoint(
     name="crypto_list",
     path="cryptocurrency-list",
     version=APIVersion.STABLE,
@@ -48,7 +48,7 @@ CRYPTO_LIST: Endpoint = Endpoint(
     ],
 )
 
-CRYPTO_QUOTES: Endpoint = Endpoint(
+CRYPTO_QUOTES: Endpoint[CryptoQuote] = Endpoint(
     name="crypto_quotes",
     path="quotes/crypto",
     version=APIVersion.STABLE,
@@ -99,7 +99,7 @@ CRYPTO_QUOTE: Endpoint[CryptoQuote] = Endpoint(
     ],
 )
 
-CRYPTO_HISTORICAL: Endpoint = Endpoint(
+CRYPTO_HISTORICAL: Endpoint[CryptoHistoricalPrice] = Endpoint(
     name="crypto_historical",
     path="historical-price-eod/full",
     version=APIVersion.STABLE,
@@ -143,7 +143,7 @@ CRYPTO_HISTORICAL: Endpoint = Endpoint(
     ],
 )
 
-CRYPTO_INTRADAY: Endpoint = Endpoint(
+CRYPTO_INTRADAY: Endpoint[CryptoIntradayPrice] = Endpoint(
     name="crypto_intraday",
     path="historical-chart/{interval}",
     version=APIVersion.STABLE,
@@ -179,7 +179,7 @@ CRYPTO_INTRADAY: Endpoint = Endpoint(
     ],
 )
 
-FOREX_LIST: Endpoint = Endpoint(
+FOREX_LIST: Endpoint[ForexPair] = Endpoint(
     name="forex_list",
     path="forex-list",
     version=APIVersion.STABLE,
@@ -200,7 +200,7 @@ FOREX_LIST: Endpoint = Endpoint(
     ],
 )
 
-FOREX_QUOTES: Endpoint = Endpoint(
+FOREX_QUOTES: Endpoint[ForexQuote] = Endpoint(
     name="forex_quotes",
     path="quotes/forex",
     version=APIVersion.STABLE,
@@ -250,7 +250,7 @@ FOREX_QUOTE: Endpoint[ForexQuote] = Endpoint(
     ],
 )
 
-FOREX_HISTORICAL: Endpoint = Endpoint(
+FOREX_HISTORICAL: Endpoint[ForexHistoricalPrice] = Endpoint(
     name="forex_historical",
     path="historical-price-eod/full",
     version=APIVersion.STABLE,
@@ -293,7 +293,7 @@ FOREX_HISTORICAL: Endpoint = Endpoint(
     ],
 )
 
-FOREX_INTRADAY: Endpoint = Endpoint(
+FOREX_INTRADAY: Endpoint[ForexIntradayPrice] = Endpoint(
     name="forex_intraday",
     path="historical-chart/{interval}",
     version=APIVersion.STABLE,
@@ -329,7 +329,7 @@ FOREX_INTRADAY: Endpoint = Endpoint(
     ],
 )
 
-COMMODITIES_LIST: Endpoint = Endpoint(
+COMMODITIES_LIST: Endpoint[Commodity] = Endpoint(
     name="commodities_list",
     path="commodities-list",
     version=APIVersion.STABLE,
@@ -350,7 +350,7 @@ COMMODITIES_LIST: Endpoint = Endpoint(
     ],
 )
 
-COMMODITIES_QUOTES: Endpoint = Endpoint(
+COMMODITIES_QUOTES: Endpoint[CommodityQuote] = Endpoint(
     name="commodities_quotes",
     path="quotes/commodity",
     version=APIVersion.STABLE,
@@ -402,7 +402,7 @@ COMMODITY_QUOTE: Endpoint[CommodityQuote] = Endpoint(
     ],
 )
 
-COMMODITY_HISTORICAL: Endpoint = Endpoint(
+COMMODITY_HISTORICAL: Endpoint[CommodityHistoricalPrice] = Endpoint(
     name="commodity_historical",
     path="historical-price-eod/full",
     version=APIVersion.STABLE,
@@ -449,7 +449,7 @@ COMMODITY_HISTORICAL: Endpoint = Endpoint(
     ],
 )
 
-COMMODITY_INTRADAY: Endpoint = Endpoint(
+COMMODITY_INTRADAY: Endpoint[CommodityIntradayPrice] = Endpoint(
     name="commodity_intraday",
     path="historical-chart/{interval}",
     version=APIVersion.STABLE,

--- a/fmp_data/alternative/mapping.py
+++ b/fmp_data/alternative/mapping.py
@@ -1,6 +1,8 @@
 # fmp_data/alternative/mapping.py
 from __future__ import annotations
 
+from typing import Any
+
 from fmp_data.alternative.endpoints import (
     COMMODITIES_LIST,
     COMMODITIES_QUOTES,
@@ -25,27 +27,28 @@ from fmp_data.lc.models import (
     ResponseFieldInfo,
     SemanticCategory,
 )
+from fmp_data.models import Endpoint
 
 # Create method name mapping
-ALTERNATIVE_ENDPOINT_MAP = {
-    f"get_{name}": endpoint
-    for name, endpoint in {
-        "crypto_list": CRYPTO_LIST,
-        "crypto_quotes": CRYPTO_QUOTES,
-        "crypto_quote": CRYPTO_QUOTE,
-        "crypto_historical": CRYPTO_HISTORICAL,
-        "crypto_intraday": CRYPTO_INTRADAY,
-        "forex_list": FOREX_LIST,
-        "forex_quotes": FOREX_QUOTES,
-        "forex_quote": FOREX_QUOTE,
-        "forex_historical": FOREX_HISTORICAL,
-        "forex_intraday": FOREX_INTRADAY,
-        "commodities_list": COMMODITIES_LIST,
-        "commodities_quotes": COMMODITIES_QUOTES,
-        "commodity_quote": COMMODITY_QUOTE,
-        "commodity_historical": COMMODITY_HISTORICAL,
-        "commodity_intraday": COMMODITY_INTRADAY,
-    }.items()
+_ALTERNATIVE_ENDPOINTS: dict[str, Endpoint[Any]] = {
+    "crypto_list": CRYPTO_LIST,
+    "crypto_quotes": CRYPTO_QUOTES,
+    "crypto_quote": CRYPTO_QUOTE,
+    "crypto_historical": CRYPTO_HISTORICAL,
+    "crypto_intraday": CRYPTO_INTRADAY,
+    "forex_list": FOREX_LIST,
+    "forex_quotes": FOREX_QUOTES,
+    "forex_quote": FOREX_QUOTE,
+    "forex_historical": FOREX_HISTORICAL,
+    "forex_intraday": FOREX_INTRADAY,
+    "commodities_list": COMMODITIES_LIST,
+    "commodities_quotes": COMMODITIES_QUOTES,
+    "commodity_quote": COMMODITY_QUOTE,
+    "commodity_historical": COMMODITY_HISTORICAL,
+    "commodity_intraday": COMMODITY_INTRADAY,
+}
+ALTERNATIVE_ENDPOINT_MAP: dict[str, Endpoint[Any]] = {
+    f"get_{name}": endpoint for name, endpoint in _ALTERNATIVE_ENDPOINTS.items()
 }
 
 # Common parameter hints

--- a/fmp_data/company/async_client.py
+++ b/fmp_data/company/async_client.py
@@ -78,6 +78,7 @@ from fmp_data.company.models import (
     FinancialReportJSON,
     GeographicRevenueSegment,
     HistoricalData,
+    HistoricalPrice,
     HistoricalShareFloat,
     IntradayPrice,
     MergerAcquisition,
@@ -243,12 +244,11 @@ class AsyncCompanyClient(AsyncEndpointGroup):
         if end_date:
             params["end_date"] = end_date
 
-        result = await self.client.request_async(HISTORICAL_PRICE, **params)
-
-        if isinstance(result, list):
-            return HistoricalData(symbol=symbol, historical=result)
-        else:
-            return HistoricalData(symbol=symbol, historical=[result])
+        rows = self._unwrap_list(
+            await self.client.request_async(HISTORICAL_PRICE, **params),
+            HistoricalPrice,
+        )
+        return HistoricalData(symbol=symbol, historical=rows)
 
     async def get_intraday_prices(
         self,
@@ -597,12 +597,11 @@ class AsyncCompanyClient(AsyncEndpointGroup):
         if end_date:
             params["end_date"] = end_date
 
-        result = await self.client.request_async(HISTORICAL_PRICE_LIGHT, **params)
-
-        if isinstance(result, list):
-            return HistoricalData(symbol=symbol, historical=result)
-        else:
-            return HistoricalData(symbol=symbol, historical=[result])
+        rows = self._unwrap_list(
+            await self.client.request_async(HISTORICAL_PRICE_LIGHT, **params),
+            HistoricalPrice,
+        )
+        return HistoricalData(symbol=symbol, historical=rows)
 
     async def get_historical_prices_non_split_adjusted(
         self,
@@ -628,14 +627,13 @@ class AsyncCompanyClient(AsyncEndpointGroup):
         if end_date:
             params["end_date"] = end_date
 
-        result = await self.client.request_async(
-            HISTORICAL_PRICE_NON_SPLIT_ADJUSTED, **params
+        rows = self._unwrap_list(
+            await self.client.request_async(
+                HISTORICAL_PRICE_NON_SPLIT_ADJUSTED, **params
+            ),
+            HistoricalPrice,
         )
-
-        if isinstance(result, list):
-            return HistoricalData(symbol=symbol, historical=result)
-        else:
-            return HistoricalData(symbol=symbol, historical=[result])
+        return HistoricalData(symbol=symbol, historical=rows)
 
     async def get_historical_prices_dividend_adjusted(
         self,
@@ -661,14 +659,13 @@ class AsyncCompanyClient(AsyncEndpointGroup):
         if end_date:
             params["end_date"] = end_date
 
-        result = await self.client.request_async(
-            HISTORICAL_PRICE_DIVIDEND_ADJUSTED, **params
+        rows = self._unwrap_list(
+            await self.client.request_async(
+                HISTORICAL_PRICE_DIVIDEND_ADJUSTED, **params
+            ),
+            HistoricalPrice,
         )
-
-        if isinstance(result, list):
-            return HistoricalData(symbol=symbol, historical=result)
-        else:
-            return HistoricalData(symbol=symbol, historical=[result])
+        return HistoricalData(symbol=symbol, historical=rows)
 
     async def get_dividends(
         self,

--- a/fmp_data/company/client.py
+++ b/fmp_data/company/client.py
@@ -72,6 +72,7 @@ from fmp_data.company.models import (
     FinancialReportJSON,
     GeographicRevenueSegment,
     HistoricalData,
+    HistoricalPrice,
     HistoricalShareFloat,
     IntradayPrice,
     MergerAcquisition,
@@ -233,18 +234,11 @@ class CompanyClient(EndpointGroup):
         if end_date:
             params["end_date"] = end_date
 
-        # Make request
-        # this returns list[HistoricalPrice] due to response_model=HistoricalPrice
-        result = self.client.request(HISTORICAL_PRICE, **params)
-
-        # Convert to HistoricalData
-        if isinstance(result, list):
-            # Multiple price points -
-            # use them directly since HistoricalPrice now includes symbol
-            return HistoricalData(symbol=symbol, historical=result)
-        else:
-            # Single price point
-            return HistoricalData(symbol=symbol, historical=[result])
+        rows = self._unwrap_list(
+            self.client.request(HISTORICAL_PRICE, **params),
+            HistoricalPrice,
+        )
+        return HistoricalData(symbol=symbol, historical=rows)
 
     def get_intraday_prices(
         self,
@@ -579,12 +573,11 @@ class CompanyClient(EndpointGroup):
         if end_date:
             params["end_date"] = end_date
 
-        result = self.client.request(HISTORICAL_PRICE_LIGHT, **params)
-
-        if isinstance(result, list):
-            return HistoricalData(symbol=symbol, historical=result)
-        else:
-            return HistoricalData(symbol=symbol, historical=[result])
+        rows = self._unwrap_list(
+            self.client.request(HISTORICAL_PRICE_LIGHT, **params),
+            HistoricalPrice,
+        )
+        return HistoricalData(symbol=symbol, historical=rows)
 
     def get_historical_prices_non_split_adjusted(
         self,
@@ -610,12 +603,11 @@ class CompanyClient(EndpointGroup):
         if end_date:
             params["end_date"] = end_date
 
-        result = self.client.request(HISTORICAL_PRICE_NON_SPLIT_ADJUSTED, **params)
-
-        if isinstance(result, list):
-            return HistoricalData(symbol=symbol, historical=result)
-        else:
-            return HistoricalData(symbol=symbol, historical=[result])
+        rows = self._unwrap_list(
+            self.client.request(HISTORICAL_PRICE_NON_SPLIT_ADJUSTED, **params),
+            HistoricalPrice,
+        )
+        return HistoricalData(symbol=symbol, historical=rows)
 
     def get_historical_prices_dividend_adjusted(
         self,
@@ -641,12 +633,11 @@ class CompanyClient(EndpointGroup):
         if end_date:
             params["end_date"] = end_date
 
-        result = self.client.request(HISTORICAL_PRICE_DIVIDEND_ADJUSTED, **params)
-
-        if isinstance(result, list):
-            return HistoricalData(symbol=symbol, historical=result)
-        else:
-            return HistoricalData(symbol=symbol, historical=[result])
+        rows = self._unwrap_list(
+            self.client.request(HISTORICAL_PRICE_DIVIDEND_ADJUSTED, **params),
+            HistoricalPrice,
+        )
+        return HistoricalData(symbol=symbol, historical=rows)
 
     def get_dividends(
         self,

--- a/fmp_data/company/endpoints.py
+++ b/fmp_data/company/endpoints.py
@@ -144,7 +144,7 @@ STOCK_PRICE_CHANGE: Endpoint[StockPriceChange] = Endpoint(
     response_model=StockPriceChange,
 )
 
-HISTORICAL_PRICE: Endpoint = Endpoint(
+HISTORICAL_PRICE: Endpoint[HistoricalPrice] = Endpoint(
     name="historical_price",
     path="historical-price-eod/full",
     version=APIVersion.STABLE,
@@ -176,7 +176,7 @@ HISTORICAL_PRICE: Endpoint = Endpoint(
     response_model=HistoricalPrice,
 )
 
-HISTORICAL_PRICE_LIGHT: Endpoint = Endpoint(
+HISTORICAL_PRICE_LIGHT: Endpoint[HistoricalPrice] = Endpoint(
     name="historical_price_light",
     path="historical-price-eod/light",
     version=APIVersion.STABLE,
@@ -208,7 +208,7 @@ HISTORICAL_PRICE_LIGHT: Endpoint = Endpoint(
     response_model=HistoricalPrice,
 )
 
-HISTORICAL_PRICE_NON_SPLIT_ADJUSTED: Endpoint = Endpoint(
+HISTORICAL_PRICE_NON_SPLIT_ADJUSTED: Endpoint[HistoricalPrice] = Endpoint(
     name="historical_price_non_split_adjusted",
     path="historical-price-eod/non-split-adjusted",
     version=APIVersion.STABLE,
@@ -240,7 +240,7 @@ HISTORICAL_PRICE_NON_SPLIT_ADJUSTED: Endpoint = Endpoint(
     response_model=HistoricalPrice,
 )
 
-HISTORICAL_PRICE_DIVIDEND_ADJUSTED: Endpoint = Endpoint(
+HISTORICAL_PRICE_DIVIDEND_ADJUSTED: Endpoint[HistoricalPrice] = Endpoint(
     name="historical_price_dividend_adjusted",
     path="historical-price-eod/dividend-adjusted",
     version=APIVersion.STABLE,
@@ -508,7 +508,7 @@ COMPANY_NOTES: Endpoint[CompanyNote] = Endpoint(
     ],
 )
 
-HISTORICAL_SHARE_FLOAT: Endpoint = Endpoint(
+HISTORICAL_SHARE_FLOAT: Endpoint[HistoricalShareFloat] = Endpoint(
     name="historical_share_float",
     path="historical/shares-float",
     version=APIVersion.STABLE,
@@ -705,7 +705,7 @@ HISTORICAL_MARKET_CAP: Endpoint[MarketCapitalization] = Endpoint(
     optional_params=[],
     response_model=MarketCapitalization,
 )
-PRICE_TARGET: Endpoint = Endpoint(
+PRICE_TARGET: Endpoint[PriceTarget] = Endpoint(
     name="price_target",
     path="price-target",
     version=APIVersion.STABLE,
@@ -808,7 +808,7 @@ ANALYST_ESTIMATES: Endpoint[AnalystEstimate] = Endpoint(
     response_model=AnalystEstimate,
 )
 
-ANALYST_RECOMMENDATIONS: Endpoint = Endpoint(
+ANALYST_RECOMMENDATIONS: Endpoint[AnalystRecommendation] = Endpoint(
     name="analyst_recommendations",
     path="analyst-stock-recommendations",
     version=APIVersion.STABLE,
@@ -832,7 +832,7 @@ ANALYST_RECOMMENDATIONS: Endpoint = Endpoint(
     response_model=AnalystRecommendation,
 )
 
-UPGRADES_DOWNGRADES: Endpoint = Endpoint(
+UPGRADES_DOWNGRADES: Endpoint[UpgradeDowngrade] = Endpoint(
     name="upgrades_downgrades",
     path="upgrades-downgrades",
     version=APIVersion.STABLE,
@@ -944,7 +944,7 @@ DELISTED_COMPANIES: Endpoint[DelistedCompany] = Endpoint(
     response_model=DelistedCompany,
 )
 
-HISTORICAL_EMPLOYEE_COUNT: Endpoint = Endpoint(
+HISTORICAL_EMPLOYEE_COUNT: Endpoint[EmployeeCount] = Endpoint(
     name="historical_employee_count",
     path="historical/employee-count",
     version=APIVersion.STABLE,
@@ -965,7 +965,7 @@ HISTORICAL_EMPLOYEE_COUNT: Endpoint = Endpoint(
     response_model=EmployeeCount,
 )
 
-COMPANY_OUTLOOK: Endpoint = Endpoint(
+COMPANY_OUTLOOK: Endpoint[CompanyOutlook] = Endpoint(
     name="company_outlook",
     path="company-outlook",
     version=APIVersion.STABLE,
@@ -987,7 +987,7 @@ COMPANY_OUTLOOK: Endpoint = Endpoint(
     response_model=CompanyOutlook,
 )
 
-STOCK_SCREENER: Endpoint = Endpoint(
+STOCK_SCREENER: Endpoint[CompanyProfile] = Endpoint(
     name="stock_screener",
     path="stock-screener",
     version=APIVersion.STABLE,

--- a/fmp_data/company/mapping.py
+++ b/fmp_data/company/mapping.py
@@ -1,6 +1,8 @@
 # fmp_data/company/mapping.py
 from __future__ import annotations
 
+from typing import Any
+
 from fmp_data.company.endpoints import (
     AFTERMARKET_QUOTE,
     AFTERMARKET_TRADE,
@@ -48,9 +50,10 @@ from fmp_data.lc.hints import (
     SYMBOL_HINT,
 )
 from fmp_data.lc.models import EndpointSemantics, ResponseFieldInfo, SemanticCategory
+from fmp_data.models import Endpoint
 
 # Company endpoints mapping
-COMPANY_ENDPOINT_MAP = {
+COMPANY_ENDPOINT_MAP: dict[str, Endpoint[Any]] = {
     # Price Target endpoints
     "get_price_target": PRICE_TARGET,
     "get_price_target_summary": PRICE_TARGET_SUMMARY,

--- a/fmp_data/economics/async_client.py
+++ b/fmp_data/economics/async_client.py
@@ -37,13 +37,18 @@ class AsyncEconomicsClient(AsyncEndpointGroup):
         if end_date:
             params["end_date"] = end_date.strftime("%Y-%m-%d")
 
-        return await self.client.request_async(TREASURY_RATES, **params)
+        return self._unwrap_list(
+            await self.client.request_async(TREASURY_RATES, **params), TreasuryRate
+        )
 
     async def get_economic_indicators(
         self, indicator_name: str
     ) -> list[EconomicIndicator]:
         """Get economic indicator data"""
-        return await self.client.request_async(ECONOMIC_INDICATORS, name=indicator_name)
+        return self._unwrap_list(
+            await self.client.request_async(ECONOMIC_INDICATORS, name=indicator_name),
+            EconomicIndicator,
+        )
 
     async def get_economic_calendar(
         self, start_date: date | None = None, end_date: date | None = None
@@ -55,11 +60,15 @@ class AsyncEconomicsClient(AsyncEndpointGroup):
         if end_date:
             params["end_date"] = end_date.strftime("%Y-%m-%d")
 
-        return await self.client.request_async(ECONOMIC_CALENDAR, **params)
+        return self._unwrap_list(
+            await self.client.request_async(ECONOMIC_CALENDAR, **params), EconomicEvent
+        )
 
     async def get_market_risk_premium(self) -> list[MarketRiskPremium]:
         """Get market risk premium data"""
-        return await self.client.request_async(MARKET_RISK_PREMIUM)
+        return self._unwrap_list(
+            await self.client.request_async(MARKET_RISK_PREMIUM), MarketRiskPremium
+        )
 
     async def get_commitment_of_traders_report(
         self, symbol: str, start_date: date, end_date: date
@@ -70,7 +79,10 @@ class AsyncEconomicsClient(AsyncEndpointGroup):
             "start_date": start_date.strftime("%Y-%m-%d"),
             "end_date": end_date.strftime("%Y-%m-%d"),
         }
-        return await self.client.request_async(COMMITMENT_OF_TRADERS_REPORT, **params)
+        return self._unwrap_list(
+            await self.client.request_async(COMMITMENT_OF_TRADERS_REPORT, **params),
+            CommitmentOfTradersReport,
+        )
 
     async def get_commitment_of_traders_analysis(
         self, symbol: str, start_date: date, end_date: date
@@ -81,10 +93,16 @@ class AsyncEconomicsClient(AsyncEndpointGroup):
             "start_date": start_date.strftime("%Y-%m-%d"),
             "end_date": end_date.strftime("%Y-%m-%d"),
         }
-        return await self.client.request_async(COMMITMENT_OF_TRADERS_ANALYSIS, **params)
+        return self._unwrap_list(
+            await self.client.request_async(COMMITMENT_OF_TRADERS_ANALYSIS, **params),
+            CommitmentOfTradersAnalysis,
+        )
 
     async def get_commitment_of_traders_list(
         self,
     ) -> list[CommitmentOfTradersListItem]:
         """Get list of available Commitment of Traders (COT) symbols"""
-        return await self.client.request_async(COMMITMENT_OF_TRADERS_LIST)
+        return self._unwrap_list(
+            await self.client.request_async(COMMITMENT_OF_TRADERS_LIST),
+            CommitmentOfTradersListItem,
+        )

--- a/fmp_data/economics/client.py
+++ b/fmp_data/economics/client.py
@@ -35,11 +35,16 @@ class EconomicsClient(EndpointGroup):
         if end_date:
             params["end_date"] = end_date.strftime("%Y-%m-%d")
 
-        return self.client.request(TREASURY_RATES, **params)
+        return self._unwrap_list(
+            self.client.request(TREASURY_RATES, **params), TreasuryRate
+        )
 
     def get_economic_indicators(self, indicator_name: str) -> list[EconomicIndicator]:
         """Get economic indicator data"""
-        return self.client.request(ECONOMIC_INDICATORS, name=indicator_name)
+        return self._unwrap_list(
+            self.client.request(ECONOMIC_INDICATORS, name=indicator_name),
+            EconomicIndicator,
+        )
 
     def get_economic_calendar(
         self, start_date: date | None = None, end_date: date | None = None
@@ -51,11 +56,15 @@ class EconomicsClient(EndpointGroup):
         if end_date:
             params["end_date"] = end_date.strftime("%Y-%m-%d")
 
-        return self.client.request(ECONOMIC_CALENDAR, **params)
+        return self._unwrap_list(
+            self.client.request(ECONOMIC_CALENDAR, **params), EconomicEvent
+        )
 
     def get_market_risk_premium(self) -> list[MarketRiskPremium]:
         """Get market risk premium data"""
-        return self.client.request(MARKET_RISK_PREMIUM)
+        return self._unwrap_list(
+            self.client.request(MARKET_RISK_PREMIUM), MarketRiskPremium
+        )
 
     def get_commitment_of_traders_report(
         self, symbol: str, start_date: date, end_date: date
@@ -66,7 +75,10 @@ class EconomicsClient(EndpointGroup):
             "start_date": start_date.strftime("%Y-%m-%d"),
             "end_date": end_date.strftime("%Y-%m-%d"),
         }
-        return self.client.request(COMMITMENT_OF_TRADERS_REPORT, **params)
+        return self._unwrap_list(
+            self.client.request(COMMITMENT_OF_TRADERS_REPORT, **params),
+            CommitmentOfTradersReport,
+        )
 
     def get_commitment_of_traders_analysis(
         self, symbol: str, start_date: date, end_date: date
@@ -77,8 +89,13 @@ class EconomicsClient(EndpointGroup):
             "start_date": start_date.strftime("%Y-%m-%d"),
             "end_date": end_date.strftime("%Y-%m-%d"),
         }
-        return self.client.request(COMMITMENT_OF_TRADERS_ANALYSIS, **params)
+        return self._unwrap_list(
+            self.client.request(COMMITMENT_OF_TRADERS_ANALYSIS, **params),
+            CommitmentOfTradersAnalysis,
+        )
 
     def get_commitment_of_traders_list(self) -> list[CommitmentOfTradersListItem]:
         """Get list of available Commitment of Traders (COT) symbols"""
-        return self.client.request(COMMITMENT_OF_TRADERS_LIST)
+        return self._unwrap_list(
+            self.client.request(COMMITMENT_OF_TRADERS_LIST), CommitmentOfTradersListItem
+        )

--- a/fmp_data/economics/endpoints.py
+++ b/fmp_data/economics/endpoints.py
@@ -18,7 +18,7 @@ from fmp_data.models import (
     URLType,
 )
 
-TREASURY_RATES: Endpoint = Endpoint(
+TREASURY_RATES: Endpoint[TreasuryRate] = Endpoint(
     name="treasury_rates",
     path="treasury-rates",
     version=APIVersion.STABLE,
@@ -57,7 +57,7 @@ TREASURY_RATES: Endpoint = Endpoint(
     ],
 )
 
-ECONOMIC_INDICATORS: Endpoint = Endpoint(
+ECONOMIC_INDICATORS: Endpoint[EconomicIndicator] = Endpoint(
     name="economic_indicators",
     path="economic-indicators",
     version=APIVersion.STABLE,
@@ -89,7 +89,7 @@ ECONOMIC_INDICATORS: Endpoint = Endpoint(
     ],
 )
 
-ECONOMIC_CALENDAR: Endpoint = Endpoint(
+ECONOMIC_CALENDAR: Endpoint[EconomicEvent] = Endpoint(
     name="economic_calendar",
     path="economic-calendar",
     version=APIVersion.STABLE,
@@ -128,7 +128,7 @@ ECONOMIC_CALENDAR: Endpoint = Endpoint(
     ],
 )
 
-MARKET_RISK_PREMIUM: Endpoint = Endpoint(
+MARKET_RISK_PREMIUM: Endpoint[MarketRiskPremium] = Endpoint(
     name="market_risk_premium",
     path="market-risk-premium",
     version=APIVersion.STABLE,
@@ -152,7 +152,7 @@ MARKET_RISK_PREMIUM: Endpoint = Endpoint(
     ],
 )
 
-COMMITMENT_OF_TRADERS_REPORT: Endpoint = Endpoint(
+COMMITMENT_OF_TRADERS_REPORT: Endpoint[CommitmentOfTradersReport] = Endpoint(
     name="commitment_of_traders_report",
     path="commitment-of-traders-report",
     version=APIVersion.STABLE,
@@ -190,7 +190,7 @@ COMMITMENT_OF_TRADERS_REPORT: Endpoint = Endpoint(
     ],
 )
 
-COMMITMENT_OF_TRADERS_ANALYSIS: Endpoint = Endpoint(
+COMMITMENT_OF_TRADERS_ANALYSIS: Endpoint[CommitmentOfTradersAnalysis] = Endpoint(
     name="commitment_of_traders_analysis",
     path="commitment-of-traders-analysis",
     version=APIVersion.STABLE,
@@ -228,7 +228,7 @@ COMMITMENT_OF_TRADERS_ANALYSIS: Endpoint = Endpoint(
     ],
 )
 
-COMMITMENT_OF_TRADERS_LIST: Endpoint = Endpoint(
+COMMITMENT_OF_TRADERS_LIST: Endpoint[CommitmentOfTradersListItem] = Endpoint(
     name="commitment_of_traders_list",
     path="commitment-of-traders-list",
     version=APIVersion.STABLE,

--- a/fmp_data/economics/mapping.py
+++ b/fmp_data/economics/mapping.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from fmp_data.economics.endpoints import (
     COMMITMENT_OF_TRADERS_ANALYSIS,
     COMMITMENT_OF_TRADERS_LIST,
@@ -17,8 +19,9 @@ from fmp_data.lc.models import (
     ResponseFieldInfo,
     SemanticCategory,
 )
+from fmp_data.models import Endpoint
 
-ECONOMICS_ENDPOINT_MAP = {
+ECONOMICS_ENDPOINT_MAP: dict[str, Endpoint[Any]] = {
     "get_treasury_rates": TREASURY_RATES,
     "get_economic_indicators": ECONOMIC_INDICATORS,
     "get_economic_calendar": ECONOMIC_CALENDAR,

--- a/fmp_data/fundamental/async_client.py
+++ b/fmp_data/fundamental/async_client.py
@@ -29,80 +29,110 @@ class AsyncFundamentalClient(AsyncEndpointGroup):
         self, symbol: str, period: str = "annual", limit: int | None = None
     ) -> list[IncomeStatement]:
         """Get income statements"""
-        return await self.client.request_async(
-            endpoints.INCOME_STATEMENT, symbol=symbol, period=period, limit=limit
+        return self._unwrap_list(
+            await self.client.request_async(
+                endpoints.INCOME_STATEMENT, symbol=symbol, period=period, limit=limit
+            ),
+            IncomeStatement,
         )
 
     async def get_balance_sheet(
         self, symbol: str, period: str = "annual", limit: int | None = None
     ) -> list[BalanceSheet]:
         """Get balance sheets"""
-        return await self.client.request_async(
-            endpoints.BALANCE_SHEET, symbol=symbol, period=period, limit=limit
+        return self._unwrap_list(
+            await self.client.request_async(
+                endpoints.BALANCE_SHEET, symbol=symbol, period=period, limit=limit
+            ),
+            BalanceSheet,
         )
 
     async def get_cash_flow(
         self, symbol: str, period: str = "annual", limit: int | None = None
     ) -> list[CashFlowStatement]:
         """Get cash flow statements"""
-        return await self.client.request_async(
-            endpoints.CASH_FLOW, symbol=symbol, period=period, limit=limit
+        return self._unwrap_list(
+            await self.client.request_async(
+                endpoints.CASH_FLOW, symbol=symbol, period=period, limit=limit
+            ),
+            CashFlowStatement,
         )
 
     async def get_latest_financial_statements(
         self, page: int = 0, limit: int = 250
     ) -> list[LatestFinancialStatement]:
         """Get latest financial statement metadata across symbols"""
-        return await self.client.request_async(
-            endpoints.LATEST_FINANCIAL_STATEMENTS, page=page, limit=limit
+        return self._unwrap_list(
+            await self.client.request_async(
+                endpoints.LATEST_FINANCIAL_STATEMENTS, page=page, limit=limit
+            ),
+            LatestFinancialStatement,
         )
 
     async def get_key_metrics(
         self, symbol: str, period: str = "annual", limit: int | None = None
     ) -> list[KeyMetrics]:
         """Get key financial metrics"""
-        return await self.client.request_async(
-            endpoints.KEY_METRICS, symbol=symbol, period=period, limit=limit
+        return self._unwrap_list(
+            await self.client.request_async(
+                endpoints.KEY_METRICS, symbol=symbol, period=period, limit=limit
+            ),
+            KeyMetrics,
         )
 
     async def get_financial_ratios(
         self, symbol: str, period: str = "annual", limit: int | None = None
     ) -> list[FinancialRatios]:
         """Get financial ratios"""
-        return await self.client.request_async(
-            endpoints.FINANCIAL_RATIOS, symbol=symbol, period=period, limit=limit
+        return self._unwrap_list(
+            await self.client.request_async(
+                endpoints.FINANCIAL_RATIOS, symbol=symbol, period=period, limit=limit
+            ),
+            FinancialRatios,
         )
 
     async def get_full_financial_statement(
         self, symbol: str, period: str = "annual", limit: int | None = None
     ) -> list[FinancialStatementFull]:
         """Get full financial statements as reported"""
-        return await self.client.request_async(
-            endpoints.FULL_FINANCIAL_STATEMENT,
-            symbol=symbol,
-            period=period,
-            limit=limit,
+        return self._unwrap_list(
+            await self.client.request_async(
+                endpoints.FULL_FINANCIAL_STATEMENT,
+                symbol=symbol,
+                period=period,
+                limit=limit,
+            ),
+            FinancialStatementFull,
         )
 
     async def get_financial_reports_dates(
         self, symbol: str
     ) -> list[FinancialReportDate]:
         """Get list of financial reports dates"""
-        return await self.client.request_async(
-            endpoints.FINANCIAL_REPORTS_DATES, symbol=symbol
+        return self._unwrap_list(
+            await self.client.request_async(
+                endpoints.FINANCIAL_REPORTS_DATES, symbol=symbol
+            ),
+            FinancialReportDate,
         )
 
     async def get_owner_earnings(
         self, symbol: str, limit: int | None = None
     ) -> list[OwnerEarnings]:
         """Get owner earnings metrics"""
-        return await self.client.request_async(
-            endpoints.OWNER_EARNINGS, symbol=symbol, limit=limit
+        return self._unwrap_list(
+            await self.client.request_async(
+                endpoints.OWNER_EARNINGS, symbol=symbol, limit=limit
+            ),
+            OwnerEarnings,
         )
 
     async def get_levered_dcf(self, symbol: str) -> list[LeveredDCF]:
         """Get levered DCF valuation"""
-        return await self.client.request_async(endpoints.LEVERED_DCF, symbol=symbol)
+        return self._unwrap_list(
+            await self.client.request_async(endpoints.LEVERED_DCF, symbol=symbol),
+            LeveredDCF,
+        )
 
     @deprecated(
         "historical-rating is dead. The live path ratings-historical is "
@@ -127,18 +157,27 @@ class AsyncFundamentalClient(AsyncEndpointGroup):
 
     async def get_discounted_cash_flow(self, symbol: str) -> list[DCF]:
         """Get discounted cash flow valuation"""
-        return await self.client.request_async(
-            endpoints.DISCOUNTED_CASH_FLOW, symbol=symbol
+        return self._unwrap_list(
+            await self.client.request_async(
+                endpoints.DISCOUNTED_CASH_FLOW, symbol=symbol
+            ),
+            DCF,
         )
 
     async def get_custom_discounted_cash_flow(self, symbol: str) -> list[CustomDCF]:
         """Get advanced DCF analysis with detailed projections"""
-        return await self.client.request_async(
-            endpoints.CUSTOM_DISCOUNTED_CASH_FLOW, symbol=symbol
+        return self._unwrap_list(
+            await self.client.request_async(
+                endpoints.CUSTOM_DISCOUNTED_CASH_FLOW, symbol=symbol
+            ),
+            CustomDCF,
         )
 
     async def get_custom_levered_dcf(self, symbol: str) -> list[CustomLeveredDCF]:
         """Get levered DCF analysis using FCFE"""
-        return await self.client.request_async(
-            endpoints.CUSTOM_LEVERED_DCF, symbol=symbol
+        return self._unwrap_list(
+            await self.client.request_async(
+                endpoints.CUSTOM_LEVERED_DCF, symbol=symbol
+            ),
+            CustomLeveredDCF,
         )

--- a/fmp_data/fundamental/client.py
+++ b/fmp_data/fundamental/client.py
@@ -27,74 +27,103 @@ class FundamentalClient(EndpointGroup):
         self, symbol: str, period: str = "annual", limit: int | None = None
     ) -> list[IncomeStatement]:
         """Get income statements"""
-        return self.client.request(
-            endpoints.INCOME_STATEMENT, symbol=symbol, period=period, limit=limit
+        return self._unwrap_list(
+            self.client.request(
+                endpoints.INCOME_STATEMENT, symbol=symbol, period=period, limit=limit
+            ),
+            IncomeStatement,
         )
 
     def get_balance_sheet(
         self, symbol: str, period: str = "annual", limit: int | None = None
     ) -> list[BalanceSheet]:
         """Get balance sheets"""
-        return self.client.request(
-            endpoints.BALANCE_SHEET, symbol=symbol, period=period, limit=limit
+        return self._unwrap_list(
+            self.client.request(
+                endpoints.BALANCE_SHEET, symbol=symbol, period=period, limit=limit
+            ),
+            BalanceSheet,
         )
 
     def get_cash_flow(
         self, symbol: str, period: str = "annual", limit: int | None = None
     ) -> list[CashFlowStatement]:
         """Get cash flow statements"""
-        return self.client.request(
-            endpoints.CASH_FLOW, symbol=symbol, period=period, limit=limit
+        return self._unwrap_list(
+            self.client.request(
+                endpoints.CASH_FLOW, symbol=symbol, period=period, limit=limit
+            ),
+            CashFlowStatement,
         )
 
     def get_latest_financial_statements(
         self, page: int = 0, limit: int = 250
     ) -> list[LatestFinancialStatement]:
         """Get latest financial statement metadata across symbols"""
-        return self.client.request(
-            endpoints.LATEST_FINANCIAL_STATEMENTS, page=page, limit=limit
+        return self._unwrap_list(
+            self.client.request(
+                endpoints.LATEST_FINANCIAL_STATEMENTS, page=page, limit=limit
+            ),
+            LatestFinancialStatement,
         )
 
     def get_key_metrics(
         self, symbol: str, period: str = "annual", limit: int | None = None
     ) -> list[KeyMetrics]:
         """Get key financial metrics"""
-        return self.client.request(
-            endpoints.KEY_METRICS, symbol=symbol, period=period, limit=limit
+        return self._unwrap_list(
+            self.client.request(
+                endpoints.KEY_METRICS, symbol=symbol, period=period, limit=limit
+            ),
+            KeyMetrics,
         )
 
     def get_financial_ratios(
         self, symbol: str, period: str = "annual", limit: int | None = None
     ) -> list[FinancialRatios]:
         """Get financial ratios"""
-        return self.client.request(
-            endpoints.FINANCIAL_RATIOS, symbol=symbol, period=period, limit=limit
+        return self._unwrap_list(
+            self.client.request(
+                endpoints.FINANCIAL_RATIOS, symbol=symbol, period=period, limit=limit
+            ),
+            FinancialRatios,
         )
 
     def get_full_financial_statement(
         self, symbol: str, period: str = "annual", limit: int | None = None
     ) -> list[FinancialStatementFull]:
         """Get full financial statements as reported"""
-        return self.client.request(
-            endpoints.FULL_FINANCIAL_STATEMENT,
-            symbol=symbol,
-            period=period,
-            limit=limit,
+        return self._unwrap_list(
+            self.client.request(
+                endpoints.FULL_FINANCIAL_STATEMENT,
+                symbol=symbol,
+                period=period,
+                limit=limit,
+            ),
+            FinancialStatementFull,
         )
 
     def get_financial_reports_dates(self, symbol: str) -> list[FinancialReportDate]:
         """Get list of financial reports dates"""
-        return self.client.request(endpoints.FINANCIAL_REPORTS_DATES, symbol=symbol)
+        return self._unwrap_list(
+            self.client.request(endpoints.FINANCIAL_REPORTS_DATES, symbol=symbol),
+            FinancialReportDate,
+        )
 
     def get_owner_earnings(
         self, symbol: str, limit: int | None = None
     ) -> list[OwnerEarnings]:
         """Get owner earnings metrics"""
-        return self.client.request(endpoints.OWNER_EARNINGS, symbol=symbol, limit=limit)
+        return self._unwrap_list(
+            self.client.request(endpoints.OWNER_EARNINGS, symbol=symbol, limit=limit),
+            OwnerEarnings,
+        )
 
     def get_levered_dcf(self, symbol: str) -> list[LeveredDCF]:
         """Get levered DCF valuation"""
-        return self.client.request(endpoints.LEVERED_DCF, symbol=symbol)
+        return self._unwrap_list(
+            self.client.request(endpoints.LEVERED_DCF, symbol=symbol), LeveredDCF
+        )
 
     @deprecated(
         "historical-rating is dead. The live path ratings-historical is "
@@ -119,12 +148,20 @@ class FundamentalClient(EndpointGroup):
 
     def get_discounted_cash_flow(self, symbol: str) -> list[DCF]:
         """Get discounted cash flow valuation"""
-        return self.client.request(endpoints.DISCOUNTED_CASH_FLOW, symbol=symbol)
+        return self._unwrap_list(
+            self.client.request(endpoints.DISCOUNTED_CASH_FLOW, symbol=symbol), DCF
+        )
 
     def get_custom_discounted_cash_flow(self, symbol: str) -> list[CustomDCF]:
         """Get advanced DCF analysis with detailed projections"""
-        return self.client.request(endpoints.CUSTOM_DISCOUNTED_CASH_FLOW, symbol=symbol)
+        return self._unwrap_list(
+            self.client.request(endpoints.CUSTOM_DISCOUNTED_CASH_FLOW, symbol=symbol),
+            CustomDCF,
+        )
 
     def get_custom_levered_dcf(self, symbol: str) -> list[CustomLeveredDCF]:
         """Get levered DCF analysis using FCFE"""
-        return self.client.request(endpoints.CUSTOM_LEVERED_DCF, symbol=symbol)
+        return self._unwrap_list(
+            self.client.request(endpoints.CUSTOM_LEVERED_DCF, symbol=symbol),
+            CustomLeveredDCF,
+        )

--- a/fmp_data/fundamental/endpoints.py
+++ b/fmp_data/fundamental/endpoints.py
@@ -23,7 +23,7 @@ from fmp_data.models import (
     ParamType,
 )
 
-INCOME_STATEMENT: Endpoint = Endpoint(
+INCOME_STATEMENT: Endpoint[IncomeStatement] = Endpoint(
     name="income_statement",
     path="income-statement",
     version=APIVersion.STABLE,
@@ -67,7 +67,7 @@ INCOME_STATEMENT: Endpoint = Endpoint(
     ],
 )
 
-BALANCE_SHEET: Endpoint = Endpoint(
+BALANCE_SHEET: Endpoint[BalanceSheet] = Endpoint(
     name="balance_sheet",
     path="balance-sheet-statement",
     version=APIVersion.STABLE,
@@ -110,7 +110,7 @@ BALANCE_SHEET: Endpoint = Endpoint(
     ],
 )
 
-CASH_FLOW: Endpoint = Endpoint(
+CASH_FLOW: Endpoint[CashFlowStatement] = Endpoint(
     name="cash_flow",
     path="cash-flow-statement",
     version=APIVersion.STABLE,
@@ -153,7 +153,7 @@ CASH_FLOW: Endpoint = Endpoint(
     ],
 )
 
-LATEST_FINANCIAL_STATEMENTS: Endpoint = Endpoint(
+LATEST_FINANCIAL_STATEMENTS: Endpoint[LatestFinancialStatement] = Endpoint(
     name="latest_financial_statements",
     path="latest-financial-statements",
     version=APIVersion.STABLE,
@@ -184,7 +184,7 @@ LATEST_FINANCIAL_STATEMENTS: Endpoint = Endpoint(
     ],
 )
 
-KEY_METRICS: Endpoint = Endpoint(
+KEY_METRICS: Endpoint[KeyMetrics] = Endpoint(
     name="key_metrics",
     path="key-metrics",
     version=APIVersion.STABLE,
@@ -227,7 +227,7 @@ KEY_METRICS: Endpoint = Endpoint(
     ],
 )
 
-FINANCIAL_RATIOS: Endpoint = Endpoint(
+FINANCIAL_RATIOS: Endpoint[FinancialRatios] = Endpoint(
     name="financial_ratios",
     path="ratios",
     version=APIVersion.STABLE,
@@ -269,7 +269,7 @@ FINANCIAL_RATIOS: Endpoint = Endpoint(
         "Show Amazon's liquidity metrics",
     ],
 )
-FULL_FINANCIAL_STATEMENT: Endpoint = Endpoint(
+FULL_FINANCIAL_STATEMENT: Endpoint[FinancialStatementFull] = Endpoint(
     name="full_financial_statement",
     path="financial-statement-full-as-reported",
     version=APIVersion.STABLE,
@@ -302,7 +302,7 @@ FULL_FINANCIAL_STATEMENT: Endpoint = Endpoint(
     response_model=FinancialStatementFull,
 )
 
-FINANCIAL_REPORTS_DATES: Endpoint = Endpoint(
+FINANCIAL_REPORTS_DATES: Endpoint[FinancialReportDate] = Endpoint(
     name="financial_reports_dates",
     path="financial-reports-dates",
     version=APIVersion.STABLE,
@@ -319,7 +319,7 @@ FINANCIAL_REPORTS_DATES: Endpoint = Endpoint(
     response_model=FinancialReportDate,
 )
 
-OWNER_EARNINGS: Endpoint = Endpoint(
+OWNER_EARNINGS: Endpoint[OwnerEarnings] = Endpoint(
     name="owner_earnings",
     path="owner-earnings",
     version=APIVersion.STABLE,
@@ -352,7 +352,7 @@ OWNER_EARNINGS: Endpoint = Endpoint(
     ],
 )
 
-LEVERED_DCF: Endpoint = Endpoint(
+LEVERED_DCF: Endpoint[LeveredDCF] = Endpoint(
     name="levered_dcf",
     path="levered-discounted-cash-flow",
     version=APIVersion.STABLE,
@@ -379,7 +379,7 @@ LEVERED_DCF: Endpoint = Endpoint(
     ],
 )
 
-HISTORICAL_RATING: Endpoint = Endpoint(
+HISTORICAL_RATING: Endpoint[HistoricalRating] = Endpoint(
     name="historical_rating",
     path="historical-rating",
     version=APIVersion.STABLE,
@@ -408,7 +408,7 @@ HISTORICAL_RATING: Endpoint = Endpoint(
     ],
 )
 
-DISCOUNTED_CASH_FLOW: Endpoint = Endpoint(
+DISCOUNTED_CASH_FLOW: Endpoint[DCF] = Endpoint(
     name="discounted_cash_flow",
     path="discounted-cash-flow",
     version=APIVersion.STABLE,
@@ -435,7 +435,7 @@ DISCOUNTED_CASH_FLOW: Endpoint = Endpoint(
     ],
 )
 
-CUSTOM_DISCOUNTED_CASH_FLOW: Endpoint = Endpoint(
+CUSTOM_DISCOUNTED_CASH_FLOW: Endpoint[CustomDCF] = Endpoint(
     name="custom_discounted_cash_flow",
     path="custom-discounted-cash-flow",
     version=APIVersion.STABLE,
@@ -462,7 +462,7 @@ CUSTOM_DISCOUNTED_CASH_FLOW: Endpoint = Endpoint(
     ],
 )
 
-CUSTOM_LEVERED_DCF: Endpoint = Endpoint(
+CUSTOM_LEVERED_DCF: Endpoint[CustomLeveredDCF] = Endpoint(
     name="custom_levered_dcf",
     path="custom-levered-discounted-cash-flow",
     version=APIVersion.STABLE,

--- a/fmp_data/fundamental/mapping.py
+++ b/fmp_data/fundamental/mapping.py
@@ -1,5 +1,7 @@
 # fmp_data/fundamental/mapping.py
 
+from typing import Any
+
 from fmp_data.fundamental.endpoints import (
     BALANCE_SHEET,
     CASH_FLOW,
@@ -28,9 +30,10 @@ from fmp_data.lc.models import (
     ResponseFieldInfo,
     SemanticCategory,
 )
+from fmp_data.models import Endpoint
 
 # Endpoint mappings
-FUNDAMENTAL_ENDPOINT_MAP = {
+FUNDAMENTAL_ENDPOINT_MAP: dict[str, Endpoint[Any]] = {
     "get_income_statement": INCOME_STATEMENT,
     "get_balance_sheet": BALANCE_SHEET,
     "get_cash_flow": CASH_FLOW,

--- a/fmp_data/institutional/async_client.py
+++ b/fmp_data/institutional/async_client.py
@@ -98,16 +98,15 @@ class AsyncInstitutionalClient(AsyncEndpointGroup):
             )
             return []
 
-        if isinstance(result, list):
-            if not result:
-                self.client.logger.warning(
-                    "No Form 13F data found for CIK %s in %s Q%s.",
-                    cik,
-                    year,
-                    quarter,
-                )
-            return result
-        return [result]
+        result = self._unwrap_list(result, Form13F)
+        if not result:
+            self.client.logger.warning(
+                "No Form 13F data found for CIK %s in %s Q%s.",
+                cik,
+                year,
+                quarter,
+            )
+        return result
 
     async def get_form_13f(self, cik: str | int, report_date: date) -> list[Form13F]:
         """
@@ -137,8 +136,7 @@ class AsyncInstitutionalClient(AsyncEndpointGroup):
         """
         try:
             result = await self.client.request_async(FORM_13F_DATES, cik=cik)
-            # Ensure we always return a list
-            return result if isinstance(result, list) else [result]
+            return self._unwrap_list(result, Form13FDate)
         except (FMPError, ValidationError) as e:
             # API errors return empty list for convenience (same contract as sync).
             self.client.logger.warning(
@@ -168,8 +166,11 @@ class AsyncInstitutionalClient(AsyncEndpointGroup):
         self, page: int = 0, limit: int = 100
     ) -> list[InstitutionalHolder]:
         """Get list of institutional holders"""
-        return await self.client.request_async(
-            INSTITUTIONAL_HOLDERS, page=page, limit=limit
+        return self._unwrap_list(
+            await self.client.request_async(
+                INSTITUTIONAL_HOLDERS, page=page, limit=limit
+            ),
+            InstitutionalHolder,
         )
 
     async def get_institutional_holdings_by_quarter(
@@ -186,8 +187,11 @@ class AsyncInstitutionalClient(AsyncEndpointGroup):
             year: Filing year (e.g., 2023)
             quarter: Calendar quarter, 1-4
         """
-        return await self.client.request_async(
-            INSTITUTIONAL_HOLDINGS, symbol=symbol, year=year, quarter=quarter
+        return self._unwrap_list(
+            await self.client.request_async(
+                INSTITUTIONAL_HOLDINGS, symbol=symbol, year=year, quarter=quarter
+            ),
+            InstitutionalHolding,
         )
 
     async def get_institutional_holdings(
@@ -223,17 +227,25 @@ class AsyncInstitutionalClient(AsyncEndpointGroup):
         self, symbol: str, page: int = 0, limit: int = 100
     ) -> list[InsiderTrade]:
         """Get insider trades"""
-        return await self.client.request_async(
-            INSIDER_TRADES, symbol=symbol, page=page, limit=limit
+        return self._unwrap_list(
+            await self.client.request_async(
+                INSIDER_TRADES, symbol=symbol, page=page, limit=limit
+            ),
+            InsiderTrade,
         )
 
     async def get_transaction_types(self) -> list[InsiderTransactionType]:
         """Get insider transaction types"""
-        return await self.client.request_async(TRANSACTION_TYPES)
+        return self._unwrap_list(
+            await self.client.request_async(TRANSACTION_TYPES), InsiderTransactionType
+        )
 
     async def get_insider_roster(self, symbol: str) -> list[InsiderRoster]:
         """Get insider roster"""
-        return await self.client.request_async(INSIDER_ROSTER, symbol=symbol)
+        return self._unwrap_list(
+            await self.client.request_async(INSIDER_ROSTER, symbol=symbol),
+            InsiderRoster,
+        )
 
     async def get_insider_statistics(self, symbol: str) -> InsiderStatistic:
         """Get insider trading statistics"""
@@ -244,7 +256,10 @@ class AsyncInstitutionalClient(AsyncEndpointGroup):
         self, page: int = 0, limit: int = 1000
     ) -> list[CIKMapping]:
         """Get CIK to name mappings"""
-        return await self.client.request_async(CIK_MAPPER, page=page, limit=limit)
+        return self._unwrap_list(
+            await self.client.request_async(CIK_MAPPER, page=page, limit=limit),
+            CIKMapping,
+        )
 
     async def search_cik_by_name(self, name: str, page: int = 0) -> list[CIKMapping]:
         """
@@ -261,9 +276,10 @@ class AsyncInstitutionalClient(AsyncEndpointGroup):
         Returns:
             List of CIK mappings matching the name
         """
-        results = await self.client.request_async(CIK_MAPPER, page=page, limit=10000)
-        if not isinstance(results, list):
-            results = [results]
+        results = self._unwrap_list(
+            await self.client.request_async(CIK_MAPPER, page=page, limit=10000),
+            CIKMapping,
+        )
         name_upper = name.strip().upper()
         return [
             item
@@ -274,7 +290,10 @@ class AsyncInstitutionalClient(AsyncEndpointGroup):
 
     async def get_beneficial_ownership(self, symbol: str) -> list[BeneficialOwnership]:
         """Get beneficial ownership data for a symbol"""
-        return await self.client.request_async(BENEFICIAL_OWNERSHIP, symbol=symbol)
+        return self._unwrap_list(
+            await self.client.request_async(BENEFICIAL_OWNERSHIP, symbol=symbol),
+            BeneficialOwnership,
+        )
 
     @deprecated(
         "The FMP API no longer serves fail-to-deliver data and publishes no "
@@ -302,7 +321,10 @@ class AsyncInstitutionalClient(AsyncEndpointGroup):
         params: dict[str, int | str | date] = {"page": page, "limit": limit}
         if trade_date is not None:
             params["date"] = trade_date
-        return await self.client.request_async(INSIDER_TRADING_LATEST, **params)
+        return self._unwrap_list(
+            await self.client.request_async(INSIDER_TRADING_LATEST, **params),
+            InsiderTradingLatest,
+        )
 
     async def search_insider_trading(
         self,
@@ -323,14 +345,20 @@ class AsyncInstitutionalClient(AsyncEndpointGroup):
             params["companyCik"] = company_cik
         if transaction_type:
             params["transactionType"] = transaction_type
-        return await self.client.request_async(INSIDER_TRADING_SEARCH, **params)
+        return self._unwrap_list(
+            await self.client.request_async(INSIDER_TRADING_SEARCH, **params),
+            InsiderTradingSearch,
+        )
 
     async def get_insider_trading_by_name(
         self, reporting_name: str, page: int = 0
     ) -> list[InsiderTradingByName]:
         """Search insider trades by reporting name"""
-        return await self.client.request_async(
-            INSIDER_TRADING_BY_NAME, name=reporting_name, page=page
+        return self._unwrap_list(
+            await self.client.request_async(
+                INSIDER_TRADING_BY_NAME, name=reporting_name, page=page
+            ),
+            InsiderTradingByName,
         )
 
     async def get_insider_trading_statistics_enhanced(
@@ -350,7 +378,10 @@ class AsyncInstitutionalClient(AsyncEndpointGroup):
         params: dict[str, str | int] = {"page": page, "limit": limit}
         if cik:
             params["cik"] = cik
-        return await self.client.request_async(INSTITUTIONAL_OWNERSHIP_LATEST, **params)
+        return self._unwrap_list(
+            await self.client.request_async(INSTITUTIONAL_OWNERSHIP_LATEST, **params),
+            InstitutionalOwnershipLatest,
+        )
 
     async def get_institutional_ownership_extract_by_quarter(
         self, cik: str | int, year: int, quarter: int
@@ -361,8 +392,11 @@ class AsyncInstitutionalClient(AsyncEndpointGroup):
         query parameters the API takes. See the sync
         :meth:`~fmp_data.institutional.client.InstitutionalClient.get_institutional_ownership_extract_by_quarter`.
         """
-        return await self.client.request_async(
-            INSTITUTIONAL_OWNERSHIP_EXTRACT, cik=cik, year=year, quarter=quarter
+        return self._unwrap_list(
+            await self.client.request_async(
+                INSTITUTIONAL_OWNERSHIP_EXTRACT, cik=cik, year=year, quarter=quarter
+            ),
+            InstitutionalOwnershipExtract,
         )
 
     async def get_institutional_ownership_extract(
@@ -378,7 +412,10 @@ class AsyncInstitutionalClient(AsyncEndpointGroup):
         self, cik: str | int
     ) -> list[InstitutionalOwnershipDates]:
         """Get Form 13F filing dates"""
-        return await self.client.request_async(INSTITUTIONAL_OWNERSHIP_DATES, cik=cik)
+        return self._unwrap_list(
+            await self.client.request_async(INSTITUTIONAL_OWNERSHIP_DATES, cik=cik),
+            InstitutionalOwnershipDates,
+        )
 
     async def get_institutional_ownership_analytics_by_quarter(
         self,
@@ -393,13 +430,16 @@ class AsyncInstitutionalClient(AsyncEndpointGroup):
         Wire shape of the analytics endpoint. See the sync
         :meth:`~fmp_data.institutional.client.InstitutionalClient.get_institutional_ownership_analytics_by_quarter`.
         """
-        return await self.client.request_async(
-            INSTITUTIONAL_OWNERSHIP_ANALYTICS,
-            symbol=symbol,
-            year=year,
-            quarter=quarter,
-            page=page,
-            limit=limit,
+        return self._unwrap_list(
+            await self.client.request_async(
+                INSTITUTIONAL_OWNERSHIP_ANALYTICS,
+                symbol=symbol,
+                year=year,
+                quarter=quarter,
+                page=page,
+                limit=limit,
+            ),
+            InstitutionalOwnershipAnalytics,
         )
 
     async def get_institutional_ownership_analytics(
@@ -424,7 +464,10 @@ class AsyncInstitutionalClient(AsyncEndpointGroup):
             params["year"] = year
         if quarter is not None:
             params["quarter"] = quarter
-        return await self.client.request_async(HOLDER_PERFORMANCE_SUMMARY, **params)
+        return self._unwrap_list(
+            await self.client.request_async(HOLDER_PERFORMANCE_SUMMARY, **params),
+            HolderPerformanceSummary,
+        )
 
     async def get_holder_performance_summary_by_quarter(
         self, cik: str | int, year: int, quarter: int, page: int = 0
@@ -464,8 +507,11 @@ class AsyncInstitutionalClient(AsyncEndpointGroup):
         Wire shape of the industry-breakdown endpoint. See the sync
         :meth:`~fmp_data.institutional.client.InstitutionalClient.get_holder_industry_breakdown_by_quarter`.
         """
-        return await self.client.request_async(
-            HOLDER_INDUSTRY_BREAKDOWN, cik=cik, year=year, quarter=quarter
+        return self._unwrap_list(
+            await self.client.request_async(
+                HOLDER_INDUSTRY_BREAKDOWN, cik=cik, year=year, quarter=quarter
+            ),
+            HolderIndustryBreakdown,
         )
 
     async def get_holder_industry_breakdown(
@@ -483,8 +529,11 @@ class AsyncInstitutionalClient(AsyncEndpointGroup):
         Wire shape of the symbol-positions-summary endpoint. See the sync
         :meth:`~fmp_data.institutional.client.InstitutionalClient.get_symbol_positions_summary_by_quarter`.
         """
-        return await self.client.request_async(
-            SYMBOL_POSITIONS_SUMMARY, symbol=symbol, year=year, quarter=quarter
+        return self._unwrap_list(
+            await self.client.request_async(
+                SYMBOL_POSITIONS_SUMMARY, symbol=symbol, year=year, quarter=quarter
+            ),
+            SymbolPositionsSummary,
         )
 
     async def get_symbol_positions_summary(
@@ -502,8 +551,11 @@ class AsyncInstitutionalClient(AsyncEndpointGroup):
         Wire shape of the industry-performance endpoint. See the sync
         :meth:`~fmp_data.institutional.client.InstitutionalClient.get_industry_performance_summary_by_quarter`.
         """
-        return await self.client.request_async(
-            INDUSTRY_PERFORMANCE_SUMMARY, year=year, quarter=quarter
+        return self._unwrap_list(
+            await self.client.request_async(
+                INDUSTRY_PERFORMANCE_SUMMARY, year=year, quarter=quarter
+            ),
+            IndustryPerformanceSummary,
         )
 
     async def get_industry_performance_summary(

--- a/fmp_data/institutional/client.py
+++ b/fmp_data/institutional/client.py
@@ -119,16 +119,15 @@ class InstitutionalClient(EndpointGroup):
             )
             return []
 
-        if isinstance(result, list):
-            if not result:
-                self.client.logger.warning(
-                    "No Form 13F data found for CIK %s in %s Q%s.",
-                    cik,
-                    year,
-                    quarter,
-                )
-            return result
-        return [result]
+        result = self._unwrap_list(result, Form13F)
+        if not result:
+            self.client.logger.warning(
+                "No Form 13F data found for CIK %s in %s Q%s.",
+                cik,
+                year,
+                quarter,
+            )
+        return result
 
     def get_form_13f(self, cik: str | int, report_date: date) -> list[Form13F]:
         """
@@ -158,8 +157,7 @@ class InstitutionalClient(EndpointGroup):
         """
         try:
             result = self.client.request(FORM_13F_DATES, cik=cik)
-            # Ensure we always return a list
-            return result if isinstance(result, list) else [result]
+            return self._unwrap_list(result, Form13FDate)
         except (FMPError, ValidationError) as e:
             # API errors (404, validation, etc.) return empty list for convenience
             self.client.logger.warning(
@@ -189,7 +187,10 @@ class InstitutionalClient(EndpointGroup):
         self, page: int = 0, limit: int = 100
     ) -> list[InstitutionalHolder]:
         """Get list of institutional holders"""
-        return self.client.request(INSTITUTIONAL_HOLDERS, page=page, limit=limit)
+        return self._unwrap_list(
+            self.client.request(INSTITUTIONAL_HOLDERS, page=page, limit=limit),
+            InstitutionalHolder,
+        )
 
     def get_institutional_holdings_by_quarter(
         self, symbol: str, year: int, quarter: int
@@ -207,8 +208,11 @@ class InstitutionalClient(EndpointGroup):
             year: Filing year (e.g., 2023)
             quarter: Calendar quarter, 1-4
         """
-        return self.client.request(
-            INSTITUTIONAL_HOLDINGS, symbol=symbol, year=year, quarter=quarter
+        return self._unwrap_list(
+            self.client.request(
+                INSTITUTIONAL_HOLDINGS, symbol=symbol, year=year, quarter=quarter
+            ),
+            InstitutionalHolding,
         )
 
     def get_institutional_holdings(
@@ -244,17 +248,22 @@ class InstitutionalClient(EndpointGroup):
         self, symbol: str, page: int = 0, limit: int = 100
     ) -> list[InsiderTrade]:
         """Get insider trades"""
-        return self.client.request(
-            INSIDER_TRADES, symbol=symbol, page=page, limit=limit
+        return self._unwrap_list(
+            self.client.request(INSIDER_TRADES, symbol=symbol, page=page, limit=limit),
+            InsiderTrade,
         )
 
     def get_transaction_types(self) -> list[InsiderTransactionType]:
         """Get insider transaction types"""
-        return self.client.request(TRANSACTION_TYPES)
+        return self._unwrap_list(
+            self.client.request(TRANSACTION_TYPES), InsiderTransactionType
+        )
 
     def get_insider_roster(self, symbol: str) -> list[InsiderRoster]:
         """Get insider roster"""
-        return self.client.request(INSIDER_ROSTER, symbol=symbol)
+        return self._unwrap_list(
+            self.client.request(INSIDER_ROSTER, symbol=symbol), InsiderRoster
+        )
 
     def get_insider_statistics(self, symbol: str) -> InsiderStatistic:
         """Get insider trading statistics"""
@@ -263,7 +272,9 @@ class InstitutionalClient(EndpointGroup):
 
     def get_cik_mappings(self, page: int = 0, limit: int = 1000) -> list[CIKMapping]:
         """Get CIK to name mappings"""
-        return self.client.request(CIK_MAPPER, page=page, limit=limit)
+        return self._unwrap_list(
+            self.client.request(CIK_MAPPER, page=page, limit=limit), CIKMapping
+        )
 
     def search_cik_by_name(self, name: str, page: int = 0) -> list[CIKMapping]:
         """
@@ -284,9 +295,10 @@ class InstitutionalClient(EndpointGroup):
         if not name_upper:
             raise ValidationError("Name must be non-empty for CIK search")
 
-        results = self.client.request(CIK_MAPPER, page=page, limit=10000)
-        if not isinstance(results, list):
-            results = [results]
+        results = self._unwrap_list(
+            self.client.request(CIK_MAPPER, page=page, limit=10000),
+            CIKMapping,
+        )
         return [
             item
             for item in results
@@ -296,7 +308,10 @@ class InstitutionalClient(EndpointGroup):
 
     def get_beneficial_ownership(self, symbol: str) -> list[BeneficialOwnership]:
         """Get beneficial ownership data for a symbol"""
-        return self.client.request(BENEFICIAL_OWNERSHIP, symbol=symbol)
+        return self._unwrap_list(
+            self.client.request(BENEFICIAL_OWNERSHIP, symbol=symbol),
+            BeneficialOwnership,
+        )
 
     @deprecated(
         "The FMP API no longer serves fail-to-deliver data and publishes no "
@@ -322,7 +337,9 @@ class InstitutionalClient(EndpointGroup):
         params: dict[str, int | str] = {"page": page, "limit": limit}
         if trade_date is not None:
             params["date"] = trade_date.strftime("%Y-%m-%d")
-        return self.client.request(INSIDER_TRADING_LATEST, **params)
+        return self._unwrap_list(
+            self.client.request(INSIDER_TRADING_LATEST, **params), InsiderTradingLatest
+        )
 
     def search_insider_trading(
         self,
@@ -343,14 +360,19 @@ class InstitutionalClient(EndpointGroup):
             params["companyCik"] = company_cik
         if transaction_type:
             params["transactionType"] = transaction_type
-        return self.client.request(INSIDER_TRADING_SEARCH, **params)
+        return self._unwrap_list(
+            self.client.request(INSIDER_TRADING_SEARCH, **params), InsiderTradingSearch
+        )
 
     def get_insider_trading_by_name(
         self, reporting_name: str, page: int = 0
     ) -> list[InsiderTradingByName]:
         """Search insider trades by reporting name"""
-        return self.client.request(
-            INSIDER_TRADING_BY_NAME, name=reporting_name, page=page
+        return self._unwrap_list(
+            self.client.request(
+                INSIDER_TRADING_BY_NAME, name=reporting_name, page=page
+            ),
+            InsiderTradingByName,
         )
 
     def get_insider_trading_statistics_enhanced(
@@ -368,7 +390,10 @@ class InstitutionalClient(EndpointGroup):
         params: dict[str, str | int] = {"page": page, "limit": limit}
         if cik:
             params["cik"] = cik
-        return self.client.request(INSTITUTIONAL_OWNERSHIP_LATEST, **params)
+        return self._unwrap_list(
+            self.client.request(INSTITUTIONAL_OWNERSHIP_LATEST, **params),
+            InstitutionalOwnershipLatest,
+        )
 
     def get_institutional_ownership_extract_by_quarter(
         self, cik: str | int, year: int, quarter: int
@@ -379,8 +404,11 @@ class InstitutionalClient(EndpointGroup):
         query parameters the API takes. :meth:`get_institutional_ownership_extract`
         is the date-shaped convenience layered over this method.
         """
-        return self.client.request(
-            INSTITUTIONAL_OWNERSHIP_EXTRACT, cik=cik, year=year, quarter=quarter
+        return self._unwrap_list(
+            self.client.request(
+                INSTITUTIONAL_OWNERSHIP_EXTRACT, cik=cik, year=year, quarter=quarter
+            ),
+            InstitutionalOwnershipExtract,
         )
 
     def get_institutional_ownership_extract(
@@ -394,7 +422,10 @@ class InstitutionalClient(EndpointGroup):
         self, cik: str | int
     ) -> list[InstitutionalOwnershipDates]:
         """Get Form 13F filing dates"""
-        return self.client.request(INSTITUTIONAL_OWNERSHIP_DATES, cik=cik)
+        return self._unwrap_list(
+            self.client.request(INSTITUTIONAL_OWNERSHIP_DATES, cik=cik),
+            InstitutionalOwnershipDates,
+        )
 
     def get_institutional_ownership_analytics_by_quarter(
         self,
@@ -410,13 +441,16 @@ class InstitutionalClient(EndpointGroup):
         :meth:`get_institutional_ownership_analytics` is the date-shaped
         convenience layered over this method.
         """
-        return self.client.request(
-            INSTITUTIONAL_OWNERSHIP_ANALYTICS,
-            symbol=symbol,
-            year=year,
-            quarter=quarter,
-            page=page,
-            limit=limit,
+        return self._unwrap_list(
+            self.client.request(
+                INSTITUTIONAL_OWNERSHIP_ANALYTICS,
+                symbol=symbol,
+                year=year,
+                quarter=quarter,
+                page=page,
+                limit=limit,
+            ),
+            InstitutionalOwnershipAnalytics,
         )
 
     def get_institutional_ownership_analytics(
@@ -441,7 +475,10 @@ class InstitutionalClient(EndpointGroup):
             params["year"] = year
         if quarter is not None:
             params["quarter"] = quarter
-        return self.client.request(HOLDER_PERFORMANCE_SUMMARY, **params)
+        return self._unwrap_list(
+            self.client.request(HOLDER_PERFORMANCE_SUMMARY, **params),
+            HolderPerformanceSummary,
+        )
 
     def get_holder_performance_summary_by_quarter(
         self, cik: str | int, year: int, quarter: int, page: int = 0
@@ -495,8 +532,11 @@ class InstitutionalClient(EndpointGroup):
         Wire shape of the industry-breakdown endpoint.
         :meth:`get_holder_industry_breakdown` is the date-shaped convenience.
         """
-        return self.client.request(
-            HOLDER_INDUSTRY_BREAKDOWN, cik=cik, year=year, quarter=quarter
+        return self._unwrap_list(
+            self.client.request(
+                HOLDER_INDUSTRY_BREAKDOWN, cik=cik, year=year, quarter=quarter
+            ),
+            HolderIndustryBreakdown,
         )
 
     def get_holder_industry_breakdown(
@@ -514,8 +554,11 @@ class InstitutionalClient(EndpointGroup):
         Wire shape of the symbol-positions-summary endpoint.
         :meth:`get_symbol_positions_summary` is the date-shaped convenience.
         """
-        return self.client.request(
-            SYMBOL_POSITIONS_SUMMARY, symbol=symbol, year=year, quarter=quarter
+        return self._unwrap_list(
+            self.client.request(
+                SYMBOL_POSITIONS_SUMMARY, symbol=symbol, year=year, quarter=quarter
+            ),
+            SymbolPositionsSummary,
         )
 
     def get_symbol_positions_summary(
@@ -533,8 +576,11 @@ class InstitutionalClient(EndpointGroup):
         Wire shape of the industry-performance endpoint.
         :meth:`get_industry_performance_summary` is the date-shaped convenience.
         """
-        return self.client.request(
-            INDUSTRY_PERFORMANCE_SUMMARY, year=year, quarter=quarter
+        return self._unwrap_list(
+            self.client.request(
+                INDUSTRY_PERFORMANCE_SUMMARY, year=year, quarter=quarter
+            ),
+            IndustryPerformanceSummary,
         )
 
     def get_industry_performance_summary(

--- a/fmp_data/institutional/endpoints.py
+++ b/fmp_data/institutional/endpoints.py
@@ -34,7 +34,7 @@ from fmp_data.models import (
     URLType,
 )
 
-FORM_13F: Endpoint = Endpoint(
+FORM_13F: Endpoint[Form13F] = Endpoint(
     name="form_13f",
     path="institutional-ownership/extract",
     version=APIVersion.STABLE,
@@ -65,7 +65,7 @@ FORM_13F: Endpoint = Endpoint(
     response_model=Form13F,
 )
 
-FORM_13F_DATES: Endpoint = Endpoint(
+FORM_13F_DATES: Endpoint[Form13FDate] = Endpoint(
     name="form_13f_dates",
     path="institutional-ownership/dates",
     version=APIVersion.STABLE,
@@ -84,7 +84,7 @@ FORM_13F_DATES: Endpoint = Endpoint(
     response_model=Form13FDate,
 )
 
-ASSET_ALLOCATION: Endpoint = Endpoint(
+ASSET_ALLOCATION: Endpoint[AssetAllocation] = Endpoint(
     name="asset_allocation",
     path="13f-asset-allocation",
     version=APIVersion.STABLE,
@@ -108,7 +108,7 @@ ASSET_ALLOCATION: Endpoint = Endpoint(
     response_model=AssetAllocation,
 )
 
-INSTITUTIONAL_HOLDERS: Endpoint = Endpoint(
+INSTITUTIONAL_HOLDERS: Endpoint[InstitutionalHolder] = Endpoint(
     name="institutional_holders",
     path="institutional-ownership/latest",
     version=APIVersion.STABLE,
@@ -135,7 +135,7 @@ INSTITUTIONAL_HOLDERS: Endpoint = Endpoint(
     response_model=InstitutionalHolder,
 )
 
-INSTITUTIONAL_HOLDINGS: Endpoint = Endpoint(
+INSTITUTIONAL_HOLDINGS: Endpoint[InstitutionalHolding] = Endpoint(
     name="institutional_holdings",
     path="institutional-ownership/symbol-positions-summary",
     version=APIVersion.STABLE,
@@ -166,7 +166,7 @@ INSTITUTIONAL_HOLDINGS: Endpoint = Endpoint(
     response_model=InstitutionalHolding,
 )
 
-INSIDER_TRADES: Endpoint = Endpoint(
+INSIDER_TRADES: Endpoint[InsiderTrade] = Endpoint(
     name="insider_trades",
     path="insider-trading/search",
     version=APIVersion.STABLE,
@@ -200,7 +200,7 @@ INSIDER_TRADES: Endpoint = Endpoint(
     response_model=InsiderTrade,
 )
 
-TRANSACTION_TYPES: Endpoint = Endpoint(
+TRANSACTION_TYPES: Endpoint[InsiderTransactionType] = Endpoint(
     name="transaction_types",
     path="insider-trading-transaction-type",
     version=APIVersion.STABLE,
@@ -212,7 +212,7 @@ TRANSACTION_TYPES: Endpoint = Endpoint(
     response_model=InsiderTransactionType,
 )
 
-INSIDER_ROSTER: Endpoint = Endpoint(
+INSIDER_ROSTER: Endpoint[InsiderRoster] = Endpoint(
     name="insider_roster",
     path="insider-trading/search",
     version=APIVersion.STABLE,
@@ -250,7 +250,7 @@ INSIDER_STATISTICS: Endpoint[InsiderStatistic] = Endpoint(
     response_model=InsiderStatistic,
 )
 
-CIK_MAPPER: Endpoint = Endpoint(
+CIK_MAPPER: Endpoint[CIKMapping] = Endpoint(
     name="cik_mapper",
     path="cik-list",
     version=APIVersion.STABLE,
@@ -282,7 +282,7 @@ CIK_MAPPER: Endpoint = Endpoint(
 # .search_cik_by_name`` remains the interface: it calls ``CIK_MAPPER`` with
 # ``limit=10000`` and filters locally.
 
-BENEFICIAL_OWNERSHIP: Endpoint = Endpoint(
+BENEFICIAL_OWNERSHIP: Endpoint[BeneficialOwnership] = Endpoint(
     name="beneficial_ownership",
     path="acquisition-of-beneficial-ownership",
     version=APIVersion.STABLE,
@@ -299,7 +299,7 @@ BENEFICIAL_OWNERSHIP: Endpoint = Endpoint(
     response_model=BeneficialOwnership,
 )
 
-FAIL_TO_DELIVER: Endpoint = Endpoint(
+FAIL_TO_DELIVER: Endpoint[FailToDeliver] = Endpoint(
     # The second naming oddity #166 raised: underscores in a ``path`` where
     # every other path in the catalogue uses hyphens, and ``name == path``.
     # Left alone deliberately, and not for lack of checking -- probed against
@@ -339,7 +339,7 @@ FAIL_TO_DELIVER: Endpoint = Endpoint(
 )
 
 # Insider Trading Endpoints
-INSIDER_TRADING_LATEST: Endpoint = Endpoint(
+INSIDER_TRADING_LATEST: Endpoint[InsiderTradingLatest] = Endpoint(
     name="insider_trading_latest",
     path="insider-trading/latest",
     version=APIVersion.STABLE,
@@ -372,7 +372,7 @@ INSIDER_TRADING_LATEST: Endpoint = Endpoint(
     response_model=InsiderTradingLatest,
 )
 
-INSIDER_TRADING_SEARCH: Endpoint = Endpoint(
+INSIDER_TRADING_SEARCH: Endpoint[InsiderTradingSearch] = Endpoint(
     name="insider_trading_search",
     path="insider-trading/search",
     version=APIVersion.STABLE,
@@ -423,7 +423,7 @@ INSIDER_TRADING_SEARCH: Endpoint = Endpoint(
     response_model=InsiderTradingSearch,
 )
 
-INSIDER_TRADING_BY_NAME: Endpoint = Endpoint(
+INSIDER_TRADING_BY_NAME: Endpoint[InsiderTradingByName] = Endpoint(
     name="insider_trading_by_name",
     path="insider-trading/reporting-name",
     version=APIVersion.STABLE,
@@ -470,7 +470,7 @@ INSIDER_TRADING_STATISTICS_ENHANCED: Endpoint[InsiderTradingStatistics] = Endpoi
 )
 
 # Form 13F Endpoints
-INSTITUTIONAL_OWNERSHIP_LATEST: Endpoint = Endpoint(
+INSTITUTIONAL_OWNERSHIP_LATEST: Endpoint[InstitutionalOwnershipLatest] = Endpoint(
     name="institutional_ownership_latest",
     path="institutional-ownership/latest",
     version=APIVersion.STABLE,
@@ -503,7 +503,7 @@ INSTITUTIONAL_OWNERSHIP_LATEST: Endpoint = Endpoint(
     response_model=InstitutionalOwnershipLatest,
 )
 
-INSTITUTIONAL_OWNERSHIP_EXTRACT: Endpoint = Endpoint(
+INSTITUTIONAL_OWNERSHIP_EXTRACT: Endpoint[InstitutionalOwnershipExtract] = Endpoint(
     name="institutional_ownership_extract",
     path="institutional-ownership/extract",
     version=APIVersion.STABLE,
@@ -534,7 +534,7 @@ INSTITUTIONAL_OWNERSHIP_EXTRACT: Endpoint = Endpoint(
     response_model=InstitutionalOwnershipExtract,
 )
 
-INSTITUTIONAL_OWNERSHIP_DATES: Endpoint = Endpoint(
+INSTITUTIONAL_OWNERSHIP_DATES: Endpoint[InstitutionalOwnershipDates] = Endpoint(
     name="institutional_ownership_dates",
     path="institutional-ownership/dates",
     version=APIVersion.STABLE,
@@ -553,7 +553,7 @@ INSTITUTIONAL_OWNERSHIP_DATES: Endpoint = Endpoint(
     response_model=InstitutionalOwnershipDates,
 )
 
-INSTITUTIONAL_OWNERSHIP_ANALYTICS: Endpoint = Endpoint(
+INSTITUTIONAL_OWNERSHIP_ANALYTICS: Endpoint[InstitutionalOwnershipAnalytics] = Endpoint(
     name="institutional_ownership_analytics",
     path="institutional-ownership/extract-analytics/holder",
     version=APIVersion.STABLE,
@@ -599,7 +599,7 @@ INSTITUTIONAL_OWNERSHIP_ANALYTICS: Endpoint = Endpoint(
     response_model=InstitutionalOwnershipAnalytics,
 )
 
-HOLDER_PERFORMANCE_SUMMARY: Endpoint = Endpoint(
+HOLDER_PERFORMANCE_SUMMARY: Endpoint[HolderPerformanceSummary] = Endpoint(
     name="holder_performance_summary",
     path="institutional-ownership/holder-performance-summary",
     version=APIVersion.STABLE,
@@ -638,7 +638,7 @@ HOLDER_PERFORMANCE_SUMMARY: Endpoint = Endpoint(
     response_model=HolderPerformanceSummary,
 )
 
-HOLDER_INDUSTRY_BREAKDOWN: Endpoint = Endpoint(
+HOLDER_INDUSTRY_BREAKDOWN: Endpoint[HolderIndustryBreakdown] = Endpoint(
     name="holder_industry_breakdown",
     path="institutional-ownership/holder-industry-breakdown",
     version=APIVersion.STABLE,
@@ -669,7 +669,7 @@ HOLDER_INDUSTRY_BREAKDOWN: Endpoint = Endpoint(
     response_model=HolderIndustryBreakdown,
 )
 
-SYMBOL_POSITIONS_SUMMARY: Endpoint = Endpoint(
+SYMBOL_POSITIONS_SUMMARY: Endpoint[SymbolPositionsSummary] = Endpoint(
     name="symbol_positions_summary",
     path="institutional-ownership/symbol-positions-summary",
     version=APIVersion.STABLE,
@@ -700,7 +700,7 @@ SYMBOL_POSITIONS_SUMMARY: Endpoint = Endpoint(
     response_model=SymbolPositionsSummary,
 )
 
-INDUSTRY_PERFORMANCE_SUMMARY: Endpoint = Endpoint(
+INDUSTRY_PERFORMANCE_SUMMARY: Endpoint[IndustryPerformanceSummary] = Endpoint(
     name="industry_performance_summary",
     path="institutional-ownership/industry-summary",
     version=APIVersion.STABLE,

--- a/fmp_data/institutional/mapping.py
+++ b/fmp_data/institutional/mapping.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fmp_data.institutional.endpoints import (
     ASSET_ALLOCATION,
     BENEFICIAL_OWNERSHIP,
@@ -26,6 +28,7 @@ from fmp_data.lc.models import (
     ResponseFieldInfo,
     SemanticCategory,
 )
+from fmp_data.models import Endpoint
 
 # Common parameter hints for reuse
 INSTITUTIONAL_TIME_PERIODS = {
@@ -73,7 +76,7 @@ INSTITUTIONAL_FILING_TYPES = {
         "Holdings report",
     ],
 }
-INSTITUTIONAL_ENDPOINT_MAP = {
+INSTITUTIONAL_ENDPOINT_MAP: dict[str, Endpoint[Any]] = {
     # The two ``_by_quarter`` keys name the wire-shaped client methods, not
     # the date-shaped conveniences that wrap them. ``FORM_13F`` and
     # ``INSTITUTIONAL_HOLDINGS`` declare mandatory ``year``/``quarter`` (the

--- a/fmp_data/intelligence/async_client.py
+++ b/fmp_data/intelligence/async_client.py
@@ -145,7 +145,9 @@ class AsyncMarketIntelligenceClient(AsyncEndpointGroup):
         params: dict[str, Any] = self._build_date_params(start_date, end_date)
         if include_report_times is not None:
             params["include_report_times"] = include_report_times
-        return await self.client.request_async(EARNINGS_CALENDAR, **params)
+        return self._unwrap_list(
+            await self.client.request_async(EARNINGS_CALENDAR, **params), EarningEvent
+        )
 
     async def get_historical_earnings(
         self,
@@ -171,7 +173,9 @@ class AsyncMarketIntelligenceClient(AsyncEndpointGroup):
             params["limit"] = limit
         if include_report_times is not None:
             params["include_report_times"] = include_report_times
-        return await self.client.request_async(HISTORICAL_EARNINGS, **params)
+        return self._unwrap_list(
+            await self.client.request_async(HISTORICAL_EARNINGS, **params), EarningEvent
+        )
 
     @deprecated(
         "The FMP API no longer serves the confirmed earnings calendar. Use "
@@ -216,21 +220,28 @@ class AsyncMarketIntelligenceClient(AsyncEndpointGroup):
     ) -> list[DividendEvent]:
         """Get dividends calendar"""
         params = self._build_date_params(start_date, end_date)
-        return await self.client.request_async(DIVIDENDS_CALENDAR, **params)
+        return self._unwrap_list(
+            await self.client.request_async(DIVIDENDS_CALENDAR, **params), DividendEvent
+        )
 
     async def get_stock_splits_calendar(
         self, start_date: date | None = None, end_date: date | None = None
     ) -> list[StockSplitEvent]:
         """Get stock splits calendar"""
         params = self._build_date_params(start_date, end_date)
-        return await self.client.request_async(STOCK_SPLITS_CALENDAR, **params)
+        return self._unwrap_list(
+            await self.client.request_async(STOCK_SPLITS_CALENDAR, **params),
+            StockSplitEvent,
+        )
 
     async def get_ipo_calendar(
         self, start_date: date | None = None, end_date: date | None = None
     ) -> list[IPOEvent]:
         """Get IPO calendar"""
         params = self._build_date_params(start_date, end_date)
-        return await self.client.request_async(IPO_CALENDAR, **params)
+        return self._unwrap_list(
+            await self.client.request_async(IPO_CALENDAR, **params), IPOEvent
+        )
 
     async def get_fmp_articles(
         self, page: int = 0, limit: int = 20, size: int | None = None
@@ -251,11 +262,10 @@ class AsyncMarketIntelligenceClient(AsyncEndpointGroup):
             "page": page,
             "limit": limit,
         }
-        response = await self.client.request_async(FMP_ARTICLES_ENDPOINT, **params)
-        # Extract articles from the content array in the response
-        return (
-            response.content if isinstance(response, FMPArticlesResponse) else response
-        )
+        response: Any = await self.client.request_async(FMP_ARTICLES_ENDPOINT, **params)
+        if isinstance(response, FMPArticlesResponse):
+            return self._unwrap_list(response.content, FMPArticle)
+        return self._unwrap_list(response, FMPArticle)
 
     async def get_general_news(
         self,
@@ -271,7 +281,10 @@ class AsyncMarketIntelligenceClient(AsyncEndpointGroup):
             "end_date": self._format_date(to_date),
             "limit": limit,
         }
-        return await self.client.request_async(GENERAL_NEWS_ENDPOINT, **params)
+        return self._unwrap_list(
+            await self.client.request_async(GENERAL_NEWS_ENDPOINT, **params),
+            GeneralNewsArticle,
+        )
 
     async def get_stock_symbol_news(
         self,
@@ -289,7 +302,10 @@ class AsyncMarketIntelligenceClient(AsyncEndpointGroup):
             "end_date": self._format_date(to_date),
             "limit": limit,
         }
-        return await self.client.request_async(STOCK_SYMBOL_NEWS_ENDPOINT, **params)
+        return self._unwrap_list(
+            await self.client.request_async(STOCK_SYMBOL_NEWS_ENDPOINT, **params),
+            StockNewsArticle,
+        )
 
     async def get_stock_news(
         self,
@@ -314,7 +330,10 @@ class AsyncMarketIntelligenceClient(AsyncEndpointGroup):
             "end_date": self._format_date(to_date),
             "limit": limit,
         }
-        return await self.client.request_async(STOCK_NEWS_ENDPOINT, **params)
+        return self._unwrap_list(
+            await self.client.request_async(STOCK_NEWS_ENDPOINT, **params),
+            StockNewsArticle,
+        )
 
     @deprecated(
         "The FMP API no longer supports this endpoint -- "
@@ -358,7 +377,10 @@ class AsyncMarketIntelligenceClient(AsyncEndpointGroup):
             "end_date": self._format_date(to_date),
             "limit": limit,
         }
-        return await self.client.request_async(FOREX_NEWS_ENDPOINT, **params)
+        return self._unwrap_list(
+            await self.client.request_async(FOREX_NEWS_ENDPOINT, **params),
+            ForexNewsArticle,
+        )
 
     async def get_forex_symbol_news(
         self,
@@ -376,7 +398,10 @@ class AsyncMarketIntelligenceClient(AsyncEndpointGroup):
             "end_date": self._format_date(to_date),
             "limit": limit,
         }
-        return await self.client.request_async(FOREX_SYMBOL_NEWS_ENDPOINT, **params)
+        return self._unwrap_list(
+            await self.client.request_async(FOREX_SYMBOL_NEWS_ENDPOINT, **params),
+            ForexNewsArticle,
+        )
 
     async def get_crypto_news(
         self,
@@ -403,7 +428,10 @@ class AsyncMarketIntelligenceClient(AsyncEndpointGroup):
             "end_date": self._format_date(to_date),
             "limit": limit,
         }
-        return await self.client.request_async(CRYPTO_NEWS_ENDPOINT, **params)
+        return self._unwrap_list(
+            await self.client.request_async(CRYPTO_NEWS_ENDPOINT, **params),
+            CryptoNewsArticle,
+        )
 
     async def get_crypto_symbol_news(
         self,
@@ -421,7 +449,10 @@ class AsyncMarketIntelligenceClient(AsyncEndpointGroup):
             "end_date": self._format_date(to_date),
             "limit": limit,
         }
-        return await self.client.request_async(CRYPTO_SYMBOL_NEWS_ENDPOINT, **params)
+        return self._unwrap_list(
+            await self.client.request_async(CRYPTO_SYMBOL_NEWS_ENDPOINT, **params),
+            CryptoNewsArticle,
+        )
 
     async def get_press_releases(
         self,
@@ -437,7 +468,10 @@ class AsyncMarketIntelligenceClient(AsyncEndpointGroup):
             "end_date": self._format_date(to_date),
             "limit": limit,
         }
-        return await self.client.request_async(PRESS_RELEASES_ENDPOINT, **params)
+        return self._unwrap_list(
+            await self.client.request_async(PRESS_RELEASES_ENDPOINT, **params),
+            PressRelease,
+        )
 
     async def get_press_releases_by_symbol(
         self,
@@ -455,8 +489,11 @@ class AsyncMarketIntelligenceClient(AsyncEndpointGroup):
             "end_date": self._format_date(to_date),
             "limit": limit,
         }
-        return await self.client.request_async(
-            PRESS_RELEASES_BY_SYMBOL_ENDPOINT, **params
+        return self._unwrap_list(
+            await self.client.request_async(
+                PRESS_RELEASES_BY_SYMBOL_ENDPOINT, **params
+            ),
+            PressReleaseBySymbol,
         )
 
     @removed("Social sentiment endpoints were discontinued by FMP.")
@@ -502,22 +539,32 @@ class AsyncMarketIntelligenceClient(AsyncEndpointGroup):
 
     async def get_esg_benchmark(self) -> list[ESGBenchmark]:
         """Get ESG benchmark data"""
-        return await self.client.request_async(ESG_BENCHMARK)
+        return self._unwrap_list(
+            await self.client.request_async(ESG_BENCHMARK), ESGBenchmark
+        )
 
     # Government trading methods
     async def get_senate_latest(
         self, page: int = 0, limit: int = 100
     ) -> list[SenateTrade]:
         """Get latest Senate financial disclosures"""
-        return await self.client.request_async(SENATE_LATEST, page=page, limit=limit)
+        return self._unwrap_list(
+            await self.client.request_async(SENATE_LATEST, page=page, limit=limit),
+            SenateTrade,
+        )
 
     async def get_senate_trading(self, symbol: str) -> list[SenateTrade]:
         """Get Senate trading data"""
-        return await self.client.request_async(SENATE_TRADING, symbol=symbol)
+        return self._unwrap_list(
+            await self.client.request_async(SENATE_TRADING, symbol=symbol), SenateTrade
+        )
 
     async def get_senate_trades_by_name(self, name: str) -> list[SenateTrade]:
         """Get Senate trading data by name"""
-        return await self.client.request_async(SENATE_TRADES_BY_NAME, name=name)
+        return self._unwrap_list(
+            await self.client.request_async(SENATE_TRADES_BY_NAME, name=name),
+            SenateTrade,
+        )
 
     @deprecated(
         "senate-trading-rss-feed is dead. The live path senate-latest is "
@@ -540,32 +587,50 @@ class AsyncMarketIntelligenceClient(AsyncEndpointGroup):
         self, page: int = 0, limit: int = 100
     ) -> list[HouseDisclosure]:
         """Get latest House financial disclosures"""
-        return await self.client.request_async(HOUSE_LATEST, page=page, limit=limit)
+        return self._unwrap_list(
+            await self.client.request_async(HOUSE_LATEST, page=page, limit=limit),
+            HouseDisclosure,
+        )
 
     async def get_house_disclosure(self, symbol: str) -> list[HouseDisclosure]:
         """Get House disclosure data"""
-        return await self.client.request_async(HOUSE_DISCLOSURE, symbol=symbol)
+        return self._unwrap_list(
+            await self.client.request_async(HOUSE_DISCLOSURE, symbol=symbol),
+            HouseDisclosure,
+        )
 
     async def get_house_trades_by_name(self, name: str) -> list[HouseDisclosure]:
         """Get House trading data by name"""
-        return await self.client.request_async(HOUSE_TRADES_BY_NAME, name=name)
+        return self._unwrap_list(
+            await self.client.request_async(HOUSE_TRADES_BY_NAME, name=name),
+            HouseDisclosure,
+        )
 
     # Fundraising methods
     async def get_crowdfunding_rss(
         self, page: int = 0, limit: int = 100
     ) -> list[CrowdfundingOffering]:
         """Get latest crowdfunding offerings"""
-        return await self.client.request_async(CROWDFUNDING_RSS, page=page, limit=limit)
+        return self._unwrap_list(
+            await self.client.request_async(CROWDFUNDING_RSS, page=page, limit=limit),
+            CrowdfundingOffering,
+        )
 
     async def search_crowdfunding(
         self, name: str
     ) -> list[CrowdfundingOfferingSearchItem]:
         """Search crowdfunding offerings"""
-        return await self.client.request_async(CROWDFUNDING_SEARCH, name=name)
+        return self._unwrap_list(
+            await self.client.request_async(CROWDFUNDING_SEARCH, name=name),
+            CrowdfundingOfferingSearchItem,
+        )
 
     async def get_crowdfunding_by_cik(self, cik: str) -> list[CrowdfundingOffering]:
         """Get crowdfunding offerings by CIK"""
-        return await self.client.request_async(CROWDFUNDING_BY_CIK, cik=cik)
+        return self._unwrap_list(
+            await self.client.request_async(CROWDFUNDING_BY_CIK, cik=cik),
+            CrowdfundingOffering,
+        )
 
     async def get_equity_offering_rss(
         self, page: int = 0, limit: int = 10, cik: str | None = None
@@ -574,15 +639,24 @@ class AsyncMarketIntelligenceClient(AsyncEndpointGroup):
         params: dict[str, int | str] = {"page": page, "limit": limit}
         if cik is not None:
             params["cik"] = cik
-        return await self.client.request_async(EQUITY_OFFERING_RSS, **params)
+        return self._unwrap_list(
+            await self.client.request_async(EQUITY_OFFERING_RSS, **params),
+            EquityOffering,
+        )
 
     async def search_equity_offering(self, name: str) -> list[EquityOfferingSearchItem]:
         """Search equity offerings"""
-        return await self.client.request_async(EQUITY_OFFERING_SEARCH, name=name)
+        return self._unwrap_list(
+            await self.client.request_async(EQUITY_OFFERING_SEARCH, name=name),
+            EquityOfferingSearchItem,
+        )
 
     async def get_equity_offering_by_cik(self, cik: str) -> list[EquityOffering]:
         """Get equity offerings by CIK"""
-        return await self.client.request_async(EQUITY_OFFERING_BY_CIK, cik=cik)
+        return self._unwrap_list(
+            await self.client.request_async(EQUITY_OFFERING_BY_CIK, cik=cik),
+            EquityOffering,
+        )
 
     # Analyst Ratings and Grades methods
     async def get_ratings_snapshot(self, symbol: str) -> RatingsSnapshot | None:
@@ -594,34 +668,49 @@ class AsyncMarketIntelligenceClient(AsyncEndpointGroup):
         self, symbol: str, limit: int = 100
     ) -> list[HistoricalRating]:
         """Get historical analyst ratings"""
-        return await self.client.request_async(
-            RATINGS_HISTORICAL, symbol=symbol, limit=limit
+        return self._unwrap_list(
+            await self.client.request_async(
+                RATINGS_HISTORICAL, symbol=symbol, limit=limit
+            ),
+            HistoricalRating,
         )
 
     async def get_price_target_news(
         self, symbol: str, page: int = 0
     ) -> list[PriceTargetNews]:
         """Get price target news"""
-        return await self.client.request_async(
-            PRICE_TARGET_NEWS, symbol=symbol, page=page
+        return self._unwrap_list(
+            await self.client.request_async(
+                PRICE_TARGET_NEWS, symbol=symbol, page=page
+            ),
+            PriceTargetNews,
         )
 
     async def get_price_target_latest_news(
         self, page: int = 0
     ) -> list[PriceTargetNews]:
         """Get latest price target news"""
-        return await self.client.request_async(PRICE_TARGET_LATEST_NEWS, page=page)
+        return self._unwrap_list(
+            await self.client.request_async(PRICE_TARGET_LATEST_NEWS, page=page),
+            PriceTargetNews,
+        )
 
     async def get_grades(self, symbol: str, page: int = 0) -> list[StockGrade]:
         """Get stock grades from analysts"""
-        return await self.client.request_async(GRADES, symbol=symbol, page=page)
+        return self._unwrap_list(
+            await self.client.request_async(GRADES, symbol=symbol, page=page),
+            StockGrade,
+        )
 
     async def get_grades_historical(
         self, symbol: str, limit: int = 100
     ) -> list[HistoricalStockGrade]:
         """Get historical stock grades"""
-        return await self.client.request_async(
-            GRADES_HISTORICAL, symbol=symbol, limit=limit
+        return self._unwrap_list(
+            await self.client.request_async(
+                GRADES_HISTORICAL, symbol=symbol, limit=limit
+            ),
+            HistoricalStockGrade,
         )
 
     async def get_grades_consensus(self, symbol: str) -> StockGradesConsensus | None:
@@ -631,8 +720,14 @@ class AsyncMarketIntelligenceClient(AsyncEndpointGroup):
 
     async def get_grades_news(self, symbol: str, page: int = 0) -> list[StockGradeNews]:
         """Get stock grade news"""
-        return await self.client.request_async(GRADES_NEWS, symbol=symbol, page=page)
+        return self._unwrap_list(
+            await self.client.request_async(GRADES_NEWS, symbol=symbol, page=page),
+            StockGradeNews,
+        )
 
     async def get_grades_latest_news(self, page: int = 0) -> list[StockGradeNews]:
         """Get latest stock grade news"""
-        return await self.client.request_async(GRADES_LATEST_NEWS, page=page)
+        return self._unwrap_list(
+            await self.client.request_async(GRADES_LATEST_NEWS, page=page),
+            StockGradeNews,
+        )

--- a/fmp_data/intelligence/client.py
+++ b/fmp_data/intelligence/client.py
@@ -143,7 +143,9 @@ class MarketIntelligenceClient(EndpointGroup):
         params: dict[str, Any] = self._build_date_params(start_date, end_date)
         if include_report_times is not None:
             params["include_report_times"] = include_report_times
-        return self.client.request(EARNINGS_CALENDAR, **params)
+        return self._unwrap_list(
+            self.client.request(EARNINGS_CALENDAR, **params), EarningEvent
+        )
 
     def get_historical_earnings(
         self,
@@ -169,7 +171,9 @@ class MarketIntelligenceClient(EndpointGroup):
             params["limit"] = limit
         if include_report_times is not None:
             params["include_report_times"] = include_report_times
-        return self.client.request(HISTORICAL_EARNINGS, **params)
+        return self._unwrap_list(
+            self.client.request(HISTORICAL_EARNINGS, **params), EarningEvent
+        )
 
     @deprecated(
         "The FMP API no longer serves the confirmed earnings calendar. Use "
@@ -214,21 +218,25 @@ class MarketIntelligenceClient(EndpointGroup):
     ) -> list[DividendEvent]:
         """Get dividends calendar"""
         params = self._build_date_params(start_date, end_date)
-        return self.client.request(DIVIDENDS_CALENDAR, **params)
+        return self._unwrap_list(
+            self.client.request(DIVIDENDS_CALENDAR, **params), DividendEvent
+        )
 
     def get_stock_splits_calendar(
         self, start_date: date | None = None, end_date: date | None = None
     ) -> list[StockSplitEvent]:
         """Get stock splits calendar"""
         params = self._build_date_params(start_date, end_date)
-        return self.client.request(STOCK_SPLITS_CALENDAR, **params)
+        return self._unwrap_list(
+            self.client.request(STOCK_SPLITS_CALENDAR, **params), StockSplitEvent
+        )
 
     def get_ipo_calendar(
         self, start_date: date | None = None, end_date: date | None = None
     ) -> list[IPOEvent]:
         """Get IPO calendar"""
         params = self._build_date_params(start_date, end_date)
-        return self.client.request(IPO_CALENDAR, **params)
+        return self._unwrap_list(self.client.request(IPO_CALENDAR, **params), IPOEvent)
 
     def get_fmp_articles(
         self, page: int = 0, limit: int = 20, size: int | None = None
@@ -249,11 +257,10 @@ class MarketIntelligenceClient(EndpointGroup):
             "page": page,
             "limit": limit,
         }
-        response = self.client.request(FMP_ARTICLES_ENDPOINT, **params)
-        # Extract articles from the content array in the response
-        return (
-            response.content if isinstance(response, FMPArticlesResponse) else response
-        )
+        response: Any = self.client.request(FMP_ARTICLES_ENDPOINT, **params)
+        if isinstance(response, FMPArticlesResponse):
+            return self._unwrap_list(response.content, FMPArticle)
+        return self._unwrap_list(response, FMPArticle)
 
     def get_general_news(
         self,
@@ -269,7 +276,9 @@ class MarketIntelligenceClient(EndpointGroup):
             "end_date": self._format_date(to_date),
             "limit": limit,
         }
-        return self.client.request(GENERAL_NEWS_ENDPOINT, **params)
+        return self._unwrap_list(
+            self.client.request(GENERAL_NEWS_ENDPOINT, **params), GeneralNewsArticle
+        )
 
     def get_stock_symbol_news(
         self,
@@ -287,7 +296,9 @@ class MarketIntelligenceClient(EndpointGroup):
             "end_date": self._format_date(to_date),
             "limit": limit,
         }
-        return self.client.request(STOCK_SYMBOL_NEWS_ENDPOINT, **params)
+        return self._unwrap_list(
+            self.client.request(STOCK_SYMBOL_NEWS_ENDPOINT, **params), StockNewsArticle
+        )
 
     def get_stock_news(
         self,
@@ -312,7 +323,9 @@ class MarketIntelligenceClient(EndpointGroup):
             "end_date": self._format_date(to_date),
             "limit": limit,
         }
-        return self.client.request(STOCK_NEWS_ENDPOINT, **params)
+        return self._unwrap_list(
+            self.client.request(STOCK_NEWS_ENDPOINT, **params), StockNewsArticle
+        )
 
     @deprecated(
         "The FMP API no longer supports this endpoint -- "
@@ -354,7 +367,9 @@ class MarketIntelligenceClient(EndpointGroup):
             "end_date": self._format_date(to_date),
             "limit": limit,
         }
-        return self.client.request(FOREX_NEWS_ENDPOINT, **params)
+        return self._unwrap_list(
+            self.client.request(FOREX_NEWS_ENDPOINT, **params), ForexNewsArticle
+        )
 
     def get_forex_symbol_news(
         self,
@@ -372,7 +387,9 @@ class MarketIntelligenceClient(EndpointGroup):
             "end_date": self._format_date(to_date),
             "limit": limit,
         }
-        return self.client.request(FOREX_SYMBOL_NEWS_ENDPOINT, **params)
+        return self._unwrap_list(
+            self.client.request(FOREX_SYMBOL_NEWS_ENDPOINT, **params), ForexNewsArticle
+        )
 
     def get_crypto_news(
         self,
@@ -399,7 +416,9 @@ class MarketIntelligenceClient(EndpointGroup):
             "end_date": self._format_date(to_date),
             "limit": limit,
         }
-        return self.client.request(CRYPTO_NEWS_ENDPOINT, **params)
+        return self._unwrap_list(
+            self.client.request(CRYPTO_NEWS_ENDPOINT, **params), CryptoNewsArticle
+        )
 
     def get_crypto_symbol_news(
         self,
@@ -417,7 +436,10 @@ class MarketIntelligenceClient(EndpointGroup):
             "end_date": self._format_date(to_date),
             "limit": limit,
         }
-        return self.client.request(CRYPTO_SYMBOL_NEWS_ENDPOINT, **params)
+        return self._unwrap_list(
+            self.client.request(CRYPTO_SYMBOL_NEWS_ENDPOINT, **params),
+            CryptoNewsArticle,
+        )
 
     def get_press_releases(
         self,
@@ -433,7 +455,9 @@ class MarketIntelligenceClient(EndpointGroup):
             "end_date": self._format_date(to_date),
             "limit": limit,
         }
-        return self.client.request(PRESS_RELEASES_ENDPOINT, **params)
+        return self._unwrap_list(
+            self.client.request(PRESS_RELEASES_ENDPOINT, **params), PressRelease
+        )
 
     def get_press_releases_by_symbol(
         self,
@@ -451,7 +475,10 @@ class MarketIntelligenceClient(EndpointGroup):
             "end_date": self._format_date(to_date),
             "limit": limit,
         }
-        return self.client.request(PRESS_RELEASES_BY_SYMBOL_ENDPOINT, **params)
+        return self._unwrap_list(
+            self.client.request(PRESS_RELEASES_BY_SYMBOL_ENDPOINT, **params),
+            PressReleaseBySymbol,
+        )
 
     @removed("Social sentiment endpoints were discontinued by FMP.")
     def get_historical_social_sentiment(
@@ -496,20 +523,26 @@ class MarketIntelligenceClient(EndpointGroup):
 
     def get_esg_benchmark(self) -> list[ESGBenchmark]:
         """Get ESG benchmark data"""
-        return self.client.request(ESG_BENCHMARK)
+        return self._unwrap_list(self.client.request(ESG_BENCHMARK), ESGBenchmark)
 
     # Government trading methods
     def get_senate_latest(self, page: int = 0, limit: int = 100) -> list[SenateTrade]:
         """Get latest Senate financial disclosures"""
-        return self.client.request(SENATE_LATEST, page=page, limit=limit)
+        return self._unwrap_list(
+            self.client.request(SENATE_LATEST, page=page, limit=limit), SenateTrade
+        )
 
     def get_senate_trading(self, symbol: str) -> list[SenateTrade]:
         """Get Senate trading data"""
-        return self.client.request(SENATE_TRADING, symbol=symbol)
+        return self._unwrap_list(
+            self.client.request(SENATE_TRADING, symbol=symbol), SenateTrade
+        )
 
     def get_senate_trades_by_name(self, name: str) -> list[SenateTrade]:
         """Get Senate trading data by name"""
-        return self.client.request(SENATE_TRADES_BY_NAME, name=name)
+        return self._unwrap_list(
+            self.client.request(SENATE_TRADES_BY_NAME, name=name), SenateTrade
+        )
 
     @deprecated(
         "senate-trading-rss-feed is dead. The live path senate-latest is "
@@ -532,30 +565,44 @@ class MarketIntelligenceClient(EndpointGroup):
         self, page: int = 0, limit: int = 100
     ) -> list[HouseDisclosure]:
         """Get latest House financial disclosures"""
-        return self.client.request(HOUSE_LATEST, page=page, limit=limit)
+        return self._unwrap_list(
+            self.client.request(HOUSE_LATEST, page=page, limit=limit), HouseDisclosure
+        )
 
     def get_house_disclosure(self, symbol: str) -> list[HouseDisclosure]:
         """Get House disclosure data"""
-        return self.client.request(HOUSE_DISCLOSURE, symbol=symbol)
+        return self._unwrap_list(
+            self.client.request(HOUSE_DISCLOSURE, symbol=symbol), HouseDisclosure
+        )
 
     def get_house_trades_by_name(self, name: str) -> list[HouseDisclosure]:
         """Get House trading data by name"""
-        return self.client.request(HOUSE_TRADES_BY_NAME, name=name)
+        return self._unwrap_list(
+            self.client.request(HOUSE_TRADES_BY_NAME, name=name), HouseDisclosure
+        )
 
     # Fundraising methods
     def get_crowdfunding_rss(
         self, page: int = 0, limit: int = 100
     ) -> list[CrowdfundingOffering]:
         """Get latest crowdfunding offerings"""
-        return self.client.request(CROWDFUNDING_RSS, page=page, limit=limit)
+        return self._unwrap_list(
+            self.client.request(CROWDFUNDING_RSS, page=page, limit=limit),
+            CrowdfundingOffering,
+        )
 
     def search_crowdfunding(self, name: str) -> list[CrowdfundingOfferingSearchItem]:
         """Search crowdfunding offerings"""
-        return self.client.request(CROWDFUNDING_SEARCH, name=name)
+        return self._unwrap_list(
+            self.client.request(CROWDFUNDING_SEARCH, name=name),
+            CrowdfundingOfferingSearchItem,
+        )
 
     def get_crowdfunding_by_cik(self, cik: str) -> list[CrowdfundingOffering]:
         """Get crowdfunding offerings by CIK"""
-        return self.client.request(CROWDFUNDING_BY_CIK, cik=cik)
+        return self._unwrap_list(
+            self.client.request(CROWDFUNDING_BY_CIK, cik=cik), CrowdfundingOffering
+        )
 
     def get_equity_offering_rss(
         self, page: int = 0, limit: int = 10, cik: str | None = None
@@ -564,15 +611,22 @@ class MarketIntelligenceClient(EndpointGroup):
         params: dict[str, int | str] = {"page": page, "limit": limit}
         if cik is not None:
             params["cik"] = cik
-        return self.client.request(EQUITY_OFFERING_RSS, **params)
+        return self._unwrap_list(
+            self.client.request(EQUITY_OFFERING_RSS, **params), EquityOffering
+        )
 
     def search_equity_offering(self, name: str) -> list[EquityOfferingSearchItem]:
         """Search equity offerings"""
-        return self.client.request(EQUITY_OFFERING_SEARCH, name=name)
+        return self._unwrap_list(
+            self.client.request(EQUITY_OFFERING_SEARCH, name=name),
+            EquityOfferingSearchItem,
+        )
 
     def get_equity_offering_by_cik(self, cik: str) -> list[EquityOffering]:
         """Get equity offerings by CIK"""
-        return self.client.request(EQUITY_OFFERING_BY_CIK, cik=cik)
+        return self._unwrap_list(
+            self.client.request(EQUITY_OFFERING_BY_CIK, cik=cik), EquityOffering
+        )
 
     # Analyst Ratings and Grades methods
     def get_ratings_snapshot(self, symbol: str) -> RatingsSnapshot | None:
@@ -584,27 +638,40 @@ class MarketIntelligenceClient(EndpointGroup):
         self, symbol: str, limit: int = 100
     ) -> list[HistoricalRating]:
         """Get historical analyst ratings"""
-        return self.client.request(RATINGS_HISTORICAL, symbol=symbol, limit=limit)
+        return self._unwrap_list(
+            self.client.request(RATINGS_HISTORICAL, symbol=symbol, limit=limit),
+            HistoricalRating,
+        )
 
     def get_price_target_news(
         self, symbol: str, page: int = 0
     ) -> list[PriceTargetNews]:
         """Get price target news"""
-        return self.client.request(PRICE_TARGET_NEWS, symbol=symbol, page=page)
+        return self._unwrap_list(
+            self.client.request(PRICE_TARGET_NEWS, symbol=symbol, page=page),
+            PriceTargetNews,
+        )
 
     def get_price_target_latest_news(self, page: int = 0) -> list[PriceTargetNews]:
         """Get latest price target news"""
-        return self.client.request(PRICE_TARGET_LATEST_NEWS, page=page)
+        return self._unwrap_list(
+            self.client.request(PRICE_TARGET_LATEST_NEWS, page=page), PriceTargetNews
+        )
 
     def get_grades(self, symbol: str, page: int = 0) -> list[StockGrade]:
         """Get stock grades from analysts"""
-        return self.client.request(GRADES, symbol=symbol, page=page)
+        return self._unwrap_list(
+            self.client.request(GRADES, symbol=symbol, page=page), StockGrade
+        )
 
     def get_grades_historical(
         self, symbol: str, limit: int = 100
     ) -> list[HistoricalStockGrade]:
         """Get historical stock grades"""
-        return self.client.request(GRADES_HISTORICAL, symbol=symbol, limit=limit)
+        return self._unwrap_list(
+            self.client.request(GRADES_HISTORICAL, symbol=symbol, limit=limit),
+            HistoricalStockGrade,
+        )
 
     def get_grades_consensus(self, symbol: str) -> StockGradesConsensus | None:
         """Get stock grades consensus summary"""
@@ -613,8 +680,12 @@ class MarketIntelligenceClient(EndpointGroup):
 
     def get_grades_news(self, symbol: str, page: int = 0) -> list[StockGradeNews]:
         """Get stock grade news"""
-        return self.client.request(GRADES_NEWS, symbol=symbol, page=page)
+        return self._unwrap_list(
+            self.client.request(GRADES_NEWS, symbol=symbol, page=page), StockGradeNews
+        )
 
     def get_grades_latest_news(self, page: int = 0) -> list[StockGradeNews]:
         """Get latest stock grade news"""
-        return self.client.request(GRADES_LATEST_NEWS, page=page)
+        return self._unwrap_list(
+            self.client.request(GRADES_LATEST_NEWS, page=page), StockGradeNews
+        )

--- a/fmp_data/intelligence/endpoints.py
+++ b/fmp_data/intelligence/endpoints.py
@@ -43,7 +43,7 @@ from fmp_data.models import (
     URLType,
 )
 
-EARNINGS_CALENDAR: Endpoint = Endpoint(
+EARNINGS_CALENDAR: Endpoint[EarningEvent] = Endpoint(
     name="earnings_calendar",
     path="earnings-calendar",
     version=APIVersion.STABLE,
@@ -80,7 +80,7 @@ EARNINGS_CALENDAR: Endpoint = Endpoint(
     response_model=EarningEvent,
 )
 
-EARNINGS_CONFIRMED: Endpoint = Endpoint(
+EARNINGS_CONFIRMED: Endpoint[EarningConfirmed] = Endpoint(
     name="earnings_confirmed",
     path="earning-calendar-confirmed",
     version=APIVersion.STABLE,
@@ -107,7 +107,7 @@ EARNINGS_CONFIRMED: Endpoint = Endpoint(
     response_model=EarningConfirmed,
 )
 
-EARNINGS_SURPRISES: Endpoint = Endpoint(
+EARNINGS_SURPRISES: Endpoint[EarningSurprise] = Endpoint(
     name="earnings_surprises",
     path="earnings-surprises",
     version=APIVersion.STABLE,
@@ -126,7 +126,7 @@ EARNINGS_SURPRISES: Endpoint = Endpoint(
     response_model=EarningSurprise,
 )
 
-HISTORICAL_EARNINGS: Endpoint = Endpoint(
+HISTORICAL_EARNINGS: Endpoint[EarningEvent] = Endpoint(
     name="historical_earnings",
     path="earnings",
     version=APIVersion.STABLE,
@@ -162,7 +162,7 @@ HISTORICAL_EARNINGS: Endpoint = Endpoint(
     response_model=EarningEvent,
 )
 
-DIVIDENDS_CALENDAR: Endpoint = Endpoint(
+DIVIDENDS_CALENDAR: Endpoint[DividendEvent] = Endpoint(
     name="dividends_calendar",
     path="dividends-calendar",
     version=APIVersion.STABLE,
@@ -189,7 +189,7 @@ DIVIDENDS_CALENDAR: Endpoint = Endpoint(
     response_model=DividendEvent,
 )
 
-STOCK_SPLITS_CALENDAR: Endpoint = Endpoint(
+STOCK_SPLITS_CALENDAR: Endpoint[StockSplitEvent] = Endpoint(
     name="stock_splits_calendar",
     path="splits-calendar",
     version=APIVersion.STABLE,
@@ -216,7 +216,7 @@ STOCK_SPLITS_CALENDAR: Endpoint = Endpoint(
     response_model=StockSplitEvent,
 )
 
-IPO_CALENDAR: Endpoint = Endpoint(
+IPO_CALENDAR: Endpoint[IPOEvent] = Endpoint(
     name="ipo_calendar",
     path="ipos-calendar",
     version=APIVersion.STABLE,
@@ -243,7 +243,7 @@ IPO_CALENDAR: Endpoint = Endpoint(
     response_model=IPOEvent,
 )
 
-FMP_ARTICLES_ENDPOINT: Endpoint = Endpoint(
+FMP_ARTICLES_ENDPOINT: Endpoint[FMPArticle] = Endpoint(
     name="fmp_articles",
     path="fmp-articles",
     version=APIVersion.STABLE,
@@ -268,7 +268,7 @@ FMP_ARTICLES_ENDPOINT: Endpoint = Endpoint(
     response_model=FMPArticle,
 )
 
-GENERAL_NEWS_ENDPOINT: Endpoint = Endpoint(
+GENERAL_NEWS_ENDPOINT: Endpoint[GeneralNewsArticle] = Endpoint(
     name="general_news",
     path="news/general-latest",
     version=APIVersion.STABLE,
@@ -307,7 +307,7 @@ GENERAL_NEWS_ENDPOINT: Endpoint = Endpoint(
     response_model=GeneralNewsArticle,
 )
 
-STOCK_NEWS_ENDPOINT: Endpoint = Endpoint(
+STOCK_NEWS_ENDPOINT: Endpoint[StockNewsArticle] = Endpoint(
     name="stock_news",
     path="news/stock-latest",
     version=APIVersion.STABLE,
@@ -346,7 +346,7 @@ STOCK_NEWS_ENDPOINT: Endpoint = Endpoint(
     response_model=StockNewsArticle,
 )
 
-STOCK_SYMBOL_NEWS_ENDPOINT: Endpoint = Endpoint(
+STOCK_SYMBOL_NEWS_ENDPOINT: Endpoint[StockNewsArticle] = Endpoint(
     name="stock_news_symbol",
     path="news/stock",
     version=APIVersion.STABLE,
@@ -392,7 +392,7 @@ STOCK_SYMBOL_NEWS_ENDPOINT: Endpoint = Endpoint(
     response_model=StockNewsArticle,
 )
 
-STOCK_NEWS_SENTIMENTS_ENDPOINT: Endpoint = Endpoint(
+STOCK_NEWS_SENTIMENTS_ENDPOINT: Endpoint[StockNewsSentiment] = Endpoint(
     name="stock_news_sentiments",
     path="stock-news-sentiments-rss-feed",
     version=APIVersion.V4,
@@ -409,7 +409,7 @@ STOCK_NEWS_SENTIMENTS_ENDPOINT: Endpoint = Endpoint(
     response_model=StockNewsSentiment,
 )
 
-FOREX_NEWS_ENDPOINT: Endpoint = Endpoint(
+FOREX_NEWS_ENDPOINT: Endpoint[ForexNewsArticle] = Endpoint(
     name="forex_news",
     path="news/forex-latest",
     version=APIVersion.STABLE,
@@ -448,7 +448,7 @@ FOREX_NEWS_ENDPOINT: Endpoint = Endpoint(
     response_model=ForexNewsArticle,
 )
 
-CRYPTO_NEWS_ENDPOINT: Endpoint = Endpoint(
+CRYPTO_NEWS_ENDPOINT: Endpoint[CryptoNewsArticle] = Endpoint(
     name="crypto_news",
     path="news/crypto-latest",
     version=APIVersion.STABLE,
@@ -487,7 +487,7 @@ CRYPTO_NEWS_ENDPOINT: Endpoint = Endpoint(
     response_model=CryptoNewsArticle,
 )
 
-FOREX_SYMBOL_NEWS_ENDPOINT: Endpoint = Endpoint(
+FOREX_SYMBOL_NEWS_ENDPOINT: Endpoint[ForexNewsArticle] = Endpoint(
     name="forex_news_symbol",
     path="news/forex",
     version=APIVersion.STABLE,
@@ -534,7 +534,7 @@ FOREX_SYMBOL_NEWS_ENDPOINT: Endpoint = Endpoint(
     response_model=ForexNewsArticle,
 )
 
-CRYPTO_SYMBOL_NEWS_ENDPOINT: Endpoint = Endpoint(
+CRYPTO_SYMBOL_NEWS_ENDPOINT: Endpoint[CryptoNewsArticle] = Endpoint(
     name="crypto_news_symbol",
     path="news/crypto",
     version=APIVersion.STABLE,
@@ -581,7 +581,7 @@ CRYPTO_SYMBOL_NEWS_ENDPOINT: Endpoint = Endpoint(
     response_model=CryptoNewsArticle,
 )
 
-PRESS_RELEASES_ENDPOINT: Endpoint = Endpoint(
+PRESS_RELEASES_ENDPOINT: Endpoint[PressRelease] = Endpoint(
     name="press_releases",
     path="news/press-releases-latest",
     version=APIVersion.STABLE,
@@ -620,7 +620,7 @@ PRESS_RELEASES_ENDPOINT: Endpoint = Endpoint(
     response_model=PressRelease,
 )
 
-PRESS_RELEASES_BY_SYMBOL_ENDPOINT: Endpoint = Endpoint(
+PRESS_RELEASES_BY_SYMBOL_ENDPOINT: Endpoint[PressReleaseBySymbol] = Endpoint(
     name="press_releases_by_symbol",
     path="news/press-releases",
     version=APIVersion.STABLE,
@@ -667,7 +667,7 @@ PRESS_RELEASES_BY_SYMBOL_ENDPOINT: Endpoint = Endpoint(
     response_model=PressReleaseBySymbol,
 )
 
-HISTORICAL_SOCIAL_SENTIMENT_ENDPOINT: Endpoint = Endpoint(
+HISTORICAL_SOCIAL_SENTIMENT_ENDPOINT: Endpoint[HistoricalSocialSentiment] = Endpoint(
     name="historical_social_sentiment",
     path="historical/social-sentiment",
     version=APIVersion.STABLE,
@@ -691,7 +691,7 @@ HISTORICAL_SOCIAL_SENTIMENT_ENDPOINT: Endpoint = Endpoint(
     response_model=HistoricalSocialSentiment,
 )
 
-TRENDING_SOCIAL_SENTIMENT_ENDPOINT: Endpoint = Endpoint(
+TRENDING_SOCIAL_SENTIMENT_ENDPOINT: Endpoint[TrendingSocialSentiment] = Endpoint(
     name="trending_social_sentiment",
     path="social-sentiments/trending",
     version=APIVersion.STABLE,
@@ -714,7 +714,7 @@ TRENDING_SOCIAL_SENTIMENT_ENDPOINT: Endpoint = Endpoint(
     response_model=TrendingSocialSentiment,
 )
 
-SOCIAL_SENTIMENT_CHANGES_ENDPOINT: Endpoint = Endpoint(
+SOCIAL_SENTIMENT_CHANGES_ENDPOINT: Endpoint[SocialSentimentChanges] = Endpoint(
     name="social_sentiment_changes",
     path="social-sentiments/change",
     version=APIVersion.STABLE,
@@ -772,7 +772,7 @@ ESG_RATINGS: Endpoint[ESGRating] = Endpoint(
     response_model=ESGRating,
 )
 
-ESG_BENCHMARK: Endpoint = Endpoint(
+ESG_BENCHMARK: Endpoint[ESGBenchmark] = Endpoint(
     name="esg_benchmark",
     path="esg-benchmark",
     version=APIVersion.STABLE,
@@ -783,7 +783,7 @@ ESG_BENCHMARK: Endpoint = Endpoint(
 )
 
 # Government Trading Endpoints
-SENATE_LATEST: Endpoint = Endpoint(
+SENATE_LATEST: Endpoint[SenateTrade] = Endpoint(
     name="senate_latest",
     path="senate-latest",
     version=APIVersion.STABLE,
@@ -808,7 +808,7 @@ SENATE_LATEST: Endpoint = Endpoint(
     response_model=SenateTrade,
 )
 
-SENATE_TRADING: Endpoint = Endpoint(
+SENATE_TRADING: Endpoint[SenateTrade] = Endpoint(
     name="senate_trading",
     path="senate-trades",
     version=APIVersion.STABLE,
@@ -825,7 +825,7 @@ SENATE_TRADING: Endpoint = Endpoint(
     response_model=SenateTrade,
 )
 
-SENATE_TRADES_BY_NAME: Endpoint = Endpoint(
+SENATE_TRADES_BY_NAME: Endpoint[SenateTrade] = Endpoint(
     name="senate_trades_by_name",
     path="senate-trades-by-name",
     version=APIVersion.STABLE,
@@ -842,7 +842,7 @@ SENATE_TRADES_BY_NAME: Endpoint = Endpoint(
     response_model=SenateTrade,
 )
 
-SENATE_TRADING_RSS: Endpoint = Endpoint(
+SENATE_TRADING_RSS: Endpoint[SenateTrade] = Endpoint(
     name="senate_trading_rss",
     path="senate-trading-rss-feed",
     version=APIVersion.STABLE,
@@ -864,7 +864,7 @@ SENATE_TRADING_RSS: Endpoint = Endpoint(
     response_model=SenateTrade,
 )
 
-HOUSE_LATEST: Endpoint = Endpoint(
+HOUSE_LATEST: Endpoint[HouseDisclosure] = Endpoint(
     name="house_latest",
     path="house-latest",
     version=APIVersion.STABLE,
@@ -889,7 +889,7 @@ HOUSE_LATEST: Endpoint = Endpoint(
     response_model=HouseDisclosure,
 )
 
-HOUSE_DISCLOSURE: Endpoint = Endpoint(
+HOUSE_DISCLOSURE: Endpoint[HouseDisclosure] = Endpoint(
     name="house_disclosure",
     path="house-trades",
     version=APIVersion.STABLE,
@@ -906,7 +906,7 @@ HOUSE_DISCLOSURE: Endpoint = Endpoint(
     response_model=HouseDisclosure,
 )
 
-HOUSE_TRADES_BY_NAME: Endpoint = Endpoint(
+HOUSE_TRADES_BY_NAME: Endpoint[HouseDisclosure] = Endpoint(
     name="house_trades_by_name",
     path="house-trades-by-name",
     version=APIVersion.STABLE,
@@ -924,7 +924,7 @@ HOUSE_TRADES_BY_NAME: Endpoint = Endpoint(
 )
 
 # Fundraising Endpoints
-CROWDFUNDING_RSS: Endpoint = Endpoint(
+CROWDFUNDING_RSS: Endpoint[CrowdfundingOffering] = Endpoint(
     name="crowdfunding_rss",
     path="crowdfunding-offerings-latest",
     version=APIVersion.STABLE,
@@ -949,7 +949,7 @@ CROWDFUNDING_RSS: Endpoint = Endpoint(
     response_model=CrowdfundingOffering,
 )
 
-CROWDFUNDING_SEARCH: Endpoint = Endpoint(
+CROWDFUNDING_SEARCH: Endpoint[CrowdfundingOfferingSearchItem] = Endpoint(
     name="crowdfunding_search",
     path="crowdfunding-offerings-search",
     version=APIVersion.STABLE,
@@ -966,7 +966,7 @@ CROWDFUNDING_SEARCH: Endpoint = Endpoint(
     response_model=CrowdfundingOfferingSearchItem,
 )
 
-CROWDFUNDING_BY_CIK: Endpoint = Endpoint(
+CROWDFUNDING_BY_CIK: Endpoint[CrowdfundingOffering] = Endpoint(
     name="crowdfunding_by_cik",
     path="crowdfunding-offerings",
     version=APIVersion.STABLE,
@@ -983,7 +983,7 @@ CROWDFUNDING_BY_CIK: Endpoint = Endpoint(
     response_model=CrowdfundingOffering,
 )
 
-EQUITY_OFFERING_RSS: Endpoint = Endpoint(
+EQUITY_OFFERING_RSS: Endpoint[EquityOffering] = Endpoint(
     name="equity_offering_rss",
     path="fundraising-latest",
     version=APIVersion.STABLE,
@@ -1015,7 +1015,7 @@ EQUITY_OFFERING_RSS: Endpoint = Endpoint(
     response_model=EquityOffering,
 )
 
-EQUITY_OFFERING_SEARCH: Endpoint = Endpoint(
+EQUITY_OFFERING_SEARCH: Endpoint[EquityOfferingSearchItem] = Endpoint(
     name="equity_offering_search",
     path="fundraising-search",
     version=APIVersion.STABLE,
@@ -1032,7 +1032,7 @@ EQUITY_OFFERING_SEARCH: Endpoint = Endpoint(
     response_model=EquityOfferingSearchItem,
 )
 
-EQUITY_OFFERING_BY_CIK: Endpoint = Endpoint(
+EQUITY_OFFERING_BY_CIK: Endpoint[EquityOffering] = Endpoint(
     name="equity_offering_by_cik",
     path="fundraising",
     version=APIVersion.STABLE,
@@ -1067,7 +1067,7 @@ RATINGS_SNAPSHOT: Endpoint[RatingsSnapshot] = Endpoint(
     response_model=RatingsSnapshot,
 )
 
-RATINGS_HISTORICAL: Endpoint = Endpoint(
+RATINGS_HISTORICAL: Endpoint[HistoricalRating] = Endpoint(
     name="ratings_historical",
     path="ratings-historical",
     version=APIVersion.STABLE,
@@ -1092,7 +1092,7 @@ RATINGS_HISTORICAL: Endpoint = Endpoint(
     response_model=HistoricalRating,
 )
 
-PRICE_TARGET_NEWS: Endpoint = Endpoint(
+PRICE_TARGET_NEWS: Endpoint[PriceTargetNews] = Endpoint(
     name="price_target_news",
     path="price-target-news",
     version=APIVersion.STABLE,
@@ -1117,7 +1117,7 @@ PRICE_TARGET_NEWS: Endpoint = Endpoint(
     response_model=PriceTargetNews,
 )
 
-PRICE_TARGET_LATEST_NEWS: Endpoint = Endpoint(
+PRICE_TARGET_LATEST_NEWS: Endpoint[PriceTargetNews] = Endpoint(
     name="price_target_latest_news",
     path="price-target-latest-news",
     version=APIVersion.STABLE,
@@ -1135,7 +1135,7 @@ PRICE_TARGET_LATEST_NEWS: Endpoint = Endpoint(
     response_model=PriceTargetNews,
 )
 
-GRADES: Endpoint = Endpoint(
+GRADES: Endpoint[StockGrade] = Endpoint(
     name="grades",
     path="grades",
     version=APIVersion.STABLE,
@@ -1160,7 +1160,7 @@ GRADES: Endpoint = Endpoint(
     response_model=StockGrade,
 )
 
-GRADES_HISTORICAL: Endpoint = Endpoint(
+GRADES_HISTORICAL: Endpoint[HistoricalStockGrade] = Endpoint(
     name="grades_historical",
     path="grades-historical",
     version=APIVersion.STABLE,
@@ -1202,7 +1202,7 @@ GRADES_CONSENSUS: Endpoint[StockGradesConsensus] = Endpoint(
     response_model=StockGradesConsensus,
 )
 
-GRADES_NEWS: Endpoint = Endpoint(
+GRADES_NEWS: Endpoint[StockGradeNews] = Endpoint(
     name="grades_news",
     path="grades-news",
     version=APIVersion.STABLE,
@@ -1227,7 +1227,7 @@ GRADES_NEWS: Endpoint = Endpoint(
     response_model=StockGradeNews,
 )
 
-GRADES_LATEST_NEWS: Endpoint = Endpoint(
+GRADES_LATEST_NEWS: Endpoint[StockGradeNews] = Endpoint(
     name="grades_latest_news",
     path="grades-latest-news",
     version=APIVersion.STABLE,

--- a/fmp_data/intelligence/mapping.py
+++ b/fmp_data/intelligence/mapping.py
@@ -1,5 +1,7 @@
 # fmp_data/intelligence/mapping.py
 
+from typing import Any
+
 from fmp_data.intelligence.endpoints import (
     CROWDFUNDING_BY_CIK,
     CROWDFUNDING_RSS,
@@ -60,9 +62,10 @@ from fmp_data.lc.models import (
     ResponseFieldInfo,
     SemanticCategory,
 )
+from fmp_data.models import Endpoint
 
 # Endpoint to method mapping
-INTELLIGENCE_ENDPOINT_MAP = {
+INTELLIGENCE_ENDPOINT_MAP: dict[str, Endpoint[Any]] = {
     # Calendar endpoints
     "get_earnings_calendar": EARNINGS_CALENDAR,
     "get_earnings_confirmed": EARNINGS_CONFIRMED,

--- a/fmp_data/investment/async_client.py
+++ b/fmp_data/investment/async_client.py
@@ -2,6 +2,7 @@
 """Async client for investment products endpoints."""
 
 from datetime import date
+from typing import cast
 import warnings
 
 from fmp_data.base import AsyncEndpointGroup
@@ -30,6 +31,7 @@ from fmp_data.investment.models import (
     FundDisclosureSearchResult,
     MutualFundHolder,
     MutualFundHolding,
+    PortfolioDate,
 )
 from fmp_data.logger import FMPLogger
 
@@ -47,7 +49,9 @@ class AsyncInvestmentClient(AsyncEndpointGroup):
         params: dict[str, str] = {"symbol": symbol}
         if holdings_date is not None:
             params["date"] = holdings_date.strftime("%Y-%m-%d")
-        return await self.client.request_async(ETF_HOLDINGS, **params)
+        return self._unwrap_list(
+            await self.client.request_async(ETF_HOLDINGS, **params), ETFHolding
+        )
 
     @deprecated(
         "etf/portfolio-dates is dead. The live path funds/disclosure-dates is "
@@ -79,11 +83,16 @@ class AsyncInvestmentClient(AsyncEndpointGroup):
             ETFInfo object if found, or None if no data/error occurs
         """
         try:
-            result = await self.client.request_async(ETF_INFO, symbol=symbol)
-            if isinstance(result, list):
-                return result[0] if result else None
+            result = cast(
+                object, await self.client.request_async(ETF_INFO, symbol=symbol)
+            )
             if isinstance(result, ETFInfo):
                 return result
+            if isinstance(result, list):
+                return cast(
+                    ETFInfo | None,
+                    self._unwrap_single(result, ETFInfo, allow_none=True),
+                )
             warnings.warn(
                 f"Unexpected result type from ETF_INFO: {type(result)}", stacklevel=2
             )
@@ -97,17 +106,25 @@ class AsyncInvestmentClient(AsyncEndpointGroup):
 
     async def get_etf_sector_weightings(self, symbol: str) -> list[ETFSectorWeighting]:
         """Get ETF sector weightings"""
-        return await self.client.request_async(ETF_SECTOR_WEIGHTINGS, symbol=symbol)
+        return self._unwrap_list(
+            await self.client.request_async(ETF_SECTOR_WEIGHTINGS, symbol=symbol),
+            ETFSectorWeighting,
+        )
 
     async def get_etf_country_weightings(
         self, symbol: str
     ) -> list[ETFCountryWeighting]:
         """Get ETF country weightings"""
-        return await self.client.request_async(ETF_COUNTRY_WEIGHTINGS, symbol=symbol)
+        return self._unwrap_list(
+            await self.client.request_async(ETF_COUNTRY_WEIGHTINGS, symbol=symbol),
+            ETFCountryWeighting,
+        )
 
     async def get_etf_exposure(self, symbol: str) -> list[ETFExposure]:
         """Get ETF stock exposure"""
-        return await self.client.request_async(ETF_EXPOSURE, symbol=symbol)
+        return self._unwrap_list(
+            await self.client.request_async(ETF_EXPOSURE, symbol=symbol), ETFExposure
+        )
 
     @deprecated(
         "etf/holder is dead and FMP publishes nothing with this shape. "
@@ -136,7 +153,7 @@ class AsyncInvestmentClient(AsyncEndpointGroup):
     # Mutual Fund methods
     async def get_mutual_fund_dates(
         self, symbol: str, cik: str | int | None = None
-    ) -> list[date]:
+    ) -> list[PortfolioDate]:
         """Get mutual fund/ETF disclosure dates
 
         Args:
@@ -144,16 +161,19 @@ class AsyncInvestmentClient(AsyncEndpointGroup):
             cik: Optional fund CIK
 
         Returns:
-            List of disclosure dates
+            List of disclosure date records
         """
         params: dict[str, str | int] = {"symbol": symbol}
         if cik is not None:
             params["cik"] = cik
-        return await self.client.request_async(MUTUAL_FUND_DATES, **params)
+        return self._unwrap_list(
+            await self.client.request_async(MUTUAL_FUND_DATES, **params),
+            PortfolioDate,
+        )
 
     async def get_fund_disclosure_dates(
         self, symbol: str, cik: str | int | None = None
-    ) -> list[date]:
+    ) -> list[PortfolioDate]:
         """Get mutual fund/ETF disclosure dates"""
         return await self.get_mutual_fund_dates(symbol=symbol, cik=cik)
 
@@ -222,8 +242,11 @@ class AsyncInvestmentClient(AsyncEndpointGroup):
         self, symbol: str
     ) -> list[FundDisclosureHolderLatest]:
         """Get latest mutual fund/ETF disclosure holders"""
-        return await self.client.request_async(
-            FUNDS_DISCLOSURE_HOLDERS_LATEST, symbol=symbol
+        return self._unwrap_list(
+            await self.client.request_async(
+                FUNDS_DISCLOSURE_HOLDERS_LATEST, symbol=symbol
+            ),
+            FundDisclosureHolderLatest,
         )
 
     async def get_fund_disclosure(
@@ -237,12 +260,16 @@ class AsyncInvestmentClient(AsyncEndpointGroup):
         }
         if cik is not None:
             params["cik"] = cik
-        return await self.client.request_async(FUNDS_DISCLOSURE, **params)
+        return self._unwrap_list(
+            await self.client.request_async(FUNDS_DISCLOSURE, **params),
+            FundDisclosureHolding,
+        )
 
     async def search_fund_disclosure_holders(
         self, name: str
     ) -> list[FundDisclosureSearchResult]:
         """Search mutual fund/ETF disclosure holders by name"""
-        return await self.client.request_async(
-            FUNDS_DISCLOSURE_HOLDERS_SEARCH, name=name
+        return self._unwrap_list(
+            await self.client.request_async(FUNDS_DISCLOSURE_HOLDERS_SEARCH, name=name),
+            FundDisclosureSearchResult,
         )

--- a/fmp_data/investment/client.py
+++ b/fmp_data/investment/client.py
@@ -1,5 +1,6 @@
 # fmp_data/investment/client.py
 from datetime import date
+from typing import cast
 import warnings
 
 from fmp_data.base import EndpointGroup
@@ -27,6 +28,7 @@ from fmp_data.investment.models import (
     FundDisclosureSearchResult,
     MutualFundHolder,
     MutualFundHolding,
+    PortfolioDate,
 )
 
 
@@ -41,7 +43,9 @@ class InvestmentClient(EndpointGroup):
         params: dict[str, str] = {"symbol": symbol}
         if holdings_date is not None:
             params["date"] = holdings_date.strftime("%Y-%m-%d")
-        return self.client.request(ETF_HOLDINGS, **params)
+        return self._unwrap_list(
+            self.client.request(ETF_HOLDINGS, **params), ETFHolding
+        )
 
     @deprecated(
         "etf/portfolio-dates is dead. The live path funds/disclosure-dates is "
@@ -73,11 +77,14 @@ class InvestmentClient(EndpointGroup):
             ETFInfo object if found, or None if no data/error occurs
         """
         try:
-            result = self.client.request(ETF_INFO, symbol=symbol)
-            if isinstance(result, list):
-                return result[0] if result else None
+            result = cast(object, self.client.request(ETF_INFO, symbol=symbol))
             if isinstance(result, ETFInfo):
                 return result
+            if isinstance(result, list):
+                return cast(
+                    ETFInfo | None,
+                    self._unwrap_single(result, ETFInfo, allow_none=True),
+                )
             warnings.warn(
                 f"Unexpected result type from ETF_INFO: {type(result)}", stacklevel=2
             )
@@ -88,15 +95,23 @@ class InvestmentClient(EndpointGroup):
 
     def get_etf_sector_weightings(self, symbol: str) -> list[ETFSectorWeighting]:
         """Get ETF sector weightings"""
-        return self.client.request(ETF_SECTOR_WEIGHTINGS, symbol=symbol)
+        return self._unwrap_list(
+            self.client.request(ETF_SECTOR_WEIGHTINGS, symbol=symbol),
+            ETFSectorWeighting,
+        )
 
     def get_etf_country_weightings(self, symbol: str) -> list[ETFCountryWeighting]:
         """Get ETF country weightings"""
-        return self.client.request(ETF_COUNTRY_WEIGHTINGS, symbol=symbol)
+        return self._unwrap_list(
+            self.client.request(ETF_COUNTRY_WEIGHTINGS, symbol=symbol),
+            ETFCountryWeighting,
+        )
 
     def get_etf_exposure(self, symbol: str) -> list[ETFExposure]:
         """Get ETF stock exposure"""
-        return self.client.request(ETF_EXPOSURE, symbol=symbol)
+        return self._unwrap_list(
+            self.client.request(ETF_EXPOSURE, symbol=symbol), ETFExposure
+        )
 
     @deprecated(
         "etf/holder is dead and FMP publishes nothing with this shape. "
@@ -125,7 +140,7 @@ class InvestmentClient(EndpointGroup):
     # Mutual Fund methods
     def get_mutual_fund_dates(
         self, symbol: str, cik: str | int | None = None
-    ) -> list[date]:
+    ) -> list[PortfolioDate]:
         """Get mutual fund/ETF disclosure dates
 
         Args:
@@ -133,16 +148,19 @@ class InvestmentClient(EndpointGroup):
             cik: Optional fund CIK
 
         Returns:
-            List of disclosure dates
+            List of disclosure date records
         """
         params: dict[str, str | int] = {"symbol": symbol}
         if cik is not None:
             params["cik"] = cik
-        return self.client.request(MUTUAL_FUND_DATES, **params)
+        return self._unwrap_list(
+            self.client.request(MUTUAL_FUND_DATES, **params),
+            PortfolioDate,
+        )
 
     def get_fund_disclosure_dates(
         self, symbol: str, cik: str | int | None = None
-    ) -> list[date]:
+    ) -> list[PortfolioDate]:
         """Get mutual fund/ETF disclosure dates"""
         return self.get_mutual_fund_dates(symbol=symbol, cik=cik)
 
@@ -211,7 +229,10 @@ class InvestmentClient(EndpointGroup):
         self, symbol: str
     ) -> list[FundDisclosureHolderLatest]:
         """Get latest mutual fund/ETF disclosure holders"""
-        return self.client.request(FUNDS_DISCLOSURE_HOLDERS_LATEST, symbol=symbol)
+        return self._unwrap_list(
+            self.client.request(FUNDS_DISCLOSURE_HOLDERS_LATEST, symbol=symbol),
+            FundDisclosureHolderLatest,
+        )
 
     def get_fund_disclosure(
         self, symbol: str, year: int, quarter: int, cik: str | int | None = None
@@ -224,10 +245,15 @@ class InvestmentClient(EndpointGroup):
         }
         if cik is not None:
             params["cik"] = cik
-        return self.client.request(FUNDS_DISCLOSURE, **params)
+        return self._unwrap_list(
+            self.client.request(FUNDS_DISCLOSURE, **params), FundDisclosureHolding
+        )
 
     def search_fund_disclosure_holders(
         self, name: str
     ) -> list[FundDisclosureSearchResult]:
         """Search mutual fund/ETF disclosure holders by name"""
-        return self.client.request(FUNDS_DISCLOSURE_HOLDERS_SEARCH, name=name)
+        return self._unwrap_list(
+            self.client.request(FUNDS_DISCLOSURE_HOLDERS_SEARCH, name=name),
+            FundDisclosureSearchResult,
+        )

--- a/fmp_data/investment/endpoints.py
+++ b/fmp_data/investment/endpoints.py
@@ -23,7 +23,7 @@ from fmp_data.models import (
 )
 
 # ETF endpoints
-ETF_HOLDINGS: Endpoint = Endpoint(
+ETF_HOLDINGS: Endpoint[ETFHolding] = Endpoint(
     name="etf_holdings",
     path="etf/holdings",
     version=APIVersion.STABLE,
@@ -47,7 +47,7 @@ ETF_HOLDINGS: Endpoint = Endpoint(
     response_model=ETFHolding,
 )
 
-ETF_HOLDING_DATES: Endpoint = Endpoint(
+ETF_HOLDING_DATES: Endpoint[ETFPortfolioDate] = Endpoint(
     name="etf_holding_dates",
     path="etf/portfolio-dates",
     version=APIVersion.STABLE,
@@ -68,7 +68,7 @@ ETF_HOLDING_DATES: Endpoint = Endpoint(
     response_model=ETFPortfolioDate,
 )
 
-ETF_INFO: Endpoint = Endpoint(
+ETF_INFO: Endpoint[ETFInfo] = Endpoint(
     name="etf_info",
     path="etf/info",
     version=APIVersion.STABLE,
@@ -85,7 +85,7 @@ ETF_INFO: Endpoint = Endpoint(
     response_model=ETFInfo,
 )
 
-ETF_SECTOR_WEIGHTINGS: Endpoint = Endpoint(
+ETF_SECTOR_WEIGHTINGS: Endpoint[ETFSectorWeighting] = Endpoint(
     name="etf_sector_weightings",
     path="etf/sector-weightings",
     version=APIVersion.STABLE,
@@ -102,7 +102,7 @@ ETF_SECTOR_WEIGHTINGS: Endpoint = Endpoint(
     response_model=ETFSectorWeighting,
 )
 
-ETF_COUNTRY_WEIGHTINGS: Endpoint = Endpoint(
+ETF_COUNTRY_WEIGHTINGS: Endpoint[ETFCountryWeighting] = Endpoint(
     name="etf_country_weightings",
     path="etf/country-weightings",
     version=APIVersion.STABLE,
@@ -119,7 +119,7 @@ ETF_COUNTRY_WEIGHTINGS: Endpoint = Endpoint(
     response_model=ETFCountryWeighting,
 )
 
-ETF_EXPOSURE: Endpoint = Endpoint(
+ETF_EXPOSURE: Endpoint[ETFExposure] = Endpoint(
     name="etf_exposure",
     path="etf/asset-exposure",
     version=APIVersion.STABLE,
@@ -136,7 +136,7 @@ ETF_EXPOSURE: Endpoint = Endpoint(
     response_model=ETFExposure,
 )
 
-ETF_HOLDER: Endpoint = Endpoint(
+ETF_HOLDER: Endpoint[ETFHolder] = Endpoint(
     name="etf_holder",
     path="etf/holder",
     version=APIVersion.STABLE,
@@ -158,7 +158,7 @@ ETF_HOLDER: Endpoint = Endpoint(
 )
 
 # Mutual Fund endpoints
-MUTUAL_FUND_DATES: Endpoint = Endpoint(
+MUTUAL_FUND_DATES: Endpoint[PortfolioDate] = Endpoint(
     name="mutual_fund_dates",
     path="funds/disclosure-dates",
     version=APIVersion.STABLE,
@@ -197,7 +197,7 @@ MUTUAL_FUND_DATES: Endpoint = Endpoint(
 # declarations to match an endpoint that never answers would be a guess
 # dressed up as a fix. Revisit this param and MutualFundHoldingsArgs.date
 # together once #152 settles where this endpoint should point.
-MUTUAL_FUND_HOLDINGS: Endpoint = Endpoint(
+MUTUAL_FUND_HOLDINGS: Endpoint[MutualFundHolding] = Endpoint(
     name="mutual_fund_holdings",
     path="mutual-fund-holdings",
     version=APIVersion.STABLE,
@@ -224,7 +224,7 @@ MUTUAL_FUND_HOLDINGS: Endpoint = Endpoint(
     response_model=MutualFundHolding,
 )
 
-MUTUAL_FUND_BY_NAME: Endpoint = Endpoint(
+MUTUAL_FUND_BY_NAME: Endpoint[MutualFundHolding] = Endpoint(
     name="mutual_fund_by_name",
     path="mutual-fund-holdings/name",
     version=APIVersion.STABLE,
@@ -245,7 +245,7 @@ MUTUAL_FUND_BY_NAME: Endpoint = Endpoint(
     response_model=MutualFundHolding,
 )
 
-MUTUAL_FUND_HOLDER: Endpoint = Endpoint(
+MUTUAL_FUND_HOLDER: Endpoint[MutualFundHolder] = Endpoint(
     name="mutual_fund_holder",
     path="etf/holder",
     version=APIVersion.STABLE,
@@ -266,7 +266,7 @@ MUTUAL_FUND_HOLDER: Endpoint = Endpoint(
     response_model=MutualFundHolder,
 )
 
-FUNDS_DISCLOSURE_HOLDERS_LATEST: Endpoint = Endpoint(
+FUNDS_DISCLOSURE_HOLDERS_LATEST: Endpoint[FundDisclosureHolderLatest] = Endpoint(
     name="funds_disclosure_holders_latest",
     path="funds/disclosure-holders-latest",
     version=APIVersion.STABLE,
@@ -283,7 +283,7 @@ FUNDS_DISCLOSURE_HOLDERS_LATEST: Endpoint = Endpoint(
     response_model=FundDisclosureHolderLatest,
 )
 
-FUNDS_DISCLOSURE: Endpoint = Endpoint(
+FUNDS_DISCLOSURE: Endpoint[FundDisclosureHolding] = Endpoint(
     name="funds_disclosure",
     path="funds/disclosure",
     version=APIVersion.STABLE,
@@ -319,7 +319,7 @@ FUNDS_DISCLOSURE: Endpoint = Endpoint(
     response_model=FundDisclosureHolding,
 )
 
-FUNDS_DISCLOSURE_HOLDERS_SEARCH: Endpoint = Endpoint(
+FUNDS_DISCLOSURE_HOLDERS_SEARCH: Endpoint[FundDisclosureSearchResult] = Endpoint(
     name="funds_disclosure_holders_search",
     path="funds/disclosure-holders-search",
     version=APIVersion.STABLE,

--- a/fmp_data/investment/mapping.py
+++ b/fmp_data/investment/mapping.py
@@ -1,5 +1,7 @@
 # fmp_data/investment/mapping.py
 
+from typing import Any
+
 from fmp_data.investment.endpoints import (
     ETF_COUNTRY_WEIGHTINGS,
     ETF_EXPOSURE,
@@ -29,6 +31,7 @@ from fmp_data.lc.models import (
     ResponseFieldInfo,
     SemanticCategory,
 )
+from fmp_data.models import Endpoint
 
 # Common parameter hints
 FUND_NAME_HINT = ParameterHint(
@@ -98,7 +101,7 @@ INVESTMENT_CALCULATIONS = {
 }
 
 # Endpoint mappings
-INVESTMENT_ENDPOINT_MAP = {
+INVESTMENT_ENDPOINT_MAP: dict[str, Endpoint[Any]] = {
     "get_etf_holdings": ETF_HOLDINGS,
     "get_etf_holding_dates": ETF_HOLDING_DATES,
     "get_etf_info": ETF_INFO,

--- a/fmp_data/market/async_client.py
+++ b/fmp_data/market/async_client.py
@@ -75,7 +75,10 @@ class AsyncMarketClient(AsyncEndpointGroup):
             params["limit"] = limit
         if exchange is not None:
             params["exchange"] = exchange
-        return await self.client.request_async(SEARCH_COMPANY, **params)
+        return self._unwrap_list(
+            await self.client.request_async(SEARCH_COMPANY, **params),
+            CompanySearchResult,
+        )
 
     async def search_symbol(
         self, query: str, limit: int | None = None, exchange: str | None = None
@@ -86,27 +89,42 @@ class AsyncMarketClient(AsyncEndpointGroup):
             params["limit"] = limit
         if exchange is not None:
             params["exchange"] = exchange
-        return await self.client.request_async(SEARCH_SYMBOL, **params)
+        return self._unwrap_list(
+            await self.client.request_async(SEARCH_SYMBOL, **params),
+            CompanySearchResult,
+        )
 
     async def search_exchange_variants(self, query: str) -> list[CompanySearchResult]:
         """Search for exchange trading variants of a company"""
-        return await self.client.request_async(SEARCH_EXCHANGE_VARIANTS, query=query)
+        return self._unwrap_list(
+            await self.client.request_async(SEARCH_EXCHANGE_VARIANTS, query=query),
+            CompanySearchResult,
+        )
 
     async def get_stock_list(self) -> list[CompanySymbol]:
         """Get list of all available stocks"""
-        return await self.client.request_async(STOCK_LIST)
+        return self._unwrap_list(
+            await self.client.request_async(STOCK_LIST), CompanySymbol
+        )
 
     async def get_financial_statement_symbol_list(self) -> list[CompanySymbol]:
         """Get list of symbols with financial statements available"""
-        return await self.client.request_async(FINANCIAL_STATEMENT_SYMBOL_LIST)
+        return self._unwrap_list(
+            await self.client.request_async(FINANCIAL_STATEMENT_SYMBOL_LIST),
+            CompanySymbol,
+        )
 
     async def get_etf_list(self) -> list[CompanySymbol]:
         """Get list of all available ETFs"""
-        return await self.client.request_async(ETF_LIST)
+        return self._unwrap_list(
+            await self.client.request_async(ETF_LIST), CompanySymbol
+        )
 
     async def get_actively_trading_list(self) -> list[CompanySymbol]:
         """Get list of actively trading stocks"""
-        return await self.client.request_async(ACTIVELY_TRADING_LIST)
+        return self._unwrap_list(
+            await self.client.request_async(ACTIVELY_TRADING_LIST), CompanySymbol
+        )
 
     @deprecated(
         "tradable-list is dead and FMP publishes no drop-in replacement: "
@@ -134,7 +152,9 @@ class AsyncMarketClient(AsyncEndpointGroup):
 
     async def get_available_indexes(self) -> list[AvailableIndex]:
         """Get list of all available indexes"""
-        return await self.client.request_async(AVAILABLE_INDEXES)
+        return self._unwrap_list(
+            await self.client.request_async(AVAILABLE_INDEXES), AvailableIndex
+        )
 
     async def search_by_cik(self, query: str) -> list[CIKResult]:
         """Search companies by CIK number.
@@ -150,21 +170,30 @@ class AsyncMarketClient(AsyncEndpointGroup):
         Returns:
             List of matching CIK records.
         """
-        return await self.client.request_async(CIK_SEARCH, query=query)
+        return self._unwrap_list(
+            await self.client.request_async(CIK_SEARCH, query=query), CIKResult
+        )
 
     async def get_cik_list(
         self, page: int = 0, limit: int = 1000
     ) -> list[CIKListEntry]:
         """Get complete list of all CIK numbers"""
-        return await self.client.request_async(CIK_LIST, page=page, limit=limit)
+        return self._unwrap_list(
+            await self.client.request_async(CIK_LIST, page=page, limit=limit),
+            CIKListEntry,
+        )
 
     async def search_by_cusip(self, query: str) -> list[CUSIPResult]:
         """Search companies by CUSIP"""
-        return await self.client.request_async(CUSIP_SEARCH, query=query)
+        return self._unwrap_list(
+            await self.client.request_async(CUSIP_SEARCH, query=query), CUSIPResult
+        )
 
     async def search_by_isin(self, query: str) -> list[ISINResult]:
         """Search companies by ISIN"""
-        return await self.client.request_async(ISIN_SEARCH, query=query)
+        return self._unwrap_list(
+            await self.client.request_async(ISIN_SEARCH, query=query), ISINResult
+        )
 
     async def get_company_screener(
         self,
@@ -217,7 +246,10 @@ class AsyncMarketClient(AsyncEndpointGroup):
             "include_all_share_classes": include_all_share_classes,
         }
         params = {key: value for key, value in params.items() if value is not None}
-        return await self.client.request_async(COMPANY_SCREENER, **params)
+        return self._unwrap_list(
+            await self.client.request_async(COMPANY_SCREENER, **params),
+            CompanySearchResult,
+        )
 
     async def get_market_hours(self, exchange: str = "NYSE") -> MarketHours:
         """Get market trading hours information for a specific exchange
@@ -229,39 +261,40 @@ class AsyncMarketClient(AsyncEndpointGroup):
             MarketHours: Exchange trading hours object
 
         Raises:
-            ValueError: If no market hours data returned from API
+            ValueError: If the API returns an empty list
         """
         result = await self.client.request_async(MARKET_HOURS, exchange=exchange)
-        if isinstance(result, list):
-            if not result:
-                raise ValueError("No market hours data returned from API")
-            return result[0]
-        return result
+        return self._unwrap_single(result, MarketHours)
 
     async def get_all_exchange_market_hours(self) -> list[MarketHours]:
         """Get market trading hours information for all exchanges"""
-        result = await self.client.request_async(ALL_EXCHANGE_MARKET_HOURS)
-        if isinstance(result, list):
-            return result
-        return [result]
+        return self._unwrap_list(
+            await self.client.request_async(ALL_EXCHANGE_MARKET_HOURS),
+            MarketHours,
+        )
 
     async def get_holidays_by_exchange(
         self, exchange: str = "NYSE"
     ) -> list[MarketHoliday]:
         """Get market holidays for a specific exchange"""
-        return await self.client.request_async(HOLIDAYS_BY_EXCHANGE, exchange=exchange)
+        return self._unwrap_list(
+            await self.client.request_async(HOLIDAYS_BY_EXCHANGE, exchange=exchange),
+            MarketHoliday,
+        )
 
     async def get_gainers(self) -> list[MarketMover]:
         """Get market gainers"""
-        return await self.client.request_async(GAINERS)
+        return self._unwrap_list(await self.client.request_async(GAINERS), MarketMover)
 
     async def get_losers(self) -> list[MarketMover]:
         """Get market losers"""
-        return await self.client.request_async(LOSERS)
+        return self._unwrap_list(await self.client.request_async(LOSERS), MarketMover)
 
     async def get_most_active(self) -> list[MarketMover]:
         """Get most active stocks"""
-        return await self.client.request_async(MOST_ACTIVE)
+        return self._unwrap_list(
+            await self.client.request_async(MOST_ACTIVE), MarketMover
+        )
 
     async def get_sector_performance(
         self,
@@ -277,7 +310,10 @@ class AsyncMarketClient(AsyncEndpointGroup):
             params["exchange"] = exchange
         snapshot_date = date or dt_date.today()
         params["date"] = snapshot_date.strftime("%Y-%m-%d")
-        return await self.client.request_async(SECTOR_PERFORMANCE, **params)
+        return self._unwrap_list(
+            await self.client.request_async(SECTOR_PERFORMANCE, **params),
+            SectorPerformance,
+        )
 
     async def get_industry_performance_snapshot(
         self,
@@ -293,7 +329,10 @@ class AsyncMarketClient(AsyncEndpointGroup):
             params["exchange"] = exchange
         snapshot_date = date or dt_date.today()
         params["date"] = snapshot_date.strftime("%Y-%m-%d")
-        return await self.client.request_async(INDUSTRY_PERFORMANCE_SNAPSHOT, **params)
+        return self._unwrap_list(
+            await self.client.request_async(INDUSTRY_PERFORMANCE_SNAPSHOT, **params),
+            IndustryPerformance,
+        )
 
     async def get_historical_sector_performance(
         self,
@@ -310,7 +349,10 @@ class AsyncMarketClient(AsyncEndpointGroup):
             params["to"] = to_date.strftime("%Y-%m-%d")
         if exchange:
             params["exchange"] = exchange
-        return await self.client.request_async(HISTORICAL_SECTOR_PERFORMANCE, **params)
+        return self._unwrap_list(
+            await self.client.request_async(HISTORICAL_SECTOR_PERFORMANCE, **params),
+            SectorPerformance,
+        )
 
     async def get_historical_industry_performance(
         self,
@@ -327,8 +369,9 @@ class AsyncMarketClient(AsyncEndpointGroup):
             params["to"] = to_date.strftime("%Y-%m-%d")
         if exchange:
             params["exchange"] = exchange
-        return await self.client.request_async(
-            HISTORICAL_INDUSTRY_PERFORMANCE, **params
+        return self._unwrap_list(
+            await self.client.request_async(HISTORICAL_INDUSTRY_PERFORMANCE, **params),
+            IndustryPerformance,
         )
 
     async def get_sector_pe_snapshot(
@@ -345,7 +388,10 @@ class AsyncMarketClient(AsyncEndpointGroup):
             params["exchange"] = exchange
         snapshot_date = date or dt_date.today()
         params["date"] = snapshot_date.strftime("%Y-%m-%d")
-        return await self.client.request_async(SECTOR_PE_SNAPSHOT, **params)
+        return self._unwrap_list(
+            await self.client.request_async(SECTOR_PE_SNAPSHOT, **params),
+            SectorPESnapshot,
+        )
 
     async def get_industry_pe_snapshot(
         self,
@@ -361,7 +407,10 @@ class AsyncMarketClient(AsyncEndpointGroup):
             params["exchange"] = exchange
         snapshot_date = date or dt_date.today()
         params["date"] = snapshot_date.strftime("%Y-%m-%d")
-        return await self.client.request_async(INDUSTRY_PE_SNAPSHOT, **params)
+        return self._unwrap_list(
+            await self.client.request_async(INDUSTRY_PE_SNAPSHOT, **params),
+            IndustryPESnapshot,
+        )
 
     async def get_historical_sector_pe(
         self,
@@ -378,7 +427,10 @@ class AsyncMarketClient(AsyncEndpointGroup):
             params["to"] = to_date.strftime("%Y-%m-%d")
         if exchange:
             params["exchange"] = exchange
-        return await self.client.request_async(HISTORICAL_SECTOR_PE, **params)
+        return self._unwrap_list(
+            await self.client.request_async(HISTORICAL_SECTOR_PE, **params),
+            SectorPESnapshot,
+        )
 
     async def get_historical_industry_pe(
         self,
@@ -395,7 +447,10 @@ class AsyncMarketClient(AsyncEndpointGroup):
             params["to"] = to_date.strftime("%Y-%m-%d")
         if exchange:
             params["exchange"] = exchange
-        return await self.client.request_async(HISTORICAL_INDUSTRY_PE, **params)
+        return self._unwrap_list(
+            await self.client.request_async(HISTORICAL_INDUSTRY_PE, **params),
+            IndustryPESnapshot,
+        )
 
     @deprecated(
         "pre-post-market is dead, and the market-wide shape no longer exists. "
@@ -421,23 +476,33 @@ class AsyncMarketClient(AsyncEndpointGroup):
 
     async def get_all_shares_float(self) -> list[ShareFloat]:
         """Get share float data for all companies"""
-        return await self.client.request_async(ALL_SHARES_FLOAT)
+        return self._unwrap_list(
+            await self.client.request_async(ALL_SHARES_FLOAT), ShareFloat
+        )
 
     async def get_available_exchanges(self) -> list[ExchangeSymbol]:
         """Get a complete list of supported stock exchanges"""
-        return await self.client.request_async(AVAILABLE_EXCHANGES)
+        return self._unwrap_list(
+            await self.client.request_async(AVAILABLE_EXCHANGES), ExchangeSymbol
+        )
 
     async def get_available_sectors(self) -> list[str]:
         """Get a complete list of industry sectors"""
-        return await self.client.request_async(AVAILABLE_SECTORS)
+        return self._unwrap_list(
+            await self.client.request_async(AVAILABLE_SECTORS), str
+        )
 
     async def get_available_industries(self) -> list[str]:
         """Get a comprehensive list of industries where stock symbols are available"""
-        return await self.client.request_async(AVAILABLE_INDUSTRIES)
+        return self._unwrap_list(
+            await self.client.request_async(AVAILABLE_INDUSTRIES), str
+        )
 
     async def get_available_countries(self) -> list[str]:
         """Get a comprehensive list of countries where stock symbols are available"""
-        return await self.client.request_async(AVAILABLE_COUNTRIES)
+        return self._unwrap_list(
+            await self.client.request_async(AVAILABLE_COUNTRIES), str
+        )
 
     async def get_ipo_disclosure(
         self,
@@ -460,7 +525,9 @@ class AsyncMarketClient(AsyncEndpointGroup):
             params["from"] = from_date.strftime("%Y-%m-%d")
         if to_date:
             params["to"] = to_date.strftime("%Y-%m-%d")
-        return await self.client.request_async(IPO_DISCLOSURE, **params)
+        return self._unwrap_list(
+            await self.client.request_async(IPO_DISCLOSURE, **params), IPODisclosure
+        )
 
     async def get_ipo_prospectus(
         self,
@@ -483,4 +550,6 @@ class AsyncMarketClient(AsyncEndpointGroup):
             params["from"] = from_date.strftime("%Y-%m-%d")
         if to_date:
             params["to"] = to_date.strftime("%Y-%m-%d")
-        return await self.client.request_async(IPO_PROSPECTUS, **params)
+        return self._unwrap_list(
+            await self.client.request_async(IPO_PROSPECTUS, **params), IPOProspectus
+        )

--- a/fmp_data/market/client.py
+++ b/fmp_data/market/client.py
@@ -73,7 +73,9 @@ class MarketClient(EndpointGroup):
             params["limit"] = str(limit)
         if exchange is not None:
             params["exchange"] = exchange
-        return self.client.request(SEARCH_COMPANY, **params)
+        return self._unwrap_list(
+            self.client.request(SEARCH_COMPANY, **params), CompanySearchResult
+        )
 
     def search_symbol(
         self, query: str, limit: int | None = None, exchange: str | None = None
@@ -84,27 +86,36 @@ class MarketClient(EndpointGroup):
             params["limit"] = str(limit)
         if exchange is not None:
             params["exchange"] = exchange
-        return self.client.request(SEARCH_SYMBOL, **params)
+        return self._unwrap_list(
+            self.client.request(SEARCH_SYMBOL, **params), CompanySearchResult
+        )
 
     def search_exchange_variants(self, query: str) -> list[CompanySearchResult]:
         """Search for exchange trading variants of a company"""
-        return self.client.request(SEARCH_EXCHANGE_VARIANTS, query=query)
+        return self._unwrap_list(
+            self.client.request(SEARCH_EXCHANGE_VARIANTS, query=query),
+            CompanySearchResult,
+        )
 
     def get_stock_list(self) -> list[CompanySymbol]:
         """Get list of all available stocks"""
-        return self.client.request(STOCK_LIST)
+        return self._unwrap_list(self.client.request(STOCK_LIST), CompanySymbol)
 
     def get_financial_statement_symbol_list(self) -> list[CompanySymbol]:
         """Get list of symbols with financial statements available"""
-        return self.client.request(FINANCIAL_STATEMENT_SYMBOL_LIST)
+        return self._unwrap_list(
+            self.client.request(FINANCIAL_STATEMENT_SYMBOL_LIST), CompanySymbol
+        )
 
     def get_etf_list(self) -> list[CompanySymbol]:
         """Get list of all available ETFs"""
-        return self.client.request(ETF_LIST)
+        return self._unwrap_list(self.client.request(ETF_LIST), CompanySymbol)
 
     def get_actively_trading_list(self) -> list[CompanySymbol]:
         """Get list of actively trading stocks"""
-        return self.client.request(ACTIVELY_TRADING_LIST)
+        return self._unwrap_list(
+            self.client.request(ACTIVELY_TRADING_LIST), CompanySymbol
+        )
 
     @deprecated(
         "tradable-list is dead and FMP publishes no drop-in replacement: "
@@ -132,7 +143,7 @@ class MarketClient(EndpointGroup):
 
     def get_available_indexes(self) -> list[AvailableIndex]:
         """Get list of all available indexes"""
-        return self.client.request(AVAILABLE_INDEXES)
+        return self._unwrap_list(self.client.request(AVAILABLE_INDEXES), AvailableIndex)
 
     def search_by_cik(self, query: str) -> list[CIKResult]:
         """Search companies by CIK number.
@@ -148,19 +159,27 @@ class MarketClient(EndpointGroup):
         Returns:
             List of matching CIK records.
         """
-        return self.client.request(CIK_SEARCH, query=query)
+        return self._unwrap_list(
+            self.client.request(CIK_SEARCH, query=query), CIKResult
+        )
 
     def get_cik_list(self, page: int = 0, limit: int = 1000) -> list[CIKListEntry]:
         """Get complete list of all CIK numbers"""
-        return self.client.request(CIK_LIST, page=page, limit=limit)
+        return self._unwrap_list(
+            self.client.request(CIK_LIST, page=page, limit=limit), CIKListEntry
+        )
 
     def search_by_cusip(self, query: str) -> list[CUSIPResult]:
         """Search companies by CUSIP"""
-        return self.client.request(CUSIP_SEARCH, query=query)
+        return self._unwrap_list(
+            self.client.request(CUSIP_SEARCH, query=query), CUSIPResult
+        )
 
     def search_by_isin(self, query: str) -> list[ISINResult]:
         """Search companies by ISIN"""
-        return self.client.request(ISIN_SEARCH, query=query)
+        return self._unwrap_list(
+            self.client.request(ISIN_SEARCH, query=query), ISINResult
+        )
 
     def get_company_screener(
         self,
@@ -213,7 +232,9 @@ class MarketClient(EndpointGroup):
             "include_all_share_classes": include_all_share_classes,
         }
         params = {key: value for key, value in params.items() if value is not None}
-        return self.client.request(COMPANY_SCREENER, **params)
+        return self._unwrap_list(
+            self.client.request(COMPANY_SCREENER, **params), CompanySearchResult
+        )
 
     def get_market_hours(self, exchange: str = "NYSE") -> MarketHours:
         """Get market trading hours information for a specific exchange
@@ -225,37 +246,35 @@ class MarketClient(EndpointGroup):
             MarketHours: Exchange trading hours object
 
         Raises:
-            ValueError: If no market hours data returned from API
+            ValueError: If the API returns an empty list
         """
         result = self.client.request(MARKET_HOURS, exchange=exchange)
-        if isinstance(result, list):
-            if not result:
-                raise ValueError("No market hours data returned from API")
-            return result[0]
-        return result
+        return self._unwrap_single(result, MarketHours)
 
     def get_all_exchange_market_hours(self) -> list[MarketHours]:
         """Get market trading hours information for all exchanges"""
-        result = self.client.request(ALL_EXCHANGE_MARKET_HOURS)
-        if isinstance(result, list):
-            return result
-        return [result]
+        return self._unwrap_list(
+            self.client.request(ALL_EXCHANGE_MARKET_HOURS),
+            MarketHours,
+        )
 
     def get_holidays_by_exchange(self, exchange: str = "NYSE") -> list[MarketHoliday]:
         """Get market holidays for a specific exchange"""
-        return self.client.request(HOLIDAYS_BY_EXCHANGE, exchange=exchange)
+        return self._unwrap_list(
+            self.client.request(HOLIDAYS_BY_EXCHANGE, exchange=exchange), MarketHoliday
+        )
 
     def get_gainers(self) -> list[MarketMover]:
         """Get market gainers"""
-        return self.client.request(GAINERS)
+        return self._unwrap_list(self.client.request(GAINERS), MarketMover)
 
     def get_losers(self) -> list[MarketMover]:
         """Get market losers"""
-        return self.client.request(LOSERS)
+        return self._unwrap_list(self.client.request(LOSERS), MarketMover)
 
     def get_most_active(self) -> list[MarketMover]:
         """Get most active stocks"""
-        return self.client.request(MOST_ACTIVE)
+        return self._unwrap_list(self.client.request(MOST_ACTIVE), MarketMover)
 
     def get_sector_performance(
         self,
@@ -271,7 +290,9 @@ class MarketClient(EndpointGroup):
             params["exchange"] = exchange
         snapshot_date = date or dt_date.today()
         params["date"] = snapshot_date.strftime("%Y-%m-%d")
-        return self.client.request(SECTOR_PERFORMANCE, **params)
+        return self._unwrap_list(
+            self.client.request(SECTOR_PERFORMANCE, **params), SectorPerformance
+        )
 
     def get_industry_performance_snapshot(
         self,
@@ -287,7 +308,10 @@ class MarketClient(EndpointGroup):
             params["exchange"] = exchange
         snapshot_date = date or dt_date.today()
         params["date"] = snapshot_date.strftime("%Y-%m-%d")
-        return self.client.request(INDUSTRY_PERFORMANCE_SNAPSHOT, **params)
+        return self._unwrap_list(
+            self.client.request(INDUSTRY_PERFORMANCE_SNAPSHOT, **params),
+            IndustryPerformance,
+        )
 
     def get_historical_sector_performance(
         self,
@@ -304,7 +328,10 @@ class MarketClient(EndpointGroup):
             params["to"] = to_date.strftime("%Y-%m-%d")
         if exchange:
             params["exchange"] = exchange
-        return self.client.request(HISTORICAL_SECTOR_PERFORMANCE, **params)
+        return self._unwrap_list(
+            self.client.request(HISTORICAL_SECTOR_PERFORMANCE, **params),
+            SectorPerformance,
+        )
 
     def get_historical_industry_performance(
         self,
@@ -321,7 +348,10 @@ class MarketClient(EndpointGroup):
             params["to"] = to_date.strftime("%Y-%m-%d")
         if exchange:
             params["exchange"] = exchange
-        return self.client.request(HISTORICAL_INDUSTRY_PERFORMANCE, **params)
+        return self._unwrap_list(
+            self.client.request(HISTORICAL_INDUSTRY_PERFORMANCE, **params),
+            IndustryPerformance,
+        )
 
     def get_sector_pe_snapshot(
         self,
@@ -337,7 +367,9 @@ class MarketClient(EndpointGroup):
             params["exchange"] = exchange
         snapshot_date = date or dt_date.today()
         params["date"] = snapshot_date.strftime("%Y-%m-%d")
-        return self.client.request(SECTOR_PE_SNAPSHOT, **params)
+        return self._unwrap_list(
+            self.client.request(SECTOR_PE_SNAPSHOT, **params), SectorPESnapshot
+        )
 
     def get_industry_pe_snapshot(
         self,
@@ -353,7 +385,9 @@ class MarketClient(EndpointGroup):
             params["exchange"] = exchange
         snapshot_date = date or dt_date.today()
         params["date"] = snapshot_date.strftime("%Y-%m-%d")
-        return self.client.request(INDUSTRY_PE_SNAPSHOT, **params)
+        return self._unwrap_list(
+            self.client.request(INDUSTRY_PE_SNAPSHOT, **params), IndustryPESnapshot
+        )
 
     def get_historical_sector_pe(
         self,
@@ -370,7 +404,9 @@ class MarketClient(EndpointGroup):
             params["to"] = to_date.strftime("%Y-%m-%d")
         if exchange:
             params["exchange"] = exchange
-        return self.client.request(HISTORICAL_SECTOR_PE, **params)
+        return self._unwrap_list(
+            self.client.request(HISTORICAL_SECTOR_PE, **params), SectorPESnapshot
+        )
 
     def get_historical_industry_pe(
         self,
@@ -387,7 +423,9 @@ class MarketClient(EndpointGroup):
             params["to"] = to_date.strftime("%Y-%m-%d")
         if exchange:
             params["exchange"] = exchange
-        return self.client.request(HISTORICAL_INDUSTRY_PE, **params)
+        return self._unwrap_list(
+            self.client.request(HISTORICAL_INDUSTRY_PE, **params), IndustryPESnapshot
+        )
 
     @deprecated(
         "pre-post-market is dead, and the market-wide shape no longer exists. "
@@ -413,23 +451,25 @@ class MarketClient(EndpointGroup):
 
     def get_all_shares_float(self) -> list[ShareFloat]:
         """Get share float data for all companies"""
-        return self.client.request(ALL_SHARES_FLOAT)
+        return self._unwrap_list(self.client.request(ALL_SHARES_FLOAT), ShareFloat)
 
     def get_available_exchanges(self) -> list[ExchangeSymbol]:
         """Get a complete list of supported stock exchanges"""
-        return self.client.request(AVAILABLE_EXCHANGES)
+        return self._unwrap_list(
+            self.client.request(AVAILABLE_EXCHANGES), ExchangeSymbol
+        )
 
     def get_available_sectors(self) -> list[str]:
         """Get a complete list of industry sectors"""
-        return self.client.request(AVAILABLE_SECTORS)
+        return self._unwrap_list(self.client.request(AVAILABLE_SECTORS), str)
 
     def get_available_industries(self) -> list[str]:
         """Get a comprehensive list of industries where stock symbols are available"""
-        return self.client.request(AVAILABLE_INDUSTRIES)
+        return self._unwrap_list(self.client.request(AVAILABLE_INDUSTRIES), str)
 
     def get_available_countries(self) -> list[str]:
         """Get a comprehensive list of countries where stock symbols are available"""
-        return self.client.request(AVAILABLE_COUNTRIES)
+        return self._unwrap_list(self.client.request(AVAILABLE_COUNTRIES), str)
 
     def get_ipo_disclosure(
         self,
@@ -452,7 +492,9 @@ class MarketClient(EndpointGroup):
             params["from"] = from_date.strftime("%Y-%m-%d")
         if to_date:
             params["to"] = to_date.strftime("%Y-%m-%d")
-        return self.client.request(IPO_DISCLOSURE, **params)
+        return self._unwrap_list(
+            self.client.request(IPO_DISCLOSURE, **params), IPODisclosure
+        )
 
     def get_ipo_prospectus(
         self,
@@ -475,4 +517,6 @@ class MarketClient(EndpointGroup):
             params["from"] = from_date.strftime("%Y-%m-%d")
         if to_date:
             params["to"] = to_date.strftime("%Y-%m-%d")
-        return self.client.request(IPO_PROSPECTUS, **params)
+        return self._unwrap_list(
+            self.client.request(IPO_PROSPECTUS, **params), IPOProspectus
+        )

--- a/fmp_data/market/endpoints.py
+++ b/fmp_data/market/endpoints.py
@@ -30,7 +30,7 @@ from fmp_data.models import (
     URLType,
 )
 
-STOCK_LIST: Endpoint = Endpoint(
+STOCK_LIST: Endpoint[CompanySymbol] = Endpoint(
     name="stock_list",
     path="stock-list",
     version=APIVersion.STABLE,
@@ -53,7 +53,7 @@ STOCK_LIST: Endpoint = Endpoint(
     ],
 )
 
-ETF_LIST: Endpoint = Endpoint(
+ETF_LIST: Endpoint[CompanySymbol] = Endpoint(
     name="etf_list",
     path="etf-list",
     version=APIVersion.STABLE,
@@ -74,7 +74,7 @@ ETF_LIST: Endpoint = Endpoint(
         "Show all exchange traded funds",
     ],
 )
-AVAILABLE_INDEXES: Endpoint = Endpoint(
+AVAILABLE_INDEXES: Endpoint[AvailableIndex] = Endpoint(
     name="available_indexes",
     path="index-list",
     version=APIVersion.STABLE,
@@ -97,7 +97,7 @@ AVAILABLE_INDEXES: Endpoint = Endpoint(
         "Show all benchmark indexes",
     ],
 )
-SEARCH_COMPANY: Endpoint = Endpoint(
+SEARCH_COMPANY: Endpoint[CompanySearchResult] = Endpoint(
     # ``name`` is snake_case like every other endpoint in the catalogue;
     # ``path`` keeps the hyphen because that is the real API path (#166).
     # Renaming ``name`` moved this endpoint's cache-key prefix and its
@@ -144,7 +144,7 @@ SEARCH_COMPANY: Endpoint = Endpoint(
         "Find companies matching 'renewable energy'",
     ],
 )
-CIK_SEARCH: Endpoint = Endpoint(
+CIK_SEARCH: Endpoint[CIKResult] = Endpoint(
     name="cik_search",
     path="search-cik",
     version=APIVersion.STABLE,
@@ -187,7 +187,7 @@ CIK_SEARCH: Endpoint = Endpoint(
     ],
 )
 
-CUSIP_SEARCH: Endpoint = Endpoint(
+CUSIP_SEARCH: Endpoint[CUSIPResult] = Endpoint(
     name="cusip_search",
     path="search-cusip",
     version=APIVersion.STABLE,
@@ -218,7 +218,7 @@ CUSIP_SEARCH: Endpoint = Endpoint(
     ],
 )
 
-ISIN_SEARCH: Endpoint = Endpoint(
+ISIN_SEARCH: Endpoint[ISINResult] = Endpoint(
     name="isin_search",
     path="search-isin",
     version=APIVersion.STABLE,
@@ -276,7 +276,7 @@ ALL_EXCHANGE_MARKET_HOURS: Endpoint[MarketHours] = Endpoint(
     response_model=MarketHours,
 )
 
-HOLIDAYS_BY_EXCHANGE: Endpoint = Endpoint(
+HOLIDAYS_BY_EXCHANGE: Endpoint[MarketHoliday] = Endpoint(
     name="holidays_by_exchange",
     path="holidays-by-exchange",
     version=APIVersion.STABLE,
@@ -294,7 +294,7 @@ HOLIDAYS_BY_EXCHANGE: Endpoint = Endpoint(
     response_model=MarketHoliday,
 )
 
-GAINERS: Endpoint = Endpoint(
+GAINERS: Endpoint[MarketMover] = Endpoint(
     name="gainers",
     path="biggest-gainers",
     version=APIVersion.STABLE,
@@ -304,7 +304,7 @@ GAINERS: Endpoint = Endpoint(
     response_model=MarketMover,
 )
 
-LOSERS: Endpoint = Endpoint(
+LOSERS: Endpoint[MarketMover] = Endpoint(
     name="losers",
     path="biggest-losers",
     version=APIVersion.STABLE,
@@ -314,7 +314,7 @@ LOSERS: Endpoint = Endpoint(
     response_model=MarketMover,
 )
 
-MOST_ACTIVE: Endpoint = Endpoint(
+MOST_ACTIVE: Endpoint[MarketMover] = Endpoint(
     name="most_active",
     path="most-actives",
     version=APIVersion.STABLE,
@@ -324,7 +324,7 @@ MOST_ACTIVE: Endpoint = Endpoint(
     response_model=MarketMover,
 )
 
-SECTOR_PERFORMANCE: Endpoint = Endpoint(
+SECTOR_PERFORMANCE: Endpoint[SectorPerformance] = Endpoint(
     name="sector_performance",
     path="sector-performance-snapshot",
     version=APIVersion.STABLE,
@@ -354,7 +354,7 @@ SECTOR_PERFORMANCE: Endpoint = Endpoint(
     response_model=SectorPerformance,
 )
 
-INDUSTRY_PERFORMANCE_SNAPSHOT: Endpoint = Endpoint(
+INDUSTRY_PERFORMANCE_SNAPSHOT: Endpoint[IndustryPerformance] = Endpoint(
     name="industry_performance_snapshot",
     path="industry-performance-snapshot",
     version=APIVersion.STABLE,
@@ -384,7 +384,7 @@ INDUSTRY_PERFORMANCE_SNAPSHOT: Endpoint = Endpoint(
     response_model=IndustryPerformance,
 )
 
-HISTORICAL_SECTOR_PERFORMANCE: Endpoint = Endpoint(
+HISTORICAL_SECTOR_PERFORMANCE: Endpoint[SectorPerformance] = Endpoint(
     name="historical_sector_performance",
     path="historical-sector-performance",
     version=APIVersion.STABLE,
@@ -420,7 +420,7 @@ HISTORICAL_SECTOR_PERFORMANCE: Endpoint = Endpoint(
     response_model=SectorPerformance,
 )
 
-HISTORICAL_INDUSTRY_PERFORMANCE: Endpoint = Endpoint(
+HISTORICAL_INDUSTRY_PERFORMANCE: Endpoint[IndustryPerformance] = Endpoint(
     name="historical_industry_performance",
     path="historical-industry-performance",
     version=APIVersion.STABLE,
@@ -456,7 +456,7 @@ HISTORICAL_INDUSTRY_PERFORMANCE: Endpoint = Endpoint(
     response_model=IndustryPerformance,
 )
 
-SECTOR_PE_SNAPSHOT: Endpoint = Endpoint(
+SECTOR_PE_SNAPSHOT: Endpoint[SectorPESnapshot] = Endpoint(
     name="sector_pe_snapshot",
     path="sector-pe-snapshot",
     version=APIVersion.STABLE,
@@ -486,7 +486,7 @@ SECTOR_PE_SNAPSHOT: Endpoint = Endpoint(
     response_model=SectorPESnapshot,
 )
 
-INDUSTRY_PE_SNAPSHOT: Endpoint = Endpoint(
+INDUSTRY_PE_SNAPSHOT: Endpoint[IndustryPESnapshot] = Endpoint(
     name="industry_pe_snapshot",
     path="industry-pe-snapshot",
     version=APIVersion.STABLE,
@@ -516,7 +516,7 @@ INDUSTRY_PE_SNAPSHOT: Endpoint = Endpoint(
     response_model=IndustryPESnapshot,
 )
 
-HISTORICAL_SECTOR_PE: Endpoint = Endpoint(
+HISTORICAL_SECTOR_PE: Endpoint[SectorPESnapshot] = Endpoint(
     name="historical_sector_pe",
     path="historical-sector-pe",
     version=APIVersion.STABLE,
@@ -552,7 +552,7 @@ HISTORICAL_SECTOR_PE: Endpoint = Endpoint(
     response_model=SectorPESnapshot,
 )
 
-HISTORICAL_INDUSTRY_PE: Endpoint = Endpoint(
+HISTORICAL_INDUSTRY_PE: Endpoint[IndustryPESnapshot] = Endpoint(
     name="historical_industry_pe",
     path="historical-industry-pe",
     version=APIVersion.STABLE,
@@ -588,7 +588,7 @@ HISTORICAL_INDUSTRY_PE: Endpoint = Endpoint(
     response_model=IndustryPESnapshot,
 )
 
-PRE_POST_MARKET: Endpoint = Endpoint(
+PRE_POST_MARKET: Endpoint[PrePostMarketQuote] = Endpoint(
     name="pre_post_market",
     path="pre-post-market",
     version=APIVersion.STABLE,
@@ -603,7 +603,7 @@ PRE_POST_MARKET: Endpoint = Endpoint(
     response_model=PrePostMarketQuote,
 )
 
-ALL_SHARES_FLOAT: Endpoint = Endpoint(
+ALL_SHARES_FLOAT: Endpoint[ShareFloat] = Endpoint(
     name="all_shares_float",
     path="shares-float-all",
     version=APIVersion.STABLE,
@@ -624,7 +624,7 @@ ALL_SHARES_FLOAT: Endpoint = Endpoint(
     ],
 )
 
-FINANCIAL_STATEMENT_SYMBOL_LIST: Endpoint = Endpoint(
+FINANCIAL_STATEMENT_SYMBOL_LIST: Endpoint[CompanySymbol] = Endpoint(
     name="financial_statement_symbol_list",
     path="financial-statement-symbol-list",
     version=APIVersion.STABLE,
@@ -634,7 +634,7 @@ FINANCIAL_STATEMENT_SYMBOL_LIST: Endpoint = Endpoint(
     response_model=CompanySymbol,
 )
 
-CIK_LIST: Endpoint = Endpoint(
+CIK_LIST: Endpoint[CIKListEntry] = Endpoint(
     name="cik_list",
     path="cik-list",
     version=APIVersion.STABLE,
@@ -657,7 +657,7 @@ CIK_LIST: Endpoint = Endpoint(
     response_model=CIKListEntry,
 )
 
-ACTIVELY_TRADING_LIST: Endpoint = Endpoint(
+ACTIVELY_TRADING_LIST: Endpoint[CompanySymbol] = Endpoint(
     name="actively_trading_list",
     path="actively-trading-list",
     version=APIVersion.STABLE,
@@ -667,7 +667,7 @@ ACTIVELY_TRADING_LIST: Endpoint = Endpoint(
     response_model=CompanySymbol,
 )
 
-TRADABLE_SEARCH: Endpoint = Endpoint(
+TRADABLE_SEARCH: Endpoint[CompanySymbol] = Endpoint(
     name="tradable_search",
     path="tradable-list",
     version=APIVersion.STABLE,
@@ -696,7 +696,7 @@ TRADABLE_SEARCH: Endpoint = Endpoint(
     response_model=CompanySymbol,
 )
 
-SEARCH_SYMBOL: Endpoint = Endpoint(
+SEARCH_SYMBOL: Endpoint[CompanySearchResult] = Endpoint(
     name="search_symbol",
     path="search-symbol",
     version=APIVersion.STABLE,
@@ -726,7 +726,7 @@ SEARCH_SYMBOL: Endpoint = Endpoint(
     response_model=CompanySearchResult,
 )
 
-COMPANY_SCREENER: Endpoint = Endpoint(
+COMPANY_SCREENER: Endpoint[CompanySearchResult] = Endpoint(
     name="company_screener",
     path="company-screener",
     version=APIVersion.STABLE,
@@ -874,7 +874,7 @@ COMPANY_SCREENER: Endpoint = Endpoint(
     response_model=CompanySearchResult,
 )
 
-SEARCH_EXCHANGE_VARIANTS: Endpoint = Endpoint(
+SEARCH_EXCHANGE_VARIANTS: Endpoint[CompanySearchResult] = Endpoint(
     name="search_exchange_variants",
     path="search-exchange-variants",
     version=APIVersion.STABLE,
@@ -891,7 +891,7 @@ SEARCH_EXCHANGE_VARIANTS: Endpoint = Endpoint(
     response_model=CompanySearchResult,
 )
 
-AVAILABLE_EXCHANGES: Endpoint = Endpoint(
+AVAILABLE_EXCHANGES: Endpoint[ExchangeSymbol] = Endpoint(
     name="available_exchanges",
     path="available-exchanges",
     version=APIVersion.STABLE,
@@ -901,7 +901,7 @@ AVAILABLE_EXCHANGES: Endpoint = Endpoint(
     response_model=ExchangeSymbol,
 )
 
-AVAILABLE_SECTORS: Endpoint = Endpoint(
+AVAILABLE_SECTORS: Endpoint[str] = Endpoint(
     name="available_sectors",
     path="available-sectors",
     version=APIVersion.STABLE,
@@ -911,7 +911,7 @@ AVAILABLE_SECTORS: Endpoint = Endpoint(
     response_model=str,  # Returns list of strings
 )
 
-AVAILABLE_INDUSTRIES: Endpoint = Endpoint(
+AVAILABLE_INDUSTRIES: Endpoint[str] = Endpoint(
     name="available_industries",
     path="available-industries",
     version=APIVersion.STABLE,
@@ -921,7 +921,7 @@ AVAILABLE_INDUSTRIES: Endpoint = Endpoint(
     response_model=str,  # Returns list of strings
 )
 
-AVAILABLE_COUNTRIES: Endpoint = Endpoint(
+AVAILABLE_COUNTRIES: Endpoint[str] = Endpoint(
     name="available_countries",
     path="available-countries",
     version=APIVersion.STABLE,
@@ -931,7 +931,7 @@ AVAILABLE_COUNTRIES: Endpoint = Endpoint(
     response_model=str,  # Returns list of strings
 )
 
-IPO_DISCLOSURE: Endpoint = Endpoint(
+IPO_DISCLOSURE: Endpoint[IPODisclosure] = Endpoint(
     name="ipo_disclosure",
     path="ipos-disclosure",
     version=APIVersion.STABLE,
@@ -972,7 +972,7 @@ IPO_DISCLOSURE: Endpoint = Endpoint(
     ],
 )
 
-IPO_PROSPECTUS: Endpoint = Endpoint(
+IPO_PROSPECTUS: Endpoint[IPOProspectus] = Endpoint(
     name="ipo_prospectus",
     path="ipos-prospectus",
     version=APIVersion.STABLE,

--- a/fmp_data/market/mapping.py
+++ b/fmp_data/market/mapping.py
@@ -1,5 +1,7 @@
 # fmp_data/market/mapping.py
 
+from typing import Any
+
 from fmp_data.lc.hints import (
     DATE_HINTS,
     EXCHANGE_HINT,
@@ -34,10 +36,11 @@ from fmp_data.market.endpoints import (
     SECTOR_PERFORMANCE,
     STOCK_LIST,
 )
+from fmp_data.models import Endpoint
 
 from .hints import COMPANY_SEARCH_HINT, IDENTIFIER_HINT
 
-MARKET_ENDPOINT_MAP = {
+MARKET_ENDPOINT_MAP: dict[str, Endpoint[Any]] = {
     "search_company": SEARCH_COMPANY,
     "get_all_shares_float": ALL_SHARES_FLOAT,
     "get_market_hours": MARKET_HOURS,

--- a/fmp_data/technical/async_client.py
+++ b/fmp_data/technical/async_client.py
@@ -2,7 +2,7 @@
 """Async client for technical analysis endpoints."""
 
 from datetime import date
-from typing import Any, TypeVar
+from typing import TypeVar
 
 from pydantic import BaseModel
 
@@ -57,7 +57,7 @@ class AsyncTechnicalClient(AsyncEndpointGroup):
         interval: str | None,
         start_date: date | None,
         end_date: date | None,
-    ) -> list[Any]:
+    ) -> list[T]:
         """Generic helper to fetch technical indicator data
 
         Args:

--- a/fmp_data/technical/async_client.py
+++ b/fmp_data/technical/async_client.py
@@ -81,7 +81,10 @@ class AsyncTechnicalClient(AsyncEndpointGroup):
             params["from"] = start_date.strftime("%Y-%m-%d")
         if end_date:
             params["to"] = end_date.strftime("%Y-%m-%d")
-        return await self.client.request_async(endpoint, **params)
+        return self._unwrap_list(
+            await self.client.request_async(endpoint, **params),
+            endpoint.response_model,
+        )
 
     async def get_sma(
         self,

--- a/fmp_data/technical/client.py
+++ b/fmp_data/technical/client.py
@@ -79,7 +79,10 @@ class TechnicalClient(EndpointGroup):
             params["from"] = start_date.strftime("%Y-%m-%d")
         if end_date:
             params["to"] = end_date.strftime("%Y-%m-%d")
-        return self.client.request(endpoint, **params)
+        return self._unwrap_list(
+            self.client.request(endpoint, **params),
+            endpoint.response_model,
+        )
 
     def get_sma(
         self,

--- a/fmp_data/technical/client.py
+++ b/fmp_data/technical/client.py
@@ -1,6 +1,6 @@
 # fmp_data/technical/client.py
 from datetime import date
-from typing import Any, TypeVar
+from typing import TypeVar
 
 from pydantic import BaseModel
 
@@ -55,7 +55,7 @@ class TechnicalClient(EndpointGroup):
         interval: str | None,
         start_date: date | None,
         end_date: date | None,
-    ) -> list[Any]:
+    ) -> list[T]:
         """Generic helper to fetch technical indicator data
 
         Args:

--- a/fmp_data/technical/endpoints.py
+++ b/fmp_data/technical/endpoints.py
@@ -25,7 +25,7 @@ from fmp_data.technical.models import (
 VALID_TIMEFRAMES = ["1min", "5min", "15min", "30min", "1hour", "4hour", "1day"]
 
 # Simple Moving Average
-SMA: Endpoint = Endpoint(
+SMA: Endpoint[SMAIndicator] = Endpoint(
     name="sma",
     path="technical-indicators/sma",
     version=APIVersion.STABLE,
@@ -79,7 +79,7 @@ SMA: Endpoint = Endpoint(
 )
 
 # Exponential Moving Average
-EMA: Endpoint = Endpoint(
+EMA: Endpoint[EMAIndicator] = Endpoint(
     name="ema",
     path="technical-indicators/ema",
     version=APIVersion.STABLE,
@@ -133,7 +133,7 @@ EMA: Endpoint = Endpoint(
 )
 
 # Weighted Moving Average
-WMA: Endpoint = Endpoint(
+WMA: Endpoint[WMAIndicator] = Endpoint(
     name="wma",
     path="technical-indicators/wma",
     version=APIVersion.STABLE,
@@ -187,7 +187,7 @@ WMA: Endpoint = Endpoint(
 )
 
 # Double Exponential Moving Average
-DEMA: Endpoint = Endpoint(
+DEMA: Endpoint[DEMAIndicator] = Endpoint(
     name="dema",
     path="technical-indicators/dema",
     version=APIVersion.STABLE,
@@ -241,7 +241,7 @@ DEMA: Endpoint = Endpoint(
 )
 
 # Triple Exponential Moving Average
-TEMA: Endpoint = Endpoint(
+TEMA: Endpoint[TEMAIndicator] = Endpoint(
     name="tema",
     path="technical-indicators/tema",
     version=APIVersion.STABLE,
@@ -295,7 +295,7 @@ TEMA: Endpoint = Endpoint(
 )
 
 # Relative Strength Index
-RSI: Endpoint = Endpoint(
+RSI: Endpoint[RSIIndicator] = Endpoint(
     name="rsi",
     path="technical-indicators/rsi",
     version=APIVersion.STABLE,
@@ -349,7 +349,7 @@ RSI: Endpoint = Endpoint(
 )
 
 # Standard Deviation
-STANDARD_DEVIATION: Endpoint = Endpoint(
+STANDARD_DEVIATION: Endpoint[StandardDeviationIndicator] = Endpoint(
     name="standard_deviation",
     path="technical-indicators/standarddeviation",
     version=APIVersion.STABLE,
@@ -403,7 +403,7 @@ STANDARD_DEVIATION: Endpoint = Endpoint(
 )
 
 # Williams %R
-WILLIAMS: Endpoint = Endpoint(
+WILLIAMS: Endpoint[WilliamsIndicator] = Endpoint(
     name="williams",
     path="technical-indicators/williams",
     version=APIVersion.STABLE,
@@ -457,7 +457,7 @@ WILLIAMS: Endpoint = Endpoint(
 )
 
 # Average Directional Index
-ADX: Endpoint = Endpoint(
+ADX: Endpoint[ADXIndicator] = Endpoint(
     name="adx",
     path="technical-indicators/adx",
     version=APIVersion.STABLE,

--- a/fmp_data/technical/mapping.py
+++ b/fmp_data/technical/mapping.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fmp_data.lc.hints import DATE_HINTS, PERIOD_LENGTH_HINT, SYMBOL_HINT
 from fmp_data.lc.models import (
     EndpointSemantics,
@@ -5,6 +7,7 @@ from fmp_data.lc.models import (
     ResponseFieldInfo,
     SemanticCategory,
 )
+from fmp_data.models import Endpoint
 from fmp_data.technical.endpoints import (
     ADX,
     DEMA,
@@ -361,7 +364,7 @@ TECHNICAL_ENDPOINTS_SEMANTICS = {
 }
 
 # Endpoint mappings
-TECHNICAL_ENDPOINT_MAP = {
+TECHNICAL_ENDPOINT_MAP: dict[str, Endpoint[Any]] = {
     "get_sma": SMA,
     "get_ema": EMA,
     "get_wma": WMA,

--- a/tests/unit/test_async_clients.py
+++ b/tests/unit/test_async_clients.py
@@ -449,6 +449,19 @@ class TestAsyncCompanyClient:
         assert result.historical[0].date.date() == dt_date(2024, 1, 1)
 
     @pytest.mark.asyncio
+    async def test_get_historical_prices_empty_list_stays_empty(self, mock_client):
+        """Empty EOD lists become HistoricalData(historical=[])."""
+        from fmp_data.company.async_client import AsyncCompanyClient
+
+        mock_client.request_async.return_value = []
+
+        async_client = AsyncCompanyClient(mock_client)
+        result = await async_client.get_historical_prices("AAPL")
+
+        assert result.symbol == "AAPL"
+        assert result.historical == []
+
+    @pytest.mark.asyncio
     async def test_get_historical_prices_with_date_filters(self, mock_client):
         """Test get_historical_prices forwards date filters."""
         from fmp_data.company import endpoints as company_endpoints
@@ -904,7 +917,7 @@ class TestAsyncMarketClient:
         mock_client.request_async.return_value = []
 
         async_client = AsyncMarketClient(mock_client)
-        with pytest.raises(ValueError, match="No market hours data"):
+        with pytest.raises(ValueError, match="Expected at least one MarketHours"):
             await async_client.get_market_hours(exchange="NYSE")
 
     @pytest.mark.asyncio
@@ -2612,7 +2625,7 @@ class TestAsyncAlternativeMarketsClient:
     async def test_get_crypto_historical_passes_dict_response(
         self, mock_client, monkeypatch
     ):
-        """Test crypto historical dict responses pass through."""
+        """Test crypto historical lone-row dicts wrap into HistoricalData."""
         from fmp_data.alternative.async_client import AsyncAlternativeMarketsClient
         from fmp_data.alternative.models import CryptoHistoricalData
 
@@ -2620,14 +2633,16 @@ class TestAsyncAlternativeMarketsClient:
         mock_validate = MagicMock(return_value=sentinel)
         monkeypatch.setattr(CryptoHistoricalData, "model_validate", mock_validate)
 
-        response = {"symbol": "BTCUSD", "historical": [{"date": "2024-01-01"}]}
+        response = {"date": "2024-01-01"}
         mock_client.request_async.return_value = response
 
         async_client = AsyncAlternativeMarketsClient(mock_client)
         result = await async_client.get_crypto_historical("BTCUSD")
 
         assert result is sentinel
-        mock_validate.assert_called_once_with(response)
+        mock_validate.assert_called_once_with(
+            {"symbol": "BTCUSD", "historical": [response]}
+        )
 
     @pytest.mark.asyncio
     async def test_get_forex_historical_formats_dates(self, mock_client):
@@ -2635,7 +2650,7 @@ class TestAsyncAlternativeMarketsClient:
         from fmp_data.alternative import endpoints as alternative_endpoints
         from fmp_data.alternative.async_client import AsyncAlternativeMarketsClient
 
-        mock_client.request_async.return_value = {"symbol": "EURUSD", "historical": []}
+        mock_client.request_async.return_value = []
 
         async_client = AsyncAlternativeMarketsClient(mock_client)
         result = await async_client.get_forex_historical(
@@ -2656,7 +2671,7 @@ class TestAsyncAlternativeMarketsClient:
         from fmp_data.alternative import endpoints as alternative_endpoints
         from fmp_data.alternative.async_client import AsyncAlternativeMarketsClient
 
-        mock_client.request_async.return_value = {"symbol": "CL", "historical": []}
+        mock_client.request_async.return_value = []
 
         async_client = AsyncAlternativeMarketsClient(mock_client)
         result = await async_client.get_commodity_historical(

--- a/tests/unit/test_company.py
+++ b/tests/unit/test_company.py
@@ -8,28 +8,45 @@ import pytest
 from fmp_data.base import BaseClient, EndpointGroup
 from fmp_data.company import CompanyClient
 from fmp_data.company.endpoints import (
+    ANALYST_RECOMMENDATIONS,
+    COMPANY_OUTLOOK,
     COMPANY_PEERS,
     DELISTED_COMPANIES,
+    HISTORICAL_EMPLOYEE_COUNT,
+    HISTORICAL_PRICE,
+    HISTORICAL_PRICE_DIVIDEND_ADJUSTED,
+    HISTORICAL_PRICE_LIGHT,
+    HISTORICAL_PRICE_NON_SPLIT_ADJUSTED,
+    HISTORICAL_SHARE_FLOAT,
     INCOME_STATEMENT_TTM,
     KEY_EXECUTIVES,
     MERGERS_ACQUISITIONS_LATEST,
+    PRICE_TARGET,
+    STOCK_SCREENER,
     SYMBOL_CHANGES,
+    UPGRADES_DOWNGRADES,
 )
 from fmp_data.company.models import (
     AnalystEstimate,
+    AnalystRecommendation,
     CompanyExecutive,
+    CompanyOutlook,
     CompanyPeer,
     CompanyProfile,
     DelistedCompany,
+    EmployeeCount,
     ExecutiveCompensationBenchmark,
     HistoricalData,
     HistoricalPrice,
+    HistoricalShareFloat,
     IntradayPrice,
     MergerAcquisition,
+    PriceTarget,
     PriceTargetSummary,
     Quote,
     SimpleQuote,
     SymbolChange,
+    UpgradeDowngrade,
 )
 from fmp_data.fundamental.models import IncomeStatement
 from fmp_data.intelligence.models import DividendEvent, EarningEvent, StockSplitEvent
@@ -1532,4 +1549,73 @@ class TestCompanyListUnwrap:
     )
     def test_list_endpoints_bind_row_type(self, endpoint, row_type):
         """List endpoints bind T as the row, not list[T]."""
+        assert endpoint.response_model is row_type
+
+
+class TestCompanyHistoricalEODUnwrap:
+    """Historical EOD helpers unwrap rows then wrap HistoricalData (#242)."""
+
+    @pytest.fixture
+    def historical_price_data(self):
+        return {
+            "date": "2024-01-05T00:00:00",
+            "open": 149.00,
+            "high": 151.00,
+            "low": 148.50,
+            "close": 150.25,
+            "volume": 82034567,
+            "change": 2.25,
+            "changePercent": 1.5,
+            "vwap": 149.92,
+        }
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            HISTORICAL_PRICE,
+            HISTORICAL_PRICE_LIGHT,
+            HISTORICAL_PRICE_NON_SPLIT_ADJUSTED,
+            HISTORICAL_PRICE_DIVIDEND_ADJUSTED,
+        ],
+    )
+    def test_historical_price_endpoints_bind_row_type(self, endpoint):
+        assert endpoint.response_model is HistoricalPrice
+
+    def test_get_historical_prices_wraps_lone_row(
+        self, fmp_client, mock_client, historical_price_data
+    ):
+        row = HistoricalPrice(**historical_price_data)
+        mock_client.request.return_value = row
+
+        result = fmp_client.get_historical_prices("AAPL")
+
+        assert isinstance(result, HistoricalData)
+        assert result.symbol == "AAPL"
+        assert result.historical == [row]
+
+    def test_get_historical_prices_empty_list_stays_empty(
+        self, fmp_client, mock_client
+    ):
+        mock_client.request.return_value = []
+
+        result = fmp_client.get_historical_prices("AAPL")
+
+        assert isinstance(result, HistoricalData)
+        assert result.symbol == "AAPL"
+        assert result.historical == []
+
+    @pytest.mark.parametrize(
+        "endpoint,row_type",
+        [
+            (HISTORICAL_SHARE_FLOAT, HistoricalShareFloat),
+            (PRICE_TARGET, PriceTarget),
+            (ANALYST_RECOMMENDATIONS, AnalystRecommendation),
+            (UPGRADES_DOWNGRADES, UpgradeDowngrade),
+            (HISTORICAL_EMPLOYEE_COUNT, EmployeeCount),
+            (STOCK_SCREENER, CompanyProfile),
+            (COMPANY_OUTLOOK, CompanyOutlook),
+        ],
+    )
+    def test_leftover_company_endpoints_bind_row_type(self, endpoint, row_type):
+        """Leftover company declarations bind T as the payload/row type."""
         assert endpoint.response_model is row_type

--- a/tests/unit/test_list_unwrap.py
+++ b/tests/unit/test_list_unwrap.py
@@ -1,0 +1,213 @@
+"""Mechanical _unwrap_list coverage for remaining domains (#242)."""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from fmp_data.alternative.async_client import AsyncAlternativeMarketsClient
+from fmp_data.alternative.client import AlternativeMarketsClient
+from fmp_data.alternative.endpoints import CRYPTO_HISTORICAL, CRYPTO_LIST
+from fmp_data.alternative.models import CryptoHistoricalPrice, CryptoPair
+from fmp_data.economics.client import EconomicsClient
+from fmp_data.economics.endpoints import ECONOMIC_INDICATORS, TREASURY_RATES
+from fmp_data.economics.models import EconomicIndicator, TreasuryRate
+from fmp_data.fundamental.client import FundamentalClient
+from fmp_data.fundamental.endpoints import INCOME_STATEMENT, KEY_METRICS
+from fmp_data.fundamental.models import IncomeStatement, KeyMetrics
+from fmp_data.institutional.client import InstitutionalClient
+from fmp_data.institutional.endpoints import FORM_13F_DATES, INSTITUTIONAL_HOLDERS
+from fmp_data.institutional.models import Form13FDate, InstitutionalHolder
+from fmp_data.intelligence.client import MarketIntelligenceClient
+from fmp_data.intelligence.endpoints import EARNINGS_CALENDAR, GENERAL_NEWS_ENDPOINT
+from fmp_data.intelligence.models import EarningEvent, GeneralNewsArticle
+from fmp_data.investment.client import InvestmentClient
+from fmp_data.investment.endpoints import ETF_HOLDINGS, ETF_SECTOR_WEIGHTINGS
+from fmp_data.investment.models import ETFHolding, ETFSectorWeighting
+from fmp_data.market.client import MarketClient
+from fmp_data.market.endpoints import (
+    ALL_EXCHANGE_MARKET_HOURS,
+    AVAILABLE_SECTORS,
+    STOCK_LIST,
+)
+from fmp_data.market.models import MarketHours
+from fmp_data.models import CompanySymbol
+from fmp_data.technical.client import TechnicalClient
+from fmp_data.technical.endpoints import SMA
+from fmp_data.technical.models import SMAIndicator
+
+
+@pytest.fixture
+def mock_client():
+    client = Mock()
+    client.logger = Mock()
+    return client
+
+
+_MARKET_CASES: list[tuple[str, dict[str, object]]] = [
+    ("get_all_exchange_market_hours", {}),
+    ("get_available_sectors", {}),
+    ("get_stock_list", {}),
+    ("get_gainers", {}),
+]
+
+_FUNDAMENTAL_CASES = [
+    ("get_income_statement", {"symbol": "AAPL"}),
+    ("get_key_metrics", {"symbol": "AAPL"}),
+]
+
+_INSTITUTIONAL_CASES = [
+    ("get_form_13f_dates", {"cik": "0001067983"}),
+    ("get_form_13f_by_quarter", {"cik": "0001067983", "year": 2023, "quarter": 3}),
+    ("get_institutional_holders", {}),
+]
+
+_INVESTMENT_CASES = [
+    ("get_etf_holdings", {"symbol": "SPY"}),
+    ("get_etf_sector_weightings", {"symbol": "SPY"}),
+]
+
+_INTELLIGENCE_CASES: list[tuple[str, dict[str, object]]] = [
+    ("get_earnings_calendar", {}),
+    ("get_general_news", {}),
+]
+
+_ALTERNATIVE_CASES = [
+    ("get_crypto_list", {}),
+    ("get_crypto_intraday", {"symbol": "BTCUSD"}),
+]
+
+_ECONOMICS_CASES = [
+    ("get_market_risk_premium", {}),
+    ("get_economic_indicators", {"indicator_name": "GDP"}),
+]
+
+_TECHNICAL_CASES = [
+    ("get_sma", {"symbol": "AAPL"}),
+]
+
+
+def _assert_wrap_single_and_empty(client, method_name, kwargs):
+    row = object()
+    method = getattr(client, method_name)
+
+    client.client.request.return_value = row
+    assert method(**kwargs) == [row]
+
+    client.client.request.return_value = []
+    assert method(**kwargs) == []
+    client.client.request.assert_called()
+
+
+class TestMarketListUnwrap:
+    @pytest.mark.parametrize("method_name,kwargs", _MARKET_CASES)
+    def test_list_methods_wrap_single_and_keep_empty(
+        self, mock_client, method_name, kwargs
+    ):
+        _assert_wrap_single_and_empty(MarketClient(mock_client), method_name, kwargs)
+
+
+class TestFundamentalListUnwrap:
+    @pytest.mark.parametrize("method_name,kwargs", _FUNDAMENTAL_CASES)
+    def test_list_methods_wrap_single_and_keep_empty(
+        self, mock_client, method_name, kwargs
+    ):
+        _assert_wrap_single_and_empty(
+            FundamentalClient(mock_client), method_name, kwargs
+        )
+
+
+class TestInstitutionalListUnwrap:
+    @pytest.mark.parametrize("method_name,kwargs", _INSTITUTIONAL_CASES)
+    def test_list_methods_wrap_single_and_keep_empty(
+        self, mock_client, method_name, kwargs
+    ):
+        _assert_wrap_single_and_empty(
+            InstitutionalClient(mock_client), method_name, kwargs
+        )
+
+
+class TestInvestmentListUnwrap:
+    @pytest.mark.parametrize("method_name,kwargs", _INVESTMENT_CASES)
+    def test_list_methods_wrap_single_and_keep_empty(
+        self, mock_client, method_name, kwargs
+    ):
+        _assert_wrap_single_and_empty(
+            InvestmentClient(mock_client), method_name, kwargs
+        )
+
+
+class TestIntelligenceListUnwrap:
+    @pytest.mark.parametrize("method_name,kwargs", _INTELLIGENCE_CASES)
+    def test_list_methods_wrap_single_and_keep_empty(
+        self, mock_client, method_name, kwargs
+    ):
+        _assert_wrap_single_and_empty(
+            MarketIntelligenceClient(mock_client), method_name, kwargs
+        )
+
+
+class TestAlternativeListUnwrap:
+    @pytest.mark.parametrize("method_name,kwargs", _ALTERNATIVE_CASES)
+    def test_list_methods_wrap_single_and_keep_empty(
+        self, mock_client, method_name, kwargs
+    ):
+        _assert_wrap_single_and_empty(
+            AlternativeMarketsClient(mock_client), method_name, kwargs
+        )
+
+
+class TestEconomicsListUnwrap:
+    @pytest.mark.parametrize("method_name,kwargs", _ECONOMICS_CASES)
+    def test_list_methods_wrap_single_and_keep_empty(
+        self, mock_client, method_name, kwargs
+    ):
+        _assert_wrap_single_and_empty(EconomicsClient(mock_client), method_name, kwargs)
+
+
+class TestTechnicalListUnwrap:
+    @pytest.mark.parametrize("method_name,kwargs", _TECHNICAL_CASES)
+    def test_list_methods_wrap_single_and_keep_empty(
+        self, mock_client, method_name, kwargs
+    ):
+        _assert_wrap_single_and_empty(TechnicalClient(mock_client), method_name, kwargs)
+
+
+class TestAsyncAlternativeListUnwrap:
+    @pytest.mark.asyncio
+    async def test_crypto_list_wraps_single_and_keeps_empty(self, mock_client):
+        mock_client.request_async = AsyncMock()
+        client = AsyncAlternativeMarketsClient(mock_client)
+        row = object()
+
+        mock_client.request_async.return_value = row
+        assert await client.get_crypto_list() == [row]
+
+        mock_client.request_async.return_value = []
+        assert await client.get_crypto_list() == []
+
+
+class TestPreviouslyUntypedEndpointRowBindings:
+    @pytest.mark.parametrize(
+        "endpoint,row_type",
+        [
+            (STOCK_LIST, CompanySymbol),
+            (ALL_EXCHANGE_MARKET_HOURS, MarketHours),
+            (AVAILABLE_SECTORS, str),
+            (INCOME_STATEMENT, IncomeStatement),
+            (KEY_METRICS, KeyMetrics),
+            (FORM_13F_DATES, Form13FDate),
+            (INSTITUTIONAL_HOLDERS, InstitutionalHolder),
+            (ETF_HOLDINGS, ETFHolding),
+            (ETF_SECTOR_WEIGHTINGS, ETFSectorWeighting),
+            (EARNINGS_CALENDAR, EarningEvent),
+            (GENERAL_NEWS_ENDPOINT, GeneralNewsArticle),
+            (CRYPTO_LIST, CryptoPair),
+            (CRYPTO_HISTORICAL, CryptoHistoricalPrice),
+            (TREASURY_RATES, TreasuryRate),
+            (ECONOMIC_INDICATORS, EconomicIndicator),
+            (SMA, SMAIndicator),
+        ],
+    )
+    def test_list_endpoints_bind_row_type(self, endpoint, row_type):
+        """List endpoints bind T as the row, not list[T]."""
+        assert endpoint.response_model is row_type

--- a/tests/unit/test_list_unwrap.py
+++ b/tests/unit/test_list_unwrap.py
@@ -1,28 +1,40 @@
 """Mechanical _unwrap_list coverage for remaining domains (#242)."""
 
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 
 from fmp_data.alternative.async_client import AsyncAlternativeMarketsClient
 from fmp_data.alternative.client import AlternativeMarketsClient
 from fmp_data.alternative.endpoints import CRYPTO_HISTORICAL, CRYPTO_LIST
-from fmp_data.alternative.models import CryptoHistoricalPrice, CryptoPair
+from fmp_data.alternative.models import (
+    CommodityPriceHistory,
+    CryptoHistoricalData,
+    CryptoHistoricalPrice,
+    CryptoPair,
+    ForexPriceHistory,
+)
+from fmp_data.economics.async_client import AsyncEconomicsClient
 from fmp_data.economics.client import EconomicsClient
 from fmp_data.economics.endpoints import ECONOMIC_INDICATORS, TREASURY_RATES
 from fmp_data.economics.models import EconomicIndicator, TreasuryRate
+from fmp_data.fundamental.async_client import AsyncFundamentalClient
 from fmp_data.fundamental.client import FundamentalClient
 from fmp_data.fundamental.endpoints import INCOME_STATEMENT, KEY_METRICS
 from fmp_data.fundamental.models import IncomeStatement, KeyMetrics
+from fmp_data.institutional.async_client import AsyncInstitutionalClient
 from fmp_data.institutional.client import InstitutionalClient
 from fmp_data.institutional.endpoints import FORM_13F_DATES, INSTITUTIONAL_HOLDERS
 from fmp_data.institutional.models import Form13FDate, InstitutionalHolder
+from fmp_data.intelligence.async_client import AsyncMarketIntelligenceClient
 from fmp_data.intelligence.client import MarketIntelligenceClient
 from fmp_data.intelligence.endpoints import EARNINGS_CALENDAR, GENERAL_NEWS_ENDPOINT
 from fmp_data.intelligence.models import EarningEvent, GeneralNewsArticle
+from fmp_data.investment.async_client import AsyncInvestmentClient
 from fmp_data.investment.client import InvestmentClient
 from fmp_data.investment.endpoints import ETF_HOLDINGS, ETF_SECTOR_WEIGHTINGS
 from fmp_data.investment.models import ETFHolding, ETFSectorWeighting
+from fmp_data.market.async_client import AsyncMarketClient
 from fmp_data.market.client import MarketClient
 from fmp_data.market.endpoints import (
     ALL_EXCHANGE_MARKET_HOURS,
@@ -31,6 +43,7 @@ from fmp_data.market.endpoints import (
 )
 from fmp_data.market.models import MarketHours
 from fmp_data.models import CompanySymbol
+from fmp_data.technical.async_client import AsyncTechnicalClient
 from fmp_data.technical.client import TechnicalClient
 from fmp_data.technical.endpoints import SMA
 from fmp_data.technical.models import SMAIndicator
@@ -40,49 +53,76 @@ from fmp_data.technical.models import SMAIndicator
 def mock_client():
     client = Mock()
     client.logger = Mock()
+    client.request_async = AsyncMock()
     return client
 
 
 _MARKET_CASES: list[tuple[str, dict[str, object]]] = [
     ("get_all_exchange_market_hours", {}),
     ("get_available_sectors", {}),
+    ("get_available_industries", {}),
     ("get_stock_list", {}),
     ("get_gainers", {}),
+    ("get_losers", {}),
+    ("get_most_active", {}),
 ]
 
 _FUNDAMENTAL_CASES = [
     ("get_income_statement", {"symbol": "AAPL"}),
+    ("get_balance_sheet", {"symbol": "AAPL"}),
+    ("get_cash_flow", {"symbol": "AAPL"}),
     ("get_key_metrics", {"symbol": "AAPL"}),
+    ("get_financial_ratios", {"symbol": "AAPL"}),
+    ("get_financial_reports_dates", {"symbol": "AAPL"}),
 ]
 
 _INSTITUTIONAL_CASES = [
     ("get_form_13f_dates", {"cik": "0001067983"}),
     ("get_form_13f_by_quarter", {"cik": "0001067983", "year": 2023, "quarter": 3}),
     ("get_institutional_holders", {}),
+    ("get_insider_trades", {"symbol": "AAPL"}),
+    ("get_insider_roster", {"symbol": "AAPL"}),
 ]
 
 _INVESTMENT_CASES = [
     ("get_etf_holdings", {"symbol": "SPY"}),
     ("get_etf_sector_weightings", {"symbol": "SPY"}),
+    ("get_etf_country_weightings", {"symbol": "SPY"}),
+    ("get_mutual_fund_dates", {"symbol": "VTSAX"}),
 ]
 
 _INTELLIGENCE_CASES: list[tuple[str, dict[str, object]]] = [
     ("get_earnings_calendar", {}),
+    ("get_dividends_calendar", {}),
+    ("get_stock_splits_calendar", {}),
+    ("get_ipo_calendar", {}),
     ("get_general_news", {}),
+    ("get_esg_benchmark", {}),
+    ("get_senate_latest", {}),
+    ("get_house_latest", {}),
+    ("get_press_releases", {}),
 ]
 
 _ALTERNATIVE_CASES = [
     ("get_crypto_list", {}),
     ("get_crypto_intraday", {"symbol": "BTCUSD"}),
+    ("get_forex_list", {}),
+    ("get_forex_intraday", {"symbol": "EURUSD"}),
+    ("get_commodities_list", {}),
+    ("get_commodity_intraday", {"symbol": "GCUSD"}),
 ]
 
 _ECONOMICS_CASES = [
     ("get_market_risk_premium", {}),
     ("get_economic_indicators", {"indicator_name": "GDP"}),
+    ("get_treasury_rates", {}),
+    ("get_economic_calendar", {}),
 ]
 
 _TECHNICAL_CASES = [
     ("get_sma", {"symbol": "AAPL"}),
+    ("get_ema", {"symbol": "AAPL"}),
+    ("get_rsi", {"symbol": "AAPL"}),
 ]
 
 
@@ -96,6 +136,18 @@ def _assert_wrap_single_and_empty(client, method_name, kwargs):
     client.client.request.return_value = []
     assert method(**kwargs) == []
     client.client.request.assert_called()
+
+
+async def _assert_wrap_single_and_empty_async(client, method_name, kwargs):
+    row = object()
+    method = getattr(client, method_name)
+
+    client.client.request_async.return_value = row
+    assert await method(**kwargs) == [row]
+
+    client.client.request_async.return_value = []
+    assert await method(**kwargs) == []
+    client.client.request_async.assert_called()
 
 
 class TestMarketListUnwrap:
@@ -172,18 +224,155 @@ class TestTechnicalListUnwrap:
         _assert_wrap_single_and_empty(TechnicalClient(mock_client), method_name, kwargs)
 
 
+class TestAsyncMarketListUnwrap:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method_name,kwargs", _MARKET_CASES)
+    async def test_list_methods_wrap_single_and_keep_empty(
+        self, mock_client, method_name, kwargs
+    ):
+        await _assert_wrap_single_and_empty_async(
+            AsyncMarketClient(mock_client), method_name, kwargs
+        )
+
+
+class TestAsyncFundamentalListUnwrap:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method_name,kwargs", _FUNDAMENTAL_CASES)
+    async def test_list_methods_wrap_single_and_keep_empty(
+        self, mock_client, method_name, kwargs
+    ):
+        await _assert_wrap_single_and_empty_async(
+            AsyncFundamentalClient(mock_client), method_name, kwargs
+        )
+
+
+class TestAsyncInstitutionalListUnwrap:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method_name,kwargs", _INSTITUTIONAL_CASES)
+    async def test_list_methods_wrap_single_and_keep_empty(
+        self, mock_client, method_name, kwargs
+    ):
+        await _assert_wrap_single_and_empty_async(
+            AsyncInstitutionalClient(mock_client), method_name, kwargs
+        )
+
+
+class TestAsyncInvestmentListUnwrap:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method_name,kwargs", _INVESTMENT_CASES)
+    async def test_list_methods_wrap_single_and_keep_empty(
+        self, mock_client, method_name, kwargs
+    ):
+        await _assert_wrap_single_and_empty_async(
+            AsyncInvestmentClient(mock_client), method_name, kwargs
+        )
+
+
+class TestAsyncIntelligenceListUnwrap:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method_name,kwargs", _INTELLIGENCE_CASES)
+    async def test_list_methods_wrap_single_and_keep_empty(
+        self, mock_client, method_name, kwargs
+    ):
+        await _assert_wrap_single_and_empty_async(
+            AsyncMarketIntelligenceClient(mock_client), method_name, kwargs
+        )
+
+
 class TestAsyncAlternativeListUnwrap:
     @pytest.mark.asyncio
-    async def test_crypto_list_wraps_single_and_keeps_empty(self, mock_client):
-        mock_client.request_async = AsyncMock()
+    @pytest.mark.parametrize("method_name,kwargs", _ALTERNATIVE_CASES)
+    async def test_list_methods_wrap_single_and_keep_empty(
+        self, mock_client, method_name, kwargs
+    ):
+        await _assert_wrap_single_and_empty_async(
+            AsyncAlternativeMarketsClient(mock_client), method_name, kwargs
+        )
+
+
+class TestAsyncEconomicsListUnwrap:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method_name,kwargs", _ECONOMICS_CASES)
+    async def test_list_methods_wrap_single_and_keep_empty(
+        self, mock_client, method_name, kwargs
+    ):
+        await _assert_wrap_single_and_empty_async(
+            AsyncEconomicsClient(mock_client), method_name, kwargs
+        )
+
+
+class TestAsyncTechnicalListUnwrap:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method_name,kwargs", _TECHNICAL_CASES)
+    async def test_list_methods_wrap_single_and_keep_empty(
+        self, mock_client, method_name, kwargs
+    ):
+        await _assert_wrap_single_and_empty_async(
+            AsyncTechnicalClient(mock_client), method_name, kwargs
+        )
+
+
+class TestAlternativeHistoryUnwrap:
+    """_wrap_history now unwraps rows then builds the container (#242)."""
+
+    @pytest.mark.parametrize(
+        "method_name,kwargs,container",
+        [
+            ("get_crypto_historical", {"symbol": "BTCUSD"}, CryptoHistoricalData),
+            ("get_forex_historical", {"symbol": "EURUSD"}, ForexPriceHistory),
+            ("get_commodity_historical", {"symbol": "GCUSD"}, CommodityPriceHistory),
+        ],
+    )
+    def test_wrap_history_lone_row_and_empty(
+        self, mock_client, monkeypatch, method_name, kwargs, container
+    ):
+        sentinel = object()
+        mock_validate = MagicMock(return_value=sentinel)
+        monkeypatch.setattr(container, "model_validate", mock_validate)
+        client = AlternativeMarketsClient(mock_client)
+        method = getattr(client, method_name)
+
+        row = {"date": "2024-01-01"}
+        mock_client.request.return_value = row
+        assert method(**kwargs) is sentinel
+        mock_validate.assert_called_with(
+            {"symbol": kwargs["symbol"], "historical": [row]}
+        )
+
+        mock_validate.reset_mock()
+        mock_client.request.return_value = []
+        assert method(**kwargs) is sentinel
+        mock_validate.assert_called_with({"symbol": kwargs["symbol"], "historical": []})
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "method_name,kwargs,container",
+        [
+            ("get_crypto_historical", {"symbol": "BTCUSD"}, CryptoHistoricalData),
+            ("get_forex_historical", {"symbol": "EURUSD"}, ForexPriceHistory),
+            ("get_commodity_historical", {"symbol": "GCUSD"}, CommodityPriceHistory),
+        ],
+    )
+    async def test_async_wrap_history_lone_row_and_empty(
+        self, mock_client, monkeypatch, method_name, kwargs, container
+    ):
+        sentinel = object()
+        mock_validate = MagicMock(return_value=sentinel)
+        monkeypatch.setattr(container, "model_validate", mock_validate)
         client = AsyncAlternativeMarketsClient(mock_client)
-        row = object()
+        method = getattr(client, method_name)
 
+        row = {"date": "2024-01-01"}
         mock_client.request_async.return_value = row
-        assert await client.get_crypto_list() == [row]
+        assert await method(**kwargs) is sentinel
+        mock_validate.assert_called_with(
+            {"symbol": kwargs["symbol"], "historical": [row]}
+        )
 
+        mock_validate.reset_mock()
         mock_client.request_async.return_value = []
-        assert await client.get_crypto_list() == []
+        assert await method(**kwargs) is sentinel
+        mock_validate.assert_called_with({"symbol": kwargs["symbol"], "historical": []})
 
 
 class TestPreviouslyUntypedEndpointRowBindings:

--- a/tests/unit/test_market.py
+++ b/tests/unit/test_market.py
@@ -99,7 +99,7 @@ def test_get_market_hours_empty_response(fmp_client):
     """Test getting market hours with empty response"""
     # Mock the client.request to return empty list directly
     with patch.object(fmp_client.market.client, "request", return_value=[]):
-        with pytest.raises(ValueError, match="No market hours data returned from API"):
+        with pytest.raises(ValueError, match="Expected at least one MarketHours"):
             fmp_client.market.get_market_hours()
 
 


### PR DESCRIPTION
Closes #242.

#235 / #239 added `request_list` / `_unwrap_list` and migrated the company list surface. `request()` stays `Endpoint[T] -> T | list[T]`. This PR does the remaining listed follow-ups in one change:

1. Company historical EOD → `_unwrap_list` + `Endpoint[HistoricalPrice]`, then wrap `HistoricalData`.
2. Replace the remaining inline wraps (institutional Form 13F, market hours list, alternative `_wrap_history`).
3. Contributing example uses `_unwrap_list`.
4. Market, fundamental, investment, intelligence, institutional, alternative, economics, and technical list endpoints are `Endpoint[T]` (row type) and list methods go through `_unwrap_list`.

## What this does not do

- Does not collapse `request()` to `list[T]`.
- Does not switch methods to `request_list()` (existing `mock_client.request` tests stay valid).
- Does not enable mypy `type-arg`.
- Does not use `Endpoint[list[T]]`.
- Does not unwrap `FINANCIAL_REPORTS_JSON` / `FINANCIAL_REPORTS_XLSX` (dict / bytes).
- Deprecated methods that already `return []` stay that way.

## Annotation correction

`get_mutual_fund_dates` / `get_fund_disclosure_dates` are annotated `list[PortfolioDate]` instead of `list[date]`. Runtime already returned `PortfolioDate` rows (`response_model=PortfolioDate`); the old hint was wrong.

## Left for a follow-up

Index, SEC, transcripts, and batch still have untyped list (or bulk-bytes) endpoints. They were outside the domains listed in #242.

## Tests

- Company historical EOD: row-type binding, lone-row wrap, empty list.
- `tests/unit/test_list_unwrap.py`: wrap-single / empty-list tables plus row-type bindings for the remaining domains.
- Targeted unit suite: 684 passed.

Isolated worktree `fmp-data--feat-unwrap-list-remaining-242` off `origin/dev`.