### PR TITLE
feat(client): migrate leftover list endpoints through _unwrap_list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,13 @@ None. No FMP path we ship was newly retired by this changelog window.
   `get_mutual_fund_dates` / `get_fund_disclosure_dates` are annotated
   `list[PortfolioDate]` (runtime already returned `PortfolioDate` rows).
 
+- **Leftover index, SEC, transcripts, and batch quote lists go through
+  `_unwrap_list` / `Endpoint[T]` (#245).** Index constituents, SEC list
+  surfaces (not `SEC_PROFILE`), transcripts, and batch JSON quote lists
+  bind the row type and normalize `request()` / `request_async()`.
+  `get_profile` stays `_unwrap_single`. Bulk-bytes / CSV paths stay on
+  `_request_csv`. `request()` stays `T | list[T]`.
+
 ### Added
 
 - **FMP hosted MCP vs `fmp-mcp` positioning (#230).** Docs-only: we are not

--- a/fmp_data/batch/async_client.py
+++ b/fmp_data/batch/async_client.py
@@ -115,7 +115,10 @@ class AsyncBatchClient(AsyncEndpointGroup):
         Returns:
             List of quote data for each symbol
         """
-        return await self.client.request_async(BATCH_QUOTE, symbols=",".join(symbols))
+        return self._unwrap_list(
+            await self.client.request_async(BATCH_QUOTE, symbols=",".join(symbols)),
+            BatchQuote,
+        )
 
     async def get_quotes_short(self, symbols: list[str]) -> list[BatchQuoteShort]:
         """Get quick price snapshots for multiple symbols
@@ -126,8 +129,11 @@ class AsyncBatchClient(AsyncEndpointGroup):
         Returns:
             List of short quote data for each symbol
         """
-        return await self.client.request_async(
-            BATCH_QUOTE_SHORT, symbols=",".join(symbols)
+        return self._unwrap_list(
+            await self.client.request_async(
+                BATCH_QUOTE_SHORT, symbols=",".join(symbols)
+            ),
+            BatchQuoteShort,
         )
 
     async def get_aftermarket_trades(
@@ -141,8 +147,11 @@ class AsyncBatchClient(AsyncEndpointGroup):
         Returns:
             List of aftermarket trade data
         """
-        return await self.client.request_async(
-            BATCH_AFTERMARKET_TRADE, symbols=",".join(symbols)
+        return self._unwrap_list(
+            await self.client.request_async(
+                BATCH_AFTERMARKET_TRADE, symbols=",".join(symbols)
+            ),
+            AftermarketTrade,
         )
 
     async def get_aftermarket_quotes(
@@ -156,8 +165,11 @@ class AsyncBatchClient(AsyncEndpointGroup):
         Returns:
             List of aftermarket quote data
         """
-        return await self.client.request_async(
-            BATCH_AFTERMARKET_QUOTE, symbols=",".join(symbols)
+        return self._unwrap_list(
+            await self.client.request_async(
+                BATCH_AFTERMARKET_QUOTE, symbols=",".join(symbols)
+            ),
+            AftermarketQuote,
         )
 
     async def get_exchange_quotes(
@@ -175,7 +187,9 @@ class AsyncBatchClient(AsyncEndpointGroup):
         params: dict[str, object] = {"exchange": exchange}
         if short is not None:
             params["short"] = short
-        return await self.client.request_async(BATCH_EXCHANGE_QUOTE, **params)
+        return self._unwrap_list(
+            await self.client.request_async(BATCH_EXCHANGE_QUOTE, **params), BatchQuote
+        )
 
     async def get_mutualfund_quotes(
         self, short: bool | None = None
@@ -191,7 +205,10 @@ class AsyncBatchClient(AsyncEndpointGroup):
         params: dict[str, object] = {}
         if short is not None:
             params["short"] = short
-        return await self.client.request_async(BATCH_MUTUALFUND_QUOTES, **params)
+        return self._unwrap_list(
+            await self.client.request_async(BATCH_MUTUALFUND_QUOTES, **params),
+            BatchQuote,
+        )
 
     async def get_etf_quotes(self, short: bool | None = None) -> list[BatchQuote]:
         """Get batch quotes for all ETFs
@@ -205,7 +222,9 @@ class AsyncBatchClient(AsyncEndpointGroup):
         params: dict[str, object] = {}
         if short is not None:
             params["short"] = short
-        return await self.client.request_async(BATCH_ETF_QUOTES, **params)
+        return self._unwrap_list(
+            await self.client.request_async(BATCH_ETF_QUOTES, **params), BatchQuote
+        )
 
     async def get_commodity_quotes(self, short: bool | None = None) -> list[BatchQuote]:
         """Get batch quotes for all commodities
@@ -219,7 +238,10 @@ class AsyncBatchClient(AsyncEndpointGroup):
         params: dict[str, object] = {}
         if short is not None:
             params["short"] = short
-        return await self.client.request_async(BATCH_COMMODITY_QUOTES, **params)
+        return self._unwrap_list(
+            await self.client.request_async(BATCH_COMMODITY_QUOTES, **params),
+            BatchQuote,
+        )
 
     async def get_crypto_quotes(self, short: bool | None = None) -> list[BatchQuote]:
         """Get batch quotes for all cryptocurrencies
@@ -233,7 +255,9 @@ class AsyncBatchClient(AsyncEndpointGroup):
         params: dict[str, object] = {}
         if short is not None:
             params["short"] = short
-        return await self.client.request_async(BATCH_CRYPTO_QUOTES, **params)
+        return self._unwrap_list(
+            await self.client.request_async(BATCH_CRYPTO_QUOTES, **params), BatchQuote
+        )
 
     async def get_forex_quotes(self, short: bool | None = None) -> list[BatchQuote]:
         """Get batch quotes for all forex pairs
@@ -247,7 +271,9 @@ class AsyncBatchClient(AsyncEndpointGroup):
         params: dict[str, object] = {}
         if short is not None:
             params["short"] = short
-        return await self.client.request_async(BATCH_FOREX_QUOTES, **params)
+        return self._unwrap_list(
+            await self.client.request_async(BATCH_FOREX_QUOTES, **params), BatchQuote
+        )
 
     async def get_index_quotes(self, short: bool | None = None) -> list[BatchQuote]:
         """Get batch quotes for all market indexes
@@ -261,7 +287,9 @@ class AsyncBatchClient(AsyncEndpointGroup):
         params: dict[str, object] = {}
         if short is not None:
             params["short"] = short
-        return await self.client.request_async(BATCH_INDEX_QUOTES, **params)
+        return self._unwrap_list(
+            await self.client.request_async(BATCH_INDEX_QUOTES, **params), BatchQuote
+        )
 
     async def get_market_caps(self, symbols: list[str]) -> list[BatchMarketCap]:
         """Get market capitalization for multiple symbols
@@ -272,8 +300,11 @@ class AsyncBatchClient(AsyncEndpointGroup):
         Returns:
             List of market cap data for each symbol
         """
-        return await self.client.request_async(
-            BATCH_MARKET_CAP, symbols=",".join(symbols)
+        return self._unwrap_list(
+            await self.client.request_async(
+                BATCH_MARKET_CAP, symbols=",".join(symbols)
+            ),
+            BatchMarketCap,
         )
 
     async def get_profile_bulk(self, part: str) -> list[CompanyProfile]:

--- a/fmp_data/batch/client.py
+++ b/fmp_data/batch/client.py
@@ -113,7 +113,9 @@ class BatchClient(EndpointGroup):
         Returns:
             List of quote data for each symbol
         """
-        return self.client.request(BATCH_QUOTE, symbols=",".join(symbols))
+        return self._unwrap_list(
+            self.client.request(BATCH_QUOTE, symbols=",".join(symbols)), BatchQuote
+        )
 
     def get_quotes_short(self, symbols: list[str]) -> list[BatchQuoteShort]:
         """Get quick price snapshots for multiple symbols
@@ -124,7 +126,10 @@ class BatchClient(EndpointGroup):
         Returns:
             List of short quote data for each symbol
         """
-        return self.client.request(BATCH_QUOTE_SHORT, symbols=",".join(symbols))
+        return self._unwrap_list(
+            self.client.request(BATCH_QUOTE_SHORT, symbols=",".join(symbols)),
+            BatchQuoteShort,
+        )
 
     def get_aftermarket_trades(self, symbols: list[str]) -> list[AftermarketTrade]:
         """Get aftermarket (post-market) trade data for multiple symbols
@@ -135,7 +140,10 @@ class BatchClient(EndpointGroup):
         Returns:
             List of aftermarket trade data
         """
-        return self.client.request(BATCH_AFTERMARKET_TRADE, symbols=",".join(symbols))
+        return self._unwrap_list(
+            self.client.request(BATCH_AFTERMARKET_TRADE, symbols=",".join(symbols)),
+            AftermarketTrade,
+        )
 
     def get_aftermarket_quotes(self, symbols: list[str]) -> list[AftermarketQuote]:
         """Get aftermarket quote data for multiple symbols
@@ -146,7 +154,10 @@ class BatchClient(EndpointGroup):
         Returns:
             List of aftermarket quote data
         """
-        return self.client.request(BATCH_AFTERMARKET_QUOTE, symbols=",".join(symbols))
+        return self._unwrap_list(
+            self.client.request(BATCH_AFTERMARKET_QUOTE, symbols=",".join(symbols)),
+            AftermarketQuote,
+        )
 
     def get_exchange_quotes(
         self, exchange: str, short: bool | None = None
@@ -163,7 +174,9 @@ class BatchClient(EndpointGroup):
         params: dict[str, object] = {"exchange": exchange}
         if short is not None:
             params["short"] = short
-        return self.client.request(BATCH_EXCHANGE_QUOTE, **params)
+        return self._unwrap_list(
+            self.client.request(BATCH_EXCHANGE_QUOTE, **params), BatchQuote
+        )
 
     def get_mutualfund_quotes(self, short: bool | None = None) -> list[BatchQuote]:
         """Get batch quotes for all mutual funds
@@ -177,7 +190,9 @@ class BatchClient(EndpointGroup):
         params: dict[str, object] = {}
         if short is not None:
             params["short"] = short
-        return self.client.request(BATCH_MUTUALFUND_QUOTES, **params)
+        return self._unwrap_list(
+            self.client.request(BATCH_MUTUALFUND_QUOTES, **params), BatchQuote
+        )
 
     def get_etf_quotes(self, short: bool | None = None) -> list[BatchQuote]:
         """Get batch quotes for all ETFs
@@ -191,7 +206,9 @@ class BatchClient(EndpointGroup):
         params: dict[str, object] = {}
         if short is not None:
             params["short"] = short
-        return self.client.request(BATCH_ETF_QUOTES, **params)
+        return self._unwrap_list(
+            self.client.request(BATCH_ETF_QUOTES, **params), BatchQuote
+        )
 
     def get_commodity_quotes(self, short: bool | None = None) -> list[BatchQuote]:
         """Get batch quotes for all commodities
@@ -205,7 +222,9 @@ class BatchClient(EndpointGroup):
         params: dict[str, object] = {}
         if short is not None:
             params["short"] = short
-        return self.client.request(BATCH_COMMODITY_QUOTES, **params)
+        return self._unwrap_list(
+            self.client.request(BATCH_COMMODITY_QUOTES, **params), BatchQuote
+        )
 
     def get_crypto_quotes(self, short: bool | None = None) -> list[BatchQuote]:
         """Get batch quotes for all cryptocurrencies
@@ -219,7 +238,9 @@ class BatchClient(EndpointGroup):
         params: dict[str, object] = {}
         if short is not None:
             params["short"] = short
-        return self.client.request(BATCH_CRYPTO_QUOTES, **params)
+        return self._unwrap_list(
+            self.client.request(BATCH_CRYPTO_QUOTES, **params), BatchQuote
+        )
 
     def get_forex_quotes(self, short: bool | None = None) -> list[BatchQuote]:
         """Get batch quotes for all forex pairs
@@ -233,7 +254,9 @@ class BatchClient(EndpointGroup):
         params: dict[str, object] = {}
         if short is not None:
             params["short"] = short
-        return self.client.request(BATCH_FOREX_QUOTES, **params)
+        return self._unwrap_list(
+            self.client.request(BATCH_FOREX_QUOTES, **params), BatchQuote
+        )
 
     def get_index_quotes(self, short: bool | None = None) -> list[BatchQuote]:
         """Get batch quotes for all market indexes
@@ -247,7 +270,9 @@ class BatchClient(EndpointGroup):
         params: dict[str, object] = {}
         if short is not None:
             params["short"] = short
-        return self.client.request(BATCH_INDEX_QUOTES, **params)
+        return self._unwrap_list(
+            self.client.request(BATCH_INDEX_QUOTES, **params), BatchQuote
+        )
 
     def get_market_caps(self, symbols: list[str]) -> list[BatchMarketCap]:
         """Get market capitalization for multiple symbols
@@ -258,7 +283,10 @@ class BatchClient(EndpointGroup):
         Returns:
             List of market cap data for each symbol
         """
-        return self.client.request(BATCH_MARKET_CAP, symbols=",".join(symbols))
+        return self._unwrap_list(
+            self.client.request(BATCH_MARKET_CAP, symbols=",".join(symbols)),
+            BatchMarketCap,
+        )
 
     def get_profile_bulk(self, part: str) -> list[CompanyProfile]:
         """Get company profile data in bulk"""

--- a/fmp_data/batch/endpoints.py
+++ b/fmp_data/batch/endpoints.py
@@ -16,7 +16,7 @@ from fmp_data.models import (
     URLType,
 )
 
-BATCH_QUOTE: Endpoint = Endpoint(
+BATCH_QUOTE: Endpoint[BatchQuote] = Endpoint(
     name="batch_quote",
     path="batch-quote",
     version=APIVersion.STABLE,
@@ -40,7 +40,7 @@ BATCH_QUOTE: Endpoint = Endpoint(
     ],
 )
 
-BATCH_QUOTE_SHORT: Endpoint = Endpoint(
+BATCH_QUOTE_SHORT: Endpoint[BatchQuoteShort] = Endpoint(
     name="batch_quote_short",
     path="batch-quote-short",
     version=APIVersion.STABLE,
@@ -64,7 +64,7 @@ BATCH_QUOTE_SHORT: Endpoint = Endpoint(
     ],
 )
 
-BATCH_AFTERMARKET_TRADE: Endpoint = Endpoint(
+BATCH_AFTERMARKET_TRADE: Endpoint[AftermarketTrade] = Endpoint(
     name="batch_aftermarket_trade",
     path="batch-aftermarket-trade",
     version=APIVersion.STABLE,
@@ -88,7 +88,7 @@ BATCH_AFTERMARKET_TRADE: Endpoint = Endpoint(
     ],
 )
 
-BATCH_AFTERMARKET_QUOTE: Endpoint = Endpoint(
+BATCH_AFTERMARKET_QUOTE: Endpoint[AftermarketQuote] = Endpoint(
     name="batch_aftermarket_quote",
     path="batch-aftermarket-quote",
     version=APIVersion.STABLE,
@@ -112,7 +112,7 @@ BATCH_AFTERMARKET_QUOTE: Endpoint = Endpoint(
     ],
 )
 
-BATCH_EXCHANGE_QUOTE: Endpoint = Endpoint(
+BATCH_EXCHANGE_QUOTE: Endpoint[BatchQuote] = Endpoint(
     name="batch_exchange_quote",
     path="batch-exchange-quote",
     version=APIVersion.STABLE,
@@ -143,7 +143,7 @@ BATCH_EXCHANGE_QUOTE: Endpoint = Endpoint(
     ],
 )
 
-BATCH_MUTUALFUND_QUOTES: Endpoint = Endpoint(
+BATCH_MUTUALFUND_QUOTES: Endpoint[BatchQuote] = Endpoint(
     name="batch_mutualfund_quotes",
     path="batch-mutualfund-quotes",
     version=APIVersion.STABLE,
@@ -167,7 +167,7 @@ BATCH_MUTUALFUND_QUOTES: Endpoint = Endpoint(
     ],
 )
 
-BATCH_ETF_QUOTES: Endpoint = Endpoint(
+BATCH_ETF_QUOTES: Endpoint[BatchQuote] = Endpoint(
     name="batch_etf_quotes",
     path="batch-etf-quotes",
     version=APIVersion.STABLE,
@@ -191,7 +191,7 @@ BATCH_ETF_QUOTES: Endpoint = Endpoint(
     ],
 )
 
-BATCH_COMMODITY_QUOTES: Endpoint = Endpoint(
+BATCH_COMMODITY_QUOTES: Endpoint[BatchQuote] = Endpoint(
     name="batch_commodity_quotes",
     path="batch-commodity-quotes",
     version=APIVersion.STABLE,
@@ -215,7 +215,7 @@ BATCH_COMMODITY_QUOTES: Endpoint = Endpoint(
     ],
 )
 
-BATCH_CRYPTO_QUOTES: Endpoint = Endpoint(
+BATCH_CRYPTO_QUOTES: Endpoint[BatchQuote] = Endpoint(
     name="batch_crypto_quotes",
     path="batch-crypto-quotes",
     version=APIVersion.STABLE,
@@ -239,7 +239,7 @@ BATCH_CRYPTO_QUOTES: Endpoint = Endpoint(
     ],
 )
 
-BATCH_FOREX_QUOTES: Endpoint = Endpoint(
+BATCH_FOREX_QUOTES: Endpoint[BatchQuote] = Endpoint(
     name="batch_forex_quotes",
     path="batch-forex-quotes",
     version=APIVersion.STABLE,
@@ -263,7 +263,7 @@ BATCH_FOREX_QUOTES: Endpoint = Endpoint(
     ],
 )
 
-BATCH_INDEX_QUOTES: Endpoint = Endpoint(
+BATCH_INDEX_QUOTES: Endpoint[BatchQuote] = Endpoint(
     name="batch_index_quotes",
     path="batch-index-quotes",
     version=APIVersion.STABLE,
@@ -287,7 +287,7 @@ BATCH_INDEX_QUOTES: Endpoint = Endpoint(
     ],
 )
 
-BATCH_MARKET_CAP: Endpoint = Endpoint(
+BATCH_MARKET_CAP: Endpoint[BatchMarketCap] = Endpoint(
     name="batch_market_cap",
     path="market-capitalization-batch",
     version=APIVersion.STABLE,

--- a/fmp_data/batch/mapping.py
+++ b/fmp_data/batch/mapping.py
@@ -1,6 +1,8 @@
 # fmp_data/batch/mapping.py
 from __future__ import annotations
 
+from typing import Any
+
 from fmp_data.batch.endpoints import (
     BALANCE_SHEET_STATEMENT_BULK,
     BALANCE_SHEET_STATEMENT_GROWTH_BULK,
@@ -41,6 +43,7 @@ from fmp_data.lc.hints import (
     YEAR_HINT,
 )
 from fmp_data.lc.models import EndpointSemantics, ParameterHint, SemanticCategory
+from fmp_data.models import Endpoint
 
 # Batch-only concepts, so they live here rather than in fmp_data.lc.hints.
 SHORT_HINT = ParameterHint(
@@ -63,7 +66,7 @@ PART_HINT = ParameterHint(
 )
 
 # Batch endpoints mapping
-BATCH_ENDPOINT_MAP = {
+BATCH_ENDPOINT_MAP: dict[str, Endpoint[Any]] = {
     "get_quotes": BATCH_QUOTE,
     "get_quotes_short": BATCH_QUOTE_SHORT,
     "get_aftermarket_trades": BATCH_AFTERMARKET_TRADE,

--- a/fmp_data/index/async_client.py
+++ b/fmp_data/index/async_client.py
@@ -25,7 +25,9 @@ class AsyncIndexClient(AsyncEndpointGroup):
         Returns:
             List of S&P 500 constituent companies
         """
-        return await self.client.request_async(SP500_CONSTITUENTS)
+        return self._unwrap_list(
+            await self.client.request_async(SP500_CONSTITUENTS), IndexConstituent
+        )
 
     async def get_nasdaq_constituents(self) -> list[IndexConstituent]:
         """Get current NASDAQ index constituents
@@ -33,7 +35,9 @@ class AsyncIndexClient(AsyncEndpointGroup):
         Returns:
             List of NASDAQ constituent companies
         """
-        return await self.client.request_async(NASDAQ_CONSTITUENTS)
+        return self._unwrap_list(
+            await self.client.request_async(NASDAQ_CONSTITUENTS), IndexConstituent
+        )
 
     async def get_dowjones_constituents(self) -> list[IndexConstituent]:
         """Get current Dow Jones Industrial Average constituents
@@ -41,7 +45,9 @@ class AsyncIndexClient(AsyncEndpointGroup):
         Returns:
             List of Dow Jones constituent companies
         """
-        return await self.client.request_async(DOWJONES_CONSTITUENTS)
+        return self._unwrap_list(
+            await self.client.request_async(DOWJONES_CONSTITUENTS), IndexConstituent
+        )
 
     async def get_historical_sp500(self) -> list[HistoricalIndexConstituent]:
         """Get historical S&P 500 constituent changes
@@ -49,7 +55,10 @@ class AsyncIndexClient(AsyncEndpointGroup):
         Returns:
             List of historical constituent additions and removals
         """
-        return await self.client.request_async(HISTORICAL_SP500)
+        return self._unwrap_list(
+            await self.client.request_async(HISTORICAL_SP500),
+            HistoricalIndexConstituent,
+        )
 
     async def get_historical_nasdaq(self) -> list[HistoricalIndexConstituent]:
         """Get historical NASDAQ constituent changes
@@ -57,7 +66,10 @@ class AsyncIndexClient(AsyncEndpointGroup):
         Returns:
             List of historical constituent additions and removals
         """
-        return await self.client.request_async(HISTORICAL_NASDAQ)
+        return self._unwrap_list(
+            await self.client.request_async(HISTORICAL_NASDAQ),
+            HistoricalIndexConstituent,
+        )
 
     async def get_historical_dowjones(self) -> list[HistoricalIndexConstituent]:
         """Get historical Dow Jones constituent changes
@@ -65,4 +77,7 @@ class AsyncIndexClient(AsyncEndpointGroup):
         Returns:
             List of historical constituent additions and removals
         """
-        return await self.client.request_async(HISTORICAL_DOWJONES)
+        return self._unwrap_list(
+            await self.client.request_async(HISTORICAL_DOWJONES),
+            HistoricalIndexConstituent,
+        )

--- a/fmp_data/index/client.py
+++ b/fmp_data/index/client.py
@@ -23,7 +23,9 @@ class IndexClient(EndpointGroup):
         Returns:
             List of S&P 500 constituent companies
         """
-        return self.client.request(SP500_CONSTITUENTS)
+        return self._unwrap_list(
+            self.client.request(SP500_CONSTITUENTS), IndexConstituent
+        )
 
     def get_nasdaq_constituents(self) -> list[IndexConstituent]:
         """Get current NASDAQ index constituents
@@ -31,7 +33,9 @@ class IndexClient(EndpointGroup):
         Returns:
             List of NASDAQ constituent companies
         """
-        return self.client.request(NASDAQ_CONSTITUENTS)
+        return self._unwrap_list(
+            self.client.request(NASDAQ_CONSTITUENTS), IndexConstituent
+        )
 
     def get_dowjones_constituents(self) -> list[IndexConstituent]:
         """Get current Dow Jones Industrial Average constituents
@@ -39,7 +43,9 @@ class IndexClient(EndpointGroup):
         Returns:
             List of Dow Jones constituent companies
         """
-        return self.client.request(DOWJONES_CONSTITUENTS)
+        return self._unwrap_list(
+            self.client.request(DOWJONES_CONSTITUENTS), IndexConstituent
+        )
 
     def get_historical_sp500(self) -> list[HistoricalIndexConstituent]:
         """Get historical S&P 500 constituent changes
@@ -47,7 +53,9 @@ class IndexClient(EndpointGroup):
         Returns:
             List of historical constituent additions and removals
         """
-        return self.client.request(HISTORICAL_SP500)
+        return self._unwrap_list(
+            self.client.request(HISTORICAL_SP500), HistoricalIndexConstituent
+        )
 
     def get_historical_nasdaq(self) -> list[HistoricalIndexConstituent]:
         """Get historical NASDAQ constituent changes
@@ -55,7 +63,9 @@ class IndexClient(EndpointGroup):
         Returns:
             List of historical constituent additions and removals
         """
-        return self.client.request(HISTORICAL_NASDAQ)
+        return self._unwrap_list(
+            self.client.request(HISTORICAL_NASDAQ), HistoricalIndexConstituent
+        )
 
     def get_historical_dowjones(self) -> list[HistoricalIndexConstituent]:
         """Get historical Dow Jones constituent changes
@@ -63,4 +73,6 @@ class IndexClient(EndpointGroup):
         Returns:
             List of historical constituent additions and removals
         """
-        return self.client.request(HISTORICAL_DOWJONES)
+        return self._unwrap_list(
+            self.client.request(HISTORICAL_DOWJONES), HistoricalIndexConstituent
+        )

--- a/fmp_data/index/endpoints.py
+++ b/fmp_data/index/endpoints.py
@@ -7,7 +7,7 @@ from fmp_data.models import (
     URLType,
 )
 
-SP500_CONSTITUENTS: Endpoint = Endpoint(
+SP500_CONSTITUENTS: Endpoint[IndexConstituent] = Endpoint(
     name="sp500_constituents",
     path="sp500-constituent",
     version=APIVersion.STABLE,
@@ -24,7 +24,7 @@ SP500_CONSTITUENTS: Endpoint = Endpoint(
     ],
 )
 
-NASDAQ_CONSTITUENTS: Endpoint = Endpoint(
+NASDAQ_CONSTITUENTS: Endpoint[IndexConstituent] = Endpoint(
     name="nasdaq_constituents",
     path="nasdaq-constituent",
     version=APIVersion.STABLE,
@@ -41,7 +41,7 @@ NASDAQ_CONSTITUENTS: Endpoint = Endpoint(
     ],
 )
 
-DOWJONES_CONSTITUENTS: Endpoint = Endpoint(
+DOWJONES_CONSTITUENTS: Endpoint[IndexConstituent] = Endpoint(
     name="dowjones_constituents",
     path="dowjones-constituent",
     version=APIVersion.STABLE,
@@ -58,7 +58,7 @@ DOWJONES_CONSTITUENTS: Endpoint = Endpoint(
     ],
 )
 
-HISTORICAL_SP500: Endpoint = Endpoint(
+HISTORICAL_SP500: Endpoint[HistoricalIndexConstituent] = Endpoint(
     name="historical_sp500",
     path="historical-sp500-constituent",
     version=APIVersion.STABLE,
@@ -75,7 +75,7 @@ HISTORICAL_SP500: Endpoint = Endpoint(
     ],
 )
 
-HISTORICAL_NASDAQ: Endpoint = Endpoint(
+HISTORICAL_NASDAQ: Endpoint[HistoricalIndexConstituent] = Endpoint(
     name="historical_nasdaq",
     path="historical-nasdaq-constituent",
     version=APIVersion.STABLE,
@@ -92,7 +92,7 @@ HISTORICAL_NASDAQ: Endpoint = Endpoint(
     ],
 )
 
-HISTORICAL_DOWJONES: Endpoint = Endpoint(
+HISTORICAL_DOWJONES: Endpoint[HistoricalIndexConstituent] = Endpoint(
     name="historical_dowjones",
     path="historical-dowjones-constituent",
     version=APIVersion.STABLE,

--- a/fmp_data/index/mapping.py
+++ b/fmp_data/index/mapping.py
@@ -1,6 +1,8 @@
 # fmp_data/index/mapping.py
 from __future__ import annotations
 
+from typing import Any
+
 from fmp_data.index.endpoints import (
     DOWJONES_CONSTITUENTS,
     HISTORICAL_DOWJONES,
@@ -10,9 +12,10 @@ from fmp_data.index.endpoints import (
     SP500_CONSTITUENTS,
 )
 from fmp_data.lc.models import EndpointSemantics, SemanticCategory
+from fmp_data.models import Endpoint
 
 # Index endpoints mapping
-INDEX_ENDPOINT_MAP = {
+INDEX_ENDPOINT_MAP: dict[str, Endpoint[Any]] = {
     "get_sp500_constituents": SP500_CONSTITUENTS,
     "get_nasdaq_constituents": NASDAQ_CONSTITUENTS,
     "get_dowjones_constituents": DOWJONES_CONSTITUENTS,

--- a/fmp_data/sec/async_client.py
+++ b/fmp_data/sec/async_client.py
@@ -58,14 +58,17 @@ class AsyncSECClient(AsyncEndpointGroup):
         """
         end_date = to_date or date.today()
         start_date = from_date or (end_date - timedelta(days=30))
-        return await self.client.request_async(
-            SEC_FILINGS_8K,
-            page=page,
-            limit=limit,
-            **{
-                "from": start_date.strftime("%Y-%m-%d"),
-                "to": end_date.strftime("%Y-%m-%d"),
-            },
+        return self._unwrap_list(
+            await self.client.request_async(
+                SEC_FILINGS_8K,
+                page=page,
+                limit=limit,
+                **{
+                    "from": start_date.strftime("%Y-%m-%d"),
+                    "to": end_date.strftime("%Y-%m-%d"),
+                },
+            ),
+            SECFiling8K,
         )
 
     async def get_latest_financials(
@@ -88,14 +91,17 @@ class AsyncSECClient(AsyncEndpointGroup):
         """
         end_date = to_date or date.today()
         start_date = from_date or (end_date - timedelta(days=30))
-        return await self.client.request_async(
-            SEC_FILINGS_FINANCIALS,
-            page=page,
-            limit=limit,
-            **{
-                "from": start_date.strftime("%Y-%m-%d"),
-                "to": end_date.strftime("%Y-%m-%d"),
-            },
+        return self._unwrap_list(
+            await self.client.request_async(
+                SEC_FILINGS_FINANCIALS,
+                page=page,
+                limit=limit,
+                **{
+                    "from": start_date.strftime("%Y-%m-%d"),
+                    "to": end_date.strftime("%Y-%m-%d"),
+                },
+            ),
+            SECFinancialFiling,
         )
 
     async def search_by_form_type(
@@ -118,15 +124,18 @@ class AsyncSECClient(AsyncEndpointGroup):
         """
         end_date = to_date or date.today()
         start_date = from_date or (end_date - timedelta(days=30))
-        return await self.client.request_async(
-            SEC_FILINGS_SEARCH_FORM_TYPE,
-            formType=form_type,
-            page=page,
-            limit=limit,
-            **{
-                "from": start_date.strftime("%Y-%m-%d"),
-                "to": end_date.strftime("%Y-%m-%d"),
-            },
+        return self._unwrap_list(
+            await self.client.request_async(
+                SEC_FILINGS_SEARCH_FORM_TYPE,
+                formType=form_type,
+                page=page,
+                limit=limit,
+                **{
+                    "from": start_date.strftime("%Y-%m-%d"),
+                    "to": end_date.strftime("%Y-%m-%d"),
+                },
+            ),
+            SECFilingSearchResult,
         )
 
     async def search_by_symbol(
@@ -149,15 +158,18 @@ class AsyncSECClient(AsyncEndpointGroup):
         """
         end_date = to_date or date.today()
         start_date = from_date or (end_date - timedelta(days=30))
-        return await self.client.request_async(
-            SEC_FILINGS_SEARCH_SYMBOL,
-            symbol=symbol,
-            page=page,
-            limit=limit,
-            **{
-                "from": start_date.strftime("%Y-%m-%d"),
-                "to": end_date.strftime("%Y-%m-%d"),
-            },
+        return self._unwrap_list(
+            await self.client.request_async(
+                SEC_FILINGS_SEARCH_SYMBOL,
+                symbol=symbol,
+                page=page,
+                limit=limit,
+                **{
+                    "from": start_date.strftime("%Y-%m-%d"),
+                    "to": end_date.strftime("%Y-%m-%d"),
+                },
+            ),
+            SECFilingSearchResult,
         )
 
     async def search_by_cik(
@@ -180,15 +192,18 @@ class AsyncSECClient(AsyncEndpointGroup):
         """
         end_date = to_date or date.today()
         start_date = from_date or (end_date - timedelta(days=30))
-        return await self.client.request_async(
-            SEC_FILINGS_SEARCH_CIK,
-            cik=cik,
-            page=page,
-            limit=limit,
-            **{
-                "from": start_date.strftime("%Y-%m-%d"),
-                "to": end_date.strftime("%Y-%m-%d"),
-            },
+        return self._unwrap_list(
+            await self.client.request_async(
+                SEC_FILINGS_SEARCH_CIK,
+                cik=cik,
+                page=page,
+                limit=limit,
+                **{
+                    "from": start_date.strftime("%Y-%m-%d"),
+                    "to": end_date.strftime("%Y-%m-%d"),
+                },
+            ),
+            SECFilingSearchResult,
         )
 
     async def search_company_by_name(
@@ -207,8 +222,11 @@ class AsyncSECClient(AsyncEndpointGroup):
         Returns:
             List of matching companies
         """
-        return await self.client.request_async(
-            SEC_COMPANY_SEARCH_NAME, company=name, page=page, limit=limit
+        return self._unwrap_list(
+            await self.client.request_async(
+                SEC_COMPANY_SEARCH_NAME, company=name, page=page, limit=limit
+            ),
+            SECCompanySearchResult,
         )
 
     async def search_company_by_symbol(
@@ -222,7 +240,10 @@ class AsyncSECClient(AsyncEndpointGroup):
         Returns:
             List of matching companies
         """
-        return await self.client.request_async(SEC_COMPANY_SEARCH_SYMBOL, symbol=symbol)
+        return self._unwrap_list(
+            await self.client.request_async(SEC_COMPANY_SEARCH_SYMBOL, symbol=symbol),
+            SECCompanySearchResult,
+        )
 
     async def search_company_by_cik(
         self, cik: str | int
@@ -235,7 +256,10 @@ class AsyncSECClient(AsyncEndpointGroup):
         Returns:
             List of matching companies
         """
-        return await self.client.request_async(SEC_COMPANY_SEARCH_CIK, cik=cik)
+        return self._unwrap_list(
+            await self.client.request_async(SEC_COMPANY_SEARCH_CIK, cik=cik),
+            SECCompanySearchResult,
+        )
 
     async def get_profile(self, symbol: str) -> SECProfile | None:
         """Get SEC profile for a company
@@ -262,7 +286,7 @@ class AsyncSECClient(AsyncEndpointGroup):
         Returns:
             List of SIC codes
         """
-        return await self.client.request_async(SIC_LIST)
+        return self._unwrap_list(await self.client.request_async(SIC_LIST), SICCode)
 
     async def search_industry_classification(
         self,
@@ -289,7 +313,10 @@ class AsyncSECClient(AsyncEndpointGroup):
             params["cik"] = cik
         if sic_code:
             params["sicCode"] = sic_code
-        return await self.client.request_async(INDUSTRY_CLASSIFICATION_SEARCH, **params)
+        return self._unwrap_list(
+            await self.client.request_async(INDUSTRY_CLASSIFICATION_SEARCH, **params),
+            IndustryClassification,
+        )
 
     async def get_all_industry_classification(
         self, page: int = 0, limit: int = 100
@@ -303,6 +330,9 @@ class AsyncSECClient(AsyncEndpointGroup):
         Returns:
             List of industry classification records
         """
-        return await self.client.request_async(
-            ALL_INDUSTRY_CLASSIFICATION, page=page, limit=limit
+        return self._unwrap_list(
+            await self.client.request_async(
+                ALL_INDUSTRY_CLASSIFICATION, page=page, limit=limit
+            ),
+            IndustryClassification,
         )

--- a/fmp_data/sec/client.py
+++ b/fmp_data/sec/client.py
@@ -56,14 +56,17 @@ class SECClient(EndpointGroup):
         """
         end_date = to_date or date.today()
         start_date = from_date or (end_date - timedelta(days=30))
-        return self.client.request(
-            SEC_FILINGS_8K,
-            page=page,
-            limit=limit,
-            **{
-                "from": start_date.strftime("%Y-%m-%d"),
-                "to": end_date.strftime("%Y-%m-%d"),
-            },
+        return self._unwrap_list(
+            self.client.request(
+                SEC_FILINGS_8K,
+                page=page,
+                limit=limit,
+                **{
+                    "from": start_date.strftime("%Y-%m-%d"),
+                    "to": end_date.strftime("%Y-%m-%d"),
+                },
+            ),
+            SECFiling8K,
         )
 
     def get_latest_financials(
@@ -86,14 +89,17 @@ class SECClient(EndpointGroup):
         """
         end_date = to_date or date.today()
         start_date = from_date or (end_date - timedelta(days=30))
-        return self.client.request(
-            SEC_FILINGS_FINANCIALS,
-            page=page,
-            limit=limit,
-            **{
-                "from": start_date.strftime("%Y-%m-%d"),
-                "to": end_date.strftime("%Y-%m-%d"),
-            },
+        return self._unwrap_list(
+            self.client.request(
+                SEC_FILINGS_FINANCIALS,
+                page=page,
+                limit=limit,
+                **{
+                    "from": start_date.strftime("%Y-%m-%d"),
+                    "to": end_date.strftime("%Y-%m-%d"),
+                },
+            ),
+            SECFinancialFiling,
         )
 
     def search_by_form_type(
@@ -116,15 +122,18 @@ class SECClient(EndpointGroup):
         """
         end_date = to_date or date.today()
         start_date = from_date or (end_date - timedelta(days=30))
-        return self.client.request(
-            SEC_FILINGS_SEARCH_FORM_TYPE,
-            formType=form_type,
-            page=page,
-            limit=limit,
-            **{
-                "from": start_date.strftime("%Y-%m-%d"),
-                "to": end_date.strftime("%Y-%m-%d"),
-            },
+        return self._unwrap_list(
+            self.client.request(
+                SEC_FILINGS_SEARCH_FORM_TYPE,
+                formType=form_type,
+                page=page,
+                limit=limit,
+                **{
+                    "from": start_date.strftime("%Y-%m-%d"),
+                    "to": end_date.strftime("%Y-%m-%d"),
+                },
+            ),
+            SECFilingSearchResult,
         )
 
     def search_by_symbol(
@@ -147,15 +156,18 @@ class SECClient(EndpointGroup):
         """
         end_date = to_date or date.today()
         start_date = from_date or (end_date - timedelta(days=30))
-        return self.client.request(
-            SEC_FILINGS_SEARCH_SYMBOL,
-            symbol=symbol,
-            page=page,
-            limit=limit,
-            **{
-                "from": start_date.strftime("%Y-%m-%d"),
-                "to": end_date.strftime("%Y-%m-%d"),
-            },
+        return self._unwrap_list(
+            self.client.request(
+                SEC_FILINGS_SEARCH_SYMBOL,
+                symbol=symbol,
+                page=page,
+                limit=limit,
+                **{
+                    "from": start_date.strftime("%Y-%m-%d"),
+                    "to": end_date.strftime("%Y-%m-%d"),
+                },
+            ),
+            SECFilingSearchResult,
         )
 
     def search_by_cik(
@@ -178,15 +190,18 @@ class SECClient(EndpointGroup):
         """
         end_date = to_date or date.today()
         start_date = from_date or (end_date - timedelta(days=30))
-        return self.client.request(
-            SEC_FILINGS_SEARCH_CIK,
-            cik=cik,
-            page=page,
-            limit=limit,
-            **{
-                "from": start_date.strftime("%Y-%m-%d"),
-                "to": end_date.strftime("%Y-%m-%d"),
-            },
+        return self._unwrap_list(
+            self.client.request(
+                SEC_FILINGS_SEARCH_CIK,
+                cik=cik,
+                page=page,
+                limit=limit,
+                **{
+                    "from": start_date.strftime("%Y-%m-%d"),
+                    "to": end_date.strftime("%Y-%m-%d"),
+                },
+            ),
+            SECFilingSearchResult,
         )
 
     def search_company_by_name(
@@ -205,8 +220,11 @@ class SECClient(EndpointGroup):
         Returns:
             List of matching companies
         """
-        return self.client.request(
-            SEC_COMPANY_SEARCH_NAME, company=name, page=page, limit=limit
+        return self._unwrap_list(
+            self.client.request(
+                SEC_COMPANY_SEARCH_NAME, company=name, page=page, limit=limit
+            ),
+            SECCompanySearchResult,
         )
 
     def search_company_by_symbol(self, symbol: str) -> list[SECCompanySearchResult]:
@@ -218,7 +236,10 @@ class SECClient(EndpointGroup):
         Returns:
             List of matching companies
         """
-        return self.client.request(SEC_COMPANY_SEARCH_SYMBOL, symbol=symbol)
+        return self._unwrap_list(
+            self.client.request(SEC_COMPANY_SEARCH_SYMBOL, symbol=symbol),
+            SECCompanySearchResult,
+        )
 
     def search_company_by_cik(self, cik: str | int) -> list[SECCompanySearchResult]:
         """Search SEC companies by CIK number
@@ -229,7 +250,10 @@ class SECClient(EndpointGroup):
         Returns:
             List of matching companies
         """
-        return self.client.request(SEC_COMPANY_SEARCH_CIK, cik=cik)
+        return self._unwrap_list(
+            self.client.request(SEC_COMPANY_SEARCH_CIK, cik=cik),
+            SECCompanySearchResult,
+        )
 
     def get_profile(self, symbol: str) -> SECProfile | None:
         """Get SEC profile for a company
@@ -256,7 +280,7 @@ class SECClient(EndpointGroup):
         Returns:
             List of SIC codes
         """
-        return self.client.request(SIC_LIST)
+        return self._unwrap_list(self.client.request(SIC_LIST), SICCode)
 
     def search_industry_classification(
         self,
@@ -283,7 +307,10 @@ class SECClient(EndpointGroup):
             params["cik"] = cik
         if sic_code:
             params["sicCode"] = sic_code
-        return self.client.request(INDUSTRY_CLASSIFICATION_SEARCH, **params)
+        return self._unwrap_list(
+            self.client.request(INDUSTRY_CLASSIFICATION_SEARCH, **params),
+            IndustryClassification,
+        )
 
     def get_all_industry_classification(
         self, page: int = 0, limit: int = 100
@@ -297,4 +324,7 @@ class SECClient(EndpointGroup):
         Returns:
             List of industry classification records
         """
-        return self.client.request(ALL_INDUSTRY_CLASSIFICATION, page=page, limit=limit)
+        return self._unwrap_list(
+            self.client.request(ALL_INDUSTRY_CLASSIFICATION, page=page, limit=limit),
+            IndustryClassification,
+        )

--- a/fmp_data/sec/endpoints.py
+++ b/fmp_data/sec/endpoints.py
@@ -18,7 +18,7 @@ from fmp_data.sec.models import (
     SICCode,
 )
 
-SEC_FILINGS_8K: Endpoint = Endpoint(
+SEC_FILINGS_8K: Endpoint[SECFiling8K] = Endpoint(
     name="sec_filings_8k",
     path="sec-filings-8k",
     version=APIVersion.STABLE,
@@ -63,7 +63,7 @@ SEC_FILINGS_8K: Endpoint = Endpoint(
     ],
 )
 
-SEC_FILINGS_FINANCIALS: Endpoint = Endpoint(
+SEC_FILINGS_FINANCIALS: Endpoint[SECFinancialFiling] = Endpoint(
     name="sec_filings_financials",
     path="sec-filings-financials",
     version=APIVersion.STABLE,
@@ -108,7 +108,7 @@ SEC_FILINGS_FINANCIALS: Endpoint = Endpoint(
     ],
 )
 
-SEC_FILINGS_SEARCH_FORM_TYPE: Endpoint = Endpoint(
+SEC_FILINGS_SEARCH_FORM_TYPE: Endpoint[SECFilingSearchResult] = Endpoint(
     name="sec_filings_search_form_type",
     path="sec-filings-search/form-type",
     version=APIVersion.STABLE,
@@ -159,7 +159,7 @@ SEC_FILINGS_SEARCH_FORM_TYPE: Endpoint = Endpoint(
     ],
 )
 
-SEC_FILINGS_SEARCH_SYMBOL: Endpoint = Endpoint(
+SEC_FILINGS_SEARCH_SYMBOL: Endpoint[SECFilingSearchResult] = Endpoint(
     name="sec_filings_search_symbol",
     path="sec-filings-search/symbol",
     version=APIVersion.STABLE,
@@ -210,7 +210,7 @@ SEC_FILINGS_SEARCH_SYMBOL: Endpoint = Endpoint(
     ],
 )
 
-SEC_FILINGS_SEARCH_CIK: Endpoint = Endpoint(
+SEC_FILINGS_SEARCH_CIK: Endpoint[SECFilingSearchResult] = Endpoint(
     name="sec_filings_search_cik",
     path="sec-filings-search/cik",
     version=APIVersion.STABLE,
@@ -261,7 +261,7 @@ SEC_FILINGS_SEARCH_CIK: Endpoint = Endpoint(
     ],
 )
 
-SEC_COMPANY_SEARCH_NAME: Endpoint = Endpoint(
+SEC_COMPANY_SEARCH_NAME: Endpoint[SECCompanySearchResult] = Endpoint(
     name="sec_company_search_name",
     path="sec-filings-company-search/name",
     version=APIVersion.STABLE,
@@ -300,7 +300,7 @@ SEC_COMPANY_SEARCH_NAME: Endpoint = Endpoint(
     ],
 )
 
-SEC_COMPANY_SEARCH_SYMBOL: Endpoint = Endpoint(
+SEC_COMPANY_SEARCH_SYMBOL: Endpoint[SECCompanySearchResult] = Endpoint(
     name="sec_company_search_symbol",
     path="sec-filings-company-search/symbol",
     version=APIVersion.STABLE,
@@ -324,7 +324,7 @@ SEC_COMPANY_SEARCH_SYMBOL: Endpoint = Endpoint(
     ],
 )
 
-SEC_COMPANY_SEARCH_CIK: Endpoint = Endpoint(
+SEC_COMPANY_SEARCH_CIK: Endpoint[SECCompanySearchResult] = Endpoint(
     name="sec_company_search_cik",
     path="sec-filings-company-search/cik",
     version=APIVersion.STABLE,
@@ -372,7 +372,7 @@ SEC_PROFILE: Endpoint[SECProfile] = Endpoint(
     ],
 )
 
-SIC_LIST: Endpoint = Endpoint(
+SIC_LIST: Endpoint[SICCode] = Endpoint(
     name="sic_list",
     path="standard-industrial-classification-list",
     version=APIVersion.STABLE,
@@ -389,7 +389,7 @@ SIC_LIST: Endpoint = Endpoint(
     ],
 )
 
-INDUSTRY_CLASSIFICATION_SEARCH: Endpoint = Endpoint(
+INDUSTRY_CLASSIFICATION_SEARCH: Endpoint[IndustryClassification] = Endpoint(
     name="industry_classification_search",
     path="industry-classification-search",
     version=APIVersion.STABLE,
@@ -432,7 +432,7 @@ INDUSTRY_CLASSIFICATION_SEARCH: Endpoint = Endpoint(
     ],
 )
 
-ALL_INDUSTRY_CLASSIFICATION: Endpoint = Endpoint(
+ALL_INDUSTRY_CLASSIFICATION: Endpoint[IndustryClassification] = Endpoint(
     name="all_industry_classification",
     path="all-industry-classification",
     version=APIVersion.STABLE,

--- a/fmp_data/sec/mapping.py
+++ b/fmp_data/sec/mapping.py
@@ -1,6 +1,8 @@
 # fmp_data/sec/mapping.py
 from __future__ import annotations
 
+from typing import Any
+
 from fmp_data.lc.hints import (
     CIK_HINT,
     FROM_TO_DATE_HINTS,
@@ -9,6 +11,7 @@ from fmp_data.lc.hints import (
     SYMBOL_HINT,
 )
 from fmp_data.lc.models import EndpointSemantics, ParameterHint, SemanticCategory
+from fmp_data.models import Endpoint
 from fmp_data.sec.endpoints import (
     ALL_INDUSTRY_CLASSIFICATION,
     INDUSTRY_CLASSIFICATION_SEARCH,
@@ -57,7 +60,7 @@ COMPANY_NAME_HINT = ParameterHint(
 )
 
 # SEC endpoints mapping
-SEC_ENDPOINT_MAP = {
+SEC_ENDPOINT_MAP: dict[str, Endpoint[Any]] = {
     "get_latest_8k": SEC_FILINGS_8K,
     "get_latest_financials": SEC_FILINGS_FINANCIALS,
     "search_by_form_type": SEC_FILINGS_SEARCH_FORM_TYPE,

--- a/fmp_data/transcripts/async_client.py
+++ b/fmp_data/transcripts/async_client.py
@@ -33,8 +33,9 @@ class AsyncTranscriptsClient(AsyncEndpointGroup):
         Returns:
             List of recent earnings transcripts
         """
-        return await self.client.request_async(
-            LATEST_TRANSCRIPTS, page=page, limit=limit
+        return self._unwrap_list(
+            await self.client.request_async(LATEST_TRANSCRIPTS, page=page, limit=limit),
+            EarningsTranscript,
         )
 
     async def get_transcript(
@@ -62,7 +63,10 @@ class AsyncTranscriptsClient(AsyncEndpointGroup):
         }
         if limit is not None:
             params["limit"] = limit
-        return await self.client.request_async(EARNINGS_TRANSCRIPT, **params)
+        return self._unwrap_list(
+            await self.client.request_async(EARNINGS_TRANSCRIPT, **params),
+            EarningsTranscript,
+        )
 
     async def get_available_dates(self, symbol: str) -> list[TranscriptDate]:
         """Get available transcript dates for a specific company
@@ -73,7 +77,10 @@ class AsyncTranscriptsClient(AsyncEndpointGroup):
         Returns:
             List of available transcript dates
         """
-        return await self.client.request_async(TRANSCRIPT_DATES, symbol=symbol)
+        return self._unwrap_list(
+            await self.client.request_async(TRANSCRIPT_DATES, symbol=symbol),
+            TranscriptDate,
+        )
 
     async def get_available_symbols(self) -> list[TranscriptSymbol]:
         """Get list of all symbols with available earnings transcripts
@@ -81,4 +88,6 @@ class AsyncTranscriptsClient(AsyncEndpointGroup):
         Returns:
             List of symbols with transcripts
         """
-        return await self.client.request_async(TRANSCRIPT_SYMBOLS)
+        return self._unwrap_list(
+            await self.client.request_async(TRANSCRIPT_SYMBOLS), TranscriptSymbol
+        )

--- a/fmp_data/transcripts/client.py
+++ b/fmp_data/transcripts/client.py
@@ -29,7 +29,10 @@ class TranscriptsClient(EndpointGroup):
         Returns:
             List of recent earnings transcripts
         """
-        return self.client.request(LATEST_TRANSCRIPTS, page=page, limit=limit)
+        return self._unwrap_list(
+            self.client.request(LATEST_TRANSCRIPTS, page=page, limit=limit),
+            EarningsTranscript,
+        )
 
     def get_transcript(
         self,
@@ -56,7 +59,10 @@ class TranscriptsClient(EndpointGroup):
         }
         if limit is not None:
             params["limit"] = limit
-        return self.client.request(EARNINGS_TRANSCRIPT, **params)
+        return self._unwrap_list(
+            self.client.request(EARNINGS_TRANSCRIPT, **params),
+            EarningsTranscript,
+        )
 
     def get_available_dates(self, symbol: str) -> list[TranscriptDate]:
         """Get available transcript dates for a specific company
@@ -67,7 +73,9 @@ class TranscriptsClient(EndpointGroup):
         Returns:
             List of available transcript dates
         """
-        return self.client.request(TRANSCRIPT_DATES, symbol=symbol)
+        return self._unwrap_list(
+            self.client.request(TRANSCRIPT_DATES, symbol=symbol), TranscriptDate
+        )
 
     def get_available_symbols(self) -> list[TranscriptSymbol]:
         """Get list of all symbols with available earnings transcripts
@@ -75,4 +83,6 @@ class TranscriptsClient(EndpointGroup):
         Returns:
             List of symbols with transcripts
         """
-        return self.client.request(TRANSCRIPT_SYMBOLS)
+        return self._unwrap_list(
+            self.client.request(TRANSCRIPT_SYMBOLS), TranscriptSymbol
+        )

--- a/fmp_data/transcripts/endpoints.py
+++ b/fmp_data/transcripts/endpoints.py
@@ -14,7 +14,7 @@ from fmp_data.transcripts.models import (
     TranscriptSymbol,
 )
 
-LATEST_TRANSCRIPTS: Endpoint = Endpoint(
+LATEST_TRANSCRIPTS: Endpoint[EarningsTranscript] = Endpoint(
     name="latest_transcripts",
     path="earning-call-transcript-latest",
     version=APIVersion.STABLE,
@@ -46,7 +46,7 @@ LATEST_TRANSCRIPTS: Endpoint = Endpoint(
     ],
 )
 
-EARNINGS_TRANSCRIPT: Endpoint = Endpoint(
+EARNINGS_TRANSCRIPT: Endpoint[EarningsTranscript] = Endpoint(
     name="earnings_transcript",
     path="earning-call-transcript",
     version=APIVersion.STABLE,
@@ -90,7 +90,7 @@ EARNINGS_TRANSCRIPT: Endpoint = Endpoint(
     ],
 )
 
-TRANSCRIPT_DATES: Endpoint = Endpoint(
+TRANSCRIPT_DATES: Endpoint[TranscriptDate] = Endpoint(
     name="transcript_dates",
     path="earning-call-transcript-dates",
     version=APIVersion.STABLE,
@@ -114,7 +114,7 @@ TRANSCRIPT_DATES: Endpoint = Endpoint(
     ],
 )
 
-TRANSCRIPT_SYMBOLS: Endpoint = Endpoint(
+TRANSCRIPT_SYMBOLS: Endpoint[TranscriptSymbol] = Endpoint(
     name="transcript_symbols",
     path="earnings-transcript-list",
     version=APIVersion.STABLE,

--- a/fmp_data/transcripts/mapping.py
+++ b/fmp_data/transcripts/mapping.py
@@ -1,6 +1,8 @@
 # fmp_data/transcripts/mapping.py
 from __future__ import annotations
 
+from typing import Any
+
 from fmp_data.lc.hints import (
     LIMIT_HINT,
     PAGE_HINT,
@@ -9,6 +11,7 @@ from fmp_data.lc.hints import (
     YEAR_HINT,
 )
 from fmp_data.lc.models import EndpointSemantics, SemanticCategory
+from fmp_data.models import Endpoint
 from fmp_data.transcripts.endpoints import (
     EARNINGS_TRANSCRIPT,
     LATEST_TRANSCRIPTS,
@@ -17,7 +20,7 @@ from fmp_data.transcripts.endpoints import (
 )
 
 # Transcripts endpoints mapping
-TRANSCRIPTS_ENDPOINT_MAP = {
+TRANSCRIPTS_ENDPOINT_MAP: dict[str, Endpoint[Any]] = {
     "get_latest": LATEST_TRANSCRIPTS,
     "get_transcript": EARNINGS_TRANSCRIPT,
     "get_available_dates": TRANSCRIPT_DATES,

--- a/tests/unit/test_list_unwrap.py
+++ b/tests/unit/test_list_unwrap.py
@@ -14,6 +14,10 @@ from fmp_data.alternative.models import (
     CryptoPair,
     ForexPriceHistory,
 )
+from fmp_data.batch.async_client import AsyncBatchClient
+from fmp_data.batch.client import BatchClient
+from fmp_data.batch.endpoints import BATCH_MARKET_CAP, BATCH_QUOTE
+from fmp_data.batch.models import BatchMarketCap, BatchQuote
 from fmp_data.economics.async_client import AsyncEconomicsClient
 from fmp_data.economics.client import EconomicsClient
 from fmp_data.economics.endpoints import ECONOMIC_INDICATORS, TREASURY_RATES
@@ -22,6 +26,10 @@ from fmp_data.fundamental.async_client import AsyncFundamentalClient
 from fmp_data.fundamental.client import FundamentalClient
 from fmp_data.fundamental.endpoints import INCOME_STATEMENT, KEY_METRICS
 from fmp_data.fundamental.models import IncomeStatement, KeyMetrics
+from fmp_data.index.async_client import AsyncIndexClient
+from fmp_data.index.client import IndexClient
+from fmp_data.index.endpoints import HISTORICAL_SP500, SP500_CONSTITUENTS
+from fmp_data.index.models import HistoricalIndexConstituent, IndexConstituent
 from fmp_data.institutional.async_client import AsyncInstitutionalClient
 from fmp_data.institutional.client import InstitutionalClient
 from fmp_data.institutional.endpoints import FORM_13F_DATES, INSTITUTIONAL_HOLDERS
@@ -43,10 +51,27 @@ from fmp_data.market.endpoints import (
 )
 from fmp_data.market.models import MarketHours
 from fmp_data.models import CompanySymbol
+from fmp_data.sec.async_client import AsyncSECClient
+from fmp_data.sec.client import SECClient
+from fmp_data.sec.endpoints import SEC_FILINGS_8K, SEC_PROFILE, SIC_LIST
+from fmp_data.sec.models import SECFiling8K, SECProfile, SICCode
 from fmp_data.technical.async_client import AsyncTechnicalClient
 from fmp_data.technical.client import TechnicalClient
 from fmp_data.technical.endpoints import SMA
 from fmp_data.technical.models import SMAIndicator
+from fmp_data.transcripts.async_client import AsyncTranscriptsClient
+from fmp_data.transcripts.client import TranscriptsClient
+from fmp_data.transcripts.endpoints import (
+    EARNINGS_TRANSCRIPT,
+    LATEST_TRANSCRIPTS,
+    TRANSCRIPT_DATES,
+    TRANSCRIPT_SYMBOLS,
+)
+from fmp_data.transcripts.models import (
+    EarningsTranscript,
+    TranscriptDate,
+    TranscriptSymbol,
+)
 
 
 @pytest.fixture
@@ -123,6 +148,45 @@ _TECHNICAL_CASES = [
     ("get_sma", {"symbol": "AAPL"}),
     ("get_ema", {"symbol": "AAPL"}),
     ("get_rsi", {"symbol": "AAPL"}),
+]
+
+_INDEX_CASES: list[tuple[str, dict[str, object]]] = [
+    ("get_sp500_constituents", {}),
+    ("get_nasdaq_constituents", {}),
+    ("get_dowjones_constituents", {}),
+    ("get_historical_sp500", {}),
+    ("get_historical_nasdaq", {}),
+    ("get_historical_dowjones", {}),
+]
+
+_SEC_CASES: list[tuple[str, dict[str, object]]] = [
+    ("get_latest_8k", {}),
+    ("get_latest_financials", {}),
+    ("search_by_form_type", {"form_type": "8-K"}),
+    ("search_by_symbol", {"symbol": "AAPL"}),
+    ("search_company_by_name", {"name": "Apple"}),
+    ("search_company_by_symbol", {"symbol": "AAPL"}),
+    ("get_sic_codes", {}),
+    ("search_industry_classification", {"symbol": "AAPL"}),
+    ("get_all_industry_classification", {}),
+]
+
+_TRANSCRIPTS_CASES: list[tuple[str, dict[str, object]]] = [
+    ("get_latest", {}),
+    ("get_transcript", {"symbol": "AAPL", "year": 2024, "quarter": 1}),
+    ("get_available_dates", {"symbol": "AAPL"}),
+    ("get_available_symbols", {}),
+]
+
+_BATCH_CASES: list[tuple[str, dict[str, object]]] = [
+    ("get_quotes", {"symbols": ["AAPL"]}),
+    ("get_quotes_short", {"symbols": ["AAPL"]}),
+    ("get_aftermarket_trades", {"symbols": ["AAPL"]}),
+    ("get_aftermarket_quotes", {"symbols": ["AAPL"]}),
+    ("get_exchange_quotes", {"exchange": "NASDAQ"}),
+    ("get_etf_quotes", {}),
+    ("get_crypto_quotes", {}),
+    ("get_market_caps", {"symbols": ["AAPL"]}),
 ]
 
 
@@ -375,6 +439,84 @@ class TestAlternativeHistoryUnwrap:
         mock_validate.assert_called_with({"symbol": kwargs["symbol"], "historical": []})
 
 
+class TestIndexListUnwrap:
+    @pytest.mark.parametrize("method_name,kwargs", _INDEX_CASES)
+    def test_list_methods_wrap_single_and_keep_empty(
+        self, mock_client, method_name, kwargs
+    ):
+        _assert_wrap_single_and_empty(IndexClient(mock_client), method_name, kwargs)
+
+
+class TestSECListUnwrap:
+    @pytest.mark.parametrize("method_name,kwargs", _SEC_CASES)
+    def test_list_methods_wrap_single_and_keep_empty(
+        self, mock_client, method_name, kwargs
+    ):
+        _assert_wrap_single_and_empty(SECClient(mock_client), method_name, kwargs)
+
+
+class TestTranscriptsListUnwrap:
+    @pytest.mark.parametrize("method_name,kwargs", _TRANSCRIPTS_CASES)
+    def test_list_methods_wrap_single_and_keep_empty(
+        self, mock_client, method_name, kwargs
+    ):
+        _assert_wrap_single_and_empty(
+            TranscriptsClient(mock_client), method_name, kwargs
+        )
+
+
+class TestBatchListUnwrap:
+    @pytest.mark.parametrize("method_name,kwargs", _BATCH_CASES)
+    def test_list_methods_wrap_single_and_keep_empty(
+        self, mock_client, method_name, kwargs
+    ):
+        _assert_wrap_single_and_empty(BatchClient(mock_client), method_name, kwargs)
+
+
+class TestAsyncIndexListUnwrap:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method_name,kwargs", _INDEX_CASES)
+    async def test_list_methods_wrap_single_and_keep_empty(
+        self, mock_client, method_name, kwargs
+    ):
+        await _assert_wrap_single_and_empty_async(
+            AsyncIndexClient(mock_client), method_name, kwargs
+        )
+
+
+class TestAsyncSECListUnwrap:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method_name,kwargs", _SEC_CASES)
+    async def test_list_methods_wrap_single_and_keep_empty(
+        self, mock_client, method_name, kwargs
+    ):
+        await _assert_wrap_single_and_empty_async(
+            AsyncSECClient(mock_client), method_name, kwargs
+        )
+
+
+class TestAsyncTranscriptsListUnwrap:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method_name,kwargs", _TRANSCRIPTS_CASES)
+    async def test_list_methods_wrap_single_and_keep_empty(
+        self, mock_client, method_name, kwargs
+    ):
+        await _assert_wrap_single_and_empty_async(
+            AsyncTranscriptsClient(mock_client), method_name, kwargs
+        )
+
+
+class TestAsyncBatchListUnwrap:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method_name,kwargs", _BATCH_CASES)
+    async def test_list_methods_wrap_single_and_keep_empty(
+        self, mock_client, method_name, kwargs
+    ):
+        await _assert_wrap_single_and_empty_async(
+            AsyncBatchClient(mock_client), method_name, kwargs
+        )
+
+
 class TestPreviouslyUntypedEndpointRowBindings:
     @pytest.mark.parametrize(
         "endpoint,row_type",
@@ -395,6 +537,17 @@ class TestPreviouslyUntypedEndpointRowBindings:
             (TREASURY_RATES, TreasuryRate),
             (ECONOMIC_INDICATORS, EconomicIndicator),
             (SMA, SMAIndicator),
+            (SP500_CONSTITUENTS, IndexConstituent),
+            (HISTORICAL_SP500, HistoricalIndexConstituent),
+            (SEC_FILINGS_8K, SECFiling8K),
+            (SIC_LIST, SICCode),
+            (SEC_PROFILE, SECProfile),
+            (LATEST_TRANSCRIPTS, EarningsTranscript),
+            (EARNINGS_TRANSCRIPT, EarningsTranscript),
+            (TRANSCRIPT_DATES, TranscriptDate),
+            (TRANSCRIPT_SYMBOLS, TranscriptSymbol),
+            (BATCH_QUOTE, BatchQuote),
+            (BATCH_MARKET_CAP, BatchMarketCap),
         ],
     )
     def test_list_endpoints_bind_row_type(self, endpoint, row_type):


### PR DESCRIPTION
Closes #245.

#242 / #244 migrated the listed domains. This PR does the leftover surfaces that were outside that list:

1. Index constituents / historical constituents → `_unwrap_list` + `Endpoint[IndexConstituent]` / `Endpoint[HistoricalIndexConstituent]`.
2. SEC list surfaces → same helper. `get_profile` stays `_unwrap_single` (`Endpoint[SECProfile]`).
3. Transcripts: `LATEST_TRANSCRIPTS`, `TRANSCRIPT_DATES`, `TRANSCRIPT_SYMBOLS`, and `get_transcript` (`EARNINGS_TRANSCRIPT`). The method is already `list[EarningsTranscript]` (it takes `limit`), so it uses `_unwrap_list` rather than `_unwrap_single`. Switching it to `_unwrap_single` would raise on an empty list.
4. Batch JSON quote lists (`BATCH_QUOTE*`, aftermarket, exchange / asset-class quotes, market cap).

## What this does not do

- Does not collapse `request()` to `list[T]`.
- Does not switch methods to `request_list()`.
- Does not enable mypy `type-arg`.
- Does not use `Endpoint[list[T]]`.
- Does not unwrap bulk-bytes / CSV (`_request_csv` / `parse_csv_*`). That stays a follow-up.

## Tests

- `tests/unit/test_list_unwrap.py`: wrap-single / empty-list tables plus row-type bindings for index, SEC, transcripts, and batch quotes (sync and async).
- Targeted existing unit files: 490 passed.

Isolated worktree `fmp-data--feat-unwrap-list-leftover-245` off `origin/dev`.