### PR TITLE
feat(batch): type bulk-bytes endpoints as Endpoint[bytes]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,11 @@ None. No FMP path we ship was newly retired by this changelog window.
   `get_profile` stays `_unwrap_single`. Bulk-bytes / CSV paths stay on
   `_request_csv`. `request()` stays `T | list[T]`.
 
+- **Batch bulk-bytes / CSV endpoints are `Endpoint[bytes]` (#247).**
+  `PROFILE_BULK`, `EOD_BULK`, statement bulks, and the other CSV downloads
+  bind `bytes` (not a row type). `_request_csv` is the only bytes helper.
+  Quote lists stay on `_unwrap_list` (#246). `request()` stays `T | list[T]`.
+
 ### Added
 
 - **FMP hosted MCP vs `fmp-mcp` positioning (#230).** Docs-only: we are not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,9 +76,11 @@ None. No FMP path we ship was newly retired by this changelog window.
   `_request_csv`. `request()` stays `T | list[T]`.
 
 - **Batch bulk-bytes / CSV endpoints are `Endpoint[bytes]` (#247).**
-  `PROFILE_BULK`, `EOD_BULK`, statement bulks, and the other CSV downloads
-  bind `bytes` (not a row type). `_request_csv` is the only bytes helper.
-  Quote lists stay on `_unwrap_list` (#246). `request()` stays `T | list[T]`.
+  All 18 `*_BULK` CSV downloads bind `bytes` (not a row type). In batch,
+  `_request_csv` is the only bytes helper. Quote lists stay on
+  `_unwrap_list` (#246). `request()` stays `T | list[T]`.
+  `FINANCIAL_REPORTS_XLSX` is unchanged: company XLSX download, still a
+  bare `Endpoint`, not `_request_csv`.
 
 ### Added
 

--- a/fmp_data/batch/async_client.py
+++ b/fmp_data/batch/async_client.py
@@ -86,8 +86,9 @@ class AsyncBatchClient(AsyncEndpointGroup):
 
     async def _request_csv(self, endpoint: Endpoint[bytes], **params: Any) -> bytes:
         """Fetch a bulk CSV/bytes payload. Do not route these through _unwrap_list."""
-        # request_async() is typed T | list[T]; validate the payload ourselves
-        # so a mock bytearray or a mistaken list[bytes] cannot leak through.
+        # request_async() is typed T | list[T]; widen so a mock bytearray
+        # (not in the union) can be coerced and a mistaken list[bytes]
+        # is rejected.
         result = await self.client.request_async(endpoint, **params)
         payload: object = result
         if isinstance(payload, bytearray):

--- a/fmp_data/batch/async_client.py
+++ b/fmp_data/batch/async_client.py
@@ -84,20 +84,24 @@ class AsyncBatchClient(AsyncEndpointGroup):
     classes in a single API call.
     """
 
-    async def _request_csv(self, endpoint: Endpoint, **params: Any) -> bytes:
+    async def _request_csv(self, endpoint: Endpoint[bytes], **params: Any) -> bytes:
+        """Fetch a bulk CSV/bytes payload. Do not route these through _unwrap_list."""
+        # request_async() is typed T | list[T]; validate the payload ourselves
+        # so a mock bytearray or a mistaken list[bytes] cannot leak through.
         result = await self.client.request_async(endpoint, **params)
-        if isinstance(result, bytearray):
-            return bytes(result)
-        if not isinstance(result, bytes):
+        payload: object = result
+        if isinstance(payload, bytearray):
+            return bytes(payload)
+        if not isinstance(payload, bytes):
             raise InvalidResponseTypeError(
                 endpoint_name=endpoint.name,
                 expected_type="bytes",
-                actual_type=type(result).__name__,
+                actual_type=type(payload).__name__,
             )
-        return result
+        return payload
 
     def _parse_csv(
-        self, raw: bytes, model: type[ModelT], endpoint: Endpoint
+        self, raw: bytes, model: type[ModelT], endpoint: Endpoint[bytes]
     ) -> list[ModelT]:
         return parse_csv_models(
             raw,

--- a/fmp_data/batch/client.py
+++ b/fmp_data/batch/client.py
@@ -84,8 +84,8 @@ class BatchClient(EndpointGroup):
 
     def _request_csv(self, endpoint: Endpoint[bytes], **params: Any) -> bytes:
         """Fetch a bulk CSV/bytes payload. Do not route these through _unwrap_list."""
-        # request() is typed T | list[T]; validate the payload ourselves so a
-        # mock bytearray or a mistaken list[bytes] cannot leak through.
+        # request() is typed T | list[T]; widen so a mock bytearray (not in
+        # the union) can be coerced and a mistaken list[bytes] is rejected.
         result = self.client.request(endpoint, **params)
         payload: object = result
         if isinstance(payload, bytearray):

--- a/fmp_data/batch/client.py
+++ b/fmp_data/batch/client.py
@@ -82,20 +82,24 @@ class BatchClient(EndpointGroup):
     in a single API call.
     """
 
-    def _request_csv(self, endpoint: Endpoint, **params: Any) -> bytes:
+    def _request_csv(self, endpoint: Endpoint[bytes], **params: Any) -> bytes:
+        """Fetch a bulk CSV/bytes payload. Do not route these through _unwrap_list."""
+        # request() is typed T | list[T]; validate the payload ourselves so a
+        # mock bytearray or a mistaken list[bytes] cannot leak through.
         result = self.client.request(endpoint, **params)
-        if isinstance(result, bytearray):
-            return bytes(result)
-        if not isinstance(result, bytes):
+        payload: object = result
+        if isinstance(payload, bytearray):
+            return bytes(payload)
+        if not isinstance(payload, bytes):
             raise InvalidResponseTypeError(
                 endpoint_name=endpoint.name,
                 expected_type="bytes",
-                actual_type=type(result).__name__,
+                actual_type=type(payload).__name__,
             )
-        return result
+        return payload
 
     def _parse_csv(
-        self, raw: bytes, model: type[ModelT], endpoint: Endpoint
+        self, raw: bytes, model: type[ModelT], endpoint: Endpoint[bytes]
     ) -> list[ModelT]:
         return parse_csv_models(
             raw,

--- a/fmp_data/batch/endpoints.py
+++ b/fmp_data/batch/endpoints.py
@@ -311,9 +311,9 @@ BATCH_MARKET_CAP: Endpoint[BatchMarketCap] = Endpoint(
     ],
 )
 
-# CSV / bulk downloads. Payloads are raw bytes; parse with _request_csv.
-# Do not pass these to _unwrap_list — isinstance(payload, bytes) would wrap
-# the whole file as a one-element list.
+# CSV / bulk downloads. Payloads are raw bytes; fetch via _request_csv,
+# then parse with _parse_csv / parse_csv_*. Do not pass these to
+# _unwrap_list — a bytes payload becomes a one-element list.
 PROFILE_BULK: Endpoint[bytes] = Endpoint(
     name="profile_bulk",
     path="profile-bulk",

--- a/fmp_data/batch/endpoints.py
+++ b/fmp_data/batch/endpoints.py
@@ -311,7 +311,10 @@ BATCH_MARKET_CAP: Endpoint[BatchMarketCap] = Endpoint(
     ],
 )
 
-PROFILE_BULK: Endpoint = Endpoint(
+# CSV / bulk downloads. Payloads are raw bytes; parse with _request_csv.
+# Do not pass these to _unwrap_list — isinstance(payload, bytes) would wrap
+# the whole file as a one-element list.
+PROFILE_BULK: Endpoint[bytes] = Endpoint(
     name="profile_bulk",
     path="profile-bulk",
     version=APIVersion.STABLE,
@@ -330,7 +333,7 @@ PROFILE_BULK: Endpoint = Endpoint(
     response_model=bytes,
 )
 
-DCF_BULK: Endpoint = Endpoint(
+DCF_BULK: Endpoint[bytes] = Endpoint(
     name="dcf_bulk",
     path="dcf-bulk",
     version=APIVersion.STABLE,
@@ -342,7 +345,7 @@ DCF_BULK: Endpoint = Endpoint(
     response_model=bytes,
 )
 
-RATING_BULK: Endpoint = Endpoint(
+RATING_BULK: Endpoint[bytes] = Endpoint(
     name="rating_bulk",
     path="rating-bulk",
     version=APIVersion.STABLE,
@@ -354,7 +357,7 @@ RATING_BULK: Endpoint = Endpoint(
     response_model=bytes,
 )
 
-SCORES_BULK: Endpoint = Endpoint(
+SCORES_BULK: Endpoint[bytes] = Endpoint(
     name="scores_bulk",
     path="scores-bulk",
     version=APIVersion.STABLE,
@@ -366,7 +369,7 @@ SCORES_BULK: Endpoint = Endpoint(
     response_model=bytes,
 )
 
-RATIOS_TTM_BULK: Endpoint = Endpoint(
+RATIOS_TTM_BULK: Endpoint[bytes] = Endpoint(
     name="ratios_ttm_bulk",
     path="ratios-ttm-bulk",
     version=APIVersion.STABLE,
@@ -378,7 +381,7 @@ RATIOS_TTM_BULK: Endpoint = Endpoint(
     response_model=bytes,
 )
 
-PRICE_TARGET_SUMMARY_BULK: Endpoint = Endpoint(
+PRICE_TARGET_SUMMARY_BULK: Endpoint[bytes] = Endpoint(
     name="price_target_summary_bulk",
     path="price-target-summary-bulk",
     version=APIVersion.STABLE,
@@ -390,7 +393,7 @@ PRICE_TARGET_SUMMARY_BULK: Endpoint = Endpoint(
     response_model=bytes,
 )
 
-ETF_HOLDER_BULK: Endpoint = Endpoint(
+ETF_HOLDER_BULK: Endpoint[bytes] = Endpoint(
     name="etf_holder_bulk",
     path="etf-holder-bulk",
     version=APIVersion.STABLE,
@@ -409,7 +412,7 @@ ETF_HOLDER_BULK: Endpoint = Endpoint(
     response_model=bytes,
 )
 
-UPGRADES_DOWNGRADES_CONSENSUS_BULK: Endpoint = Endpoint(
+UPGRADES_DOWNGRADES_CONSENSUS_BULK: Endpoint[bytes] = Endpoint(
     name="upgrades_downgrades_consensus_bulk",
     path="upgrades-downgrades-consensus-bulk",
     version=APIVersion.STABLE,
@@ -421,7 +424,7 @@ UPGRADES_DOWNGRADES_CONSENSUS_BULK: Endpoint = Endpoint(
     response_model=bytes,
 )
 
-KEY_METRICS_TTM_BULK: Endpoint = Endpoint(
+KEY_METRICS_TTM_BULK: Endpoint[bytes] = Endpoint(
     name="key_metrics_ttm_bulk",
     path="key-metrics-ttm-bulk",
     version=APIVersion.STABLE,
@@ -433,7 +436,7 @@ KEY_METRICS_TTM_BULK: Endpoint = Endpoint(
     response_model=bytes,
 )
 
-PEERS_BULK: Endpoint = Endpoint(
+PEERS_BULK: Endpoint[bytes] = Endpoint(
     name="peers_bulk",
     path="peers-bulk",
     version=APIVersion.STABLE,
@@ -445,7 +448,7 @@ PEERS_BULK: Endpoint = Endpoint(
     response_model=bytes,
 )
 
-EARNINGS_SURPRISES_BULK: Endpoint = Endpoint(
+EARNINGS_SURPRISES_BULK: Endpoint[bytes] = Endpoint(
     name="earnings_surprises_bulk",
     path="earnings-surprises-bulk",
     version=APIVersion.STABLE,
@@ -464,7 +467,7 @@ EARNINGS_SURPRISES_BULK: Endpoint = Endpoint(
     response_model=bytes,
 )
 
-INCOME_STATEMENT_BULK: Endpoint = Endpoint(
+INCOME_STATEMENT_BULK: Endpoint[bytes] = Endpoint(
     name="income_statement_bulk",
     path="income-statement-bulk",
     version=APIVersion.STABLE,
@@ -490,7 +493,7 @@ INCOME_STATEMENT_BULK: Endpoint = Endpoint(
     response_model=bytes,
 )
 
-INCOME_STATEMENT_GROWTH_BULK: Endpoint = Endpoint(
+INCOME_STATEMENT_GROWTH_BULK: Endpoint[bytes] = Endpoint(
     name="income_statement_growth_bulk",
     path="income-statement-growth-bulk",
     version=APIVersion.STABLE,
@@ -516,7 +519,7 @@ INCOME_STATEMENT_GROWTH_BULK: Endpoint = Endpoint(
     response_model=bytes,
 )
 
-BALANCE_SHEET_STATEMENT_BULK: Endpoint = Endpoint(
+BALANCE_SHEET_STATEMENT_BULK: Endpoint[bytes] = Endpoint(
     name="balance_sheet_statement_bulk",
     path="balance-sheet-statement-bulk",
     version=APIVersion.STABLE,
@@ -542,7 +545,7 @@ BALANCE_SHEET_STATEMENT_BULK: Endpoint = Endpoint(
     response_model=bytes,
 )
 
-BALANCE_SHEET_STATEMENT_GROWTH_BULK: Endpoint = Endpoint(
+BALANCE_SHEET_STATEMENT_GROWTH_BULK: Endpoint[bytes] = Endpoint(
     name="balance_sheet_statement_growth_bulk",
     path="balance-sheet-statement-growth-bulk",
     version=APIVersion.STABLE,
@@ -568,7 +571,7 @@ BALANCE_SHEET_STATEMENT_GROWTH_BULK: Endpoint = Endpoint(
     response_model=bytes,
 )
 
-CASH_FLOW_STATEMENT_BULK: Endpoint = Endpoint(
+CASH_FLOW_STATEMENT_BULK: Endpoint[bytes] = Endpoint(
     name="cash_flow_statement_bulk",
     path="cash-flow-statement-bulk",
     version=APIVersion.STABLE,
@@ -594,7 +597,7 @@ CASH_FLOW_STATEMENT_BULK: Endpoint = Endpoint(
     response_model=bytes,
 )
 
-CASH_FLOW_STATEMENT_GROWTH_BULK: Endpoint = Endpoint(
+CASH_FLOW_STATEMENT_GROWTH_BULK: Endpoint[bytes] = Endpoint(
     name="cash_flow_statement_growth_bulk",
     path="cash-flow-statement-growth-bulk",
     version=APIVersion.STABLE,
@@ -620,7 +623,7 @@ CASH_FLOW_STATEMENT_GROWTH_BULK: Endpoint = Endpoint(
     response_model=bytes,
 )
 
-EOD_BULK: Endpoint = Endpoint(
+EOD_BULK: Endpoint[bytes] = Endpoint(
     name="eod_bulk",
     path="eod-bulk",
     version=APIVersion.STABLE,

--- a/tests/unit/test_bulk_bytes.py
+++ b/tests/unit/test_bulk_bytes.py
@@ -1,0 +1,126 @@
+"""Bulk-bytes / CSV endpoints stay off ``_unwrap_list`` (#247).
+
+Quote lists are row-typed and go through ``_unwrap_list`` (#246). Bulk
+downloads are ``bytes`` and go through ``_request_csv`` only.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+from typing import get_type_hints
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from fmp_data.base import _unwrap_list_result
+from fmp_data.batch import endpoints as batch_endpoints
+from fmp_data.batch.async_client import AsyncBatchClient
+from fmp_data.batch.client import BatchClient
+from fmp_data.batch.endpoints import BATCH_QUOTE, PROFILE_BULK
+from fmp_data.batch.models import BatchQuote
+from fmp_data.exceptions import InvalidResponseTypeError
+from fmp_data.models import Endpoint
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_BATCH_CLIENTS = (
+    _REPO_ROOT / "fmp_data" / "batch" / "client.py",
+    _REPO_ROOT / "fmp_data" / "batch" / "async_client.py",
+)
+
+
+def _bulk_endpoint_names() -> list[str]:
+    names = [
+        name
+        for name, value in vars(batch_endpoints).items()
+        if name.endswith("_BULK") and isinstance(value, Endpoint)
+    ]
+    assert names, "expected at least one *_BULK endpoint"
+    return sorted(names)
+
+
+def _bulk_methods(tree: ast.AST) -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
+    methods: list[ast.FunctionDef | ast.AsyncFunctionDef] = []
+    for node in ast.walk(tree):
+        if isinstance(
+            node, ast.FunctionDef | ast.AsyncFunctionDef
+        ) and node.name.endswith("_bulk"):
+            methods.append(node)
+    return methods
+
+
+class TestBulkEndpointBindings:
+    @pytest.mark.parametrize("name", _bulk_endpoint_names())
+    def test_bulk_endpoints_bind_bytes_not_a_row_type(self, name: str) -> None:
+        endpoint = getattr(batch_endpoints, name)
+        assert endpoint.response_model is bytes
+
+    @pytest.mark.parametrize("name", _bulk_endpoint_names())
+    def test_bulk_endpoints_are_annotated_endpoint_bytes(self, name: str) -> None:
+        hints = get_type_hints(batch_endpoints)
+        assert hints[name] == Endpoint[bytes]
+
+    def test_quote_lists_stay_row_typed(self) -> None:
+        hints = get_type_hints(batch_endpoints)
+        assert hints["BATCH_QUOTE"] == Endpoint[BatchQuote]
+        assert BATCH_QUOTE.response_model is BatchQuote
+
+
+class TestRequestCsvIsTheBytesHelper:
+    @pytest.mark.parametrize(
+        "method",
+        [BatchClient._request_csv, AsyncBatchClient._request_csv],
+    )
+    def test_request_csv_is_annotated_endpoint_bytes(self, method: object) -> None:
+        hints = get_type_hints(method)
+        assert hints["endpoint"] == Endpoint[bytes]
+        assert hints["return"] is bytes
+
+    @pytest.mark.parametrize("path", _BATCH_CLIENTS)
+    def test_bulk_methods_call_request_csv_not_unwrap_list(self, path: Path) -> None:
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(path))
+        methods = _bulk_methods(tree)
+        assert methods, f"expected *_bulk methods in {path.name}"
+        for method in methods:
+            body = ast.get_source_segment(source, method)
+            assert body is not None
+            assert "_request_csv" in body, method.name
+            assert "_unwrap_list" not in body, method.name
+
+    def test_request_csv_rejects_non_bytes_payload(self) -> None:
+        mock_client = Mock()
+        mock_client.request.return_value = [{"symbol": "AAPL"}]
+        client = BatchClient(mock_client)
+
+        with pytest.raises(InvalidResponseTypeError, match="expected bytes"):
+            client._request_csv(PROFILE_BULK, part="0")
+
+    def test_request_csv_accepts_bytearray(self) -> None:
+        mock_client = Mock()
+        mock_client.request.return_value = bytearray(b"symbol\nAAPL\n")
+        client = BatchClient(mock_client)
+
+        assert client._request_csv(PROFILE_BULK, part="0") == b"symbol\nAAPL\n"
+
+    @pytest.mark.asyncio
+    async def test_async_request_csv_rejects_non_bytes_payload(self) -> None:
+        mock_client = Mock()
+        mock_client.request_async = AsyncMock(return_value=[{"symbol": "AAPL"}])
+        client = AsyncBatchClient(mock_client)
+
+        with pytest.raises(InvalidResponseTypeError, match="expected bytes"):
+            await client._request_csv(PROFILE_BULK, part="0")
+
+    def test_unwrap_list_would_wrap_bytes_as_a_single_row(self) -> None:
+        """``isinstance(payload, bytes)`` is true, so unwrap is the wrong helper."""
+        raw = b"symbol,name\nAAPL,Apple\n"
+        assert _unwrap_list_result(raw, bytes) == [raw]
+
+
+def test_request_signature_stays_union() -> None:
+    from fmp_data.base import BaseClient
+
+    source = inspect.getsource(BaseClient.request)
+    assert "-> T | list[T]" in source

--- a/tests/unit/test_bulk_bytes.py
+++ b/tests/unit/test_bulk_bytes.py
@@ -2,14 +2,15 @@
 
 Quote lists are row-typed and go through ``_unwrap_list`` (#246). Bulk
 downloads are ``bytes`` and go through ``_request_csv`` only.
+``FINANCIAL_REPORTS_XLSX`` is a company XLSX download, not a batch CSV.
 """
 
 from __future__ import annotations
 
 import ast
-import inspect
 from pathlib import Path
-from typing import get_type_hints
+from types import UnionType
+from typing import Union, get_args, get_origin, get_type_hints
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -27,6 +28,12 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 _BATCH_CLIENTS = (
     _REPO_ROOT / "fmp_data" / "batch" / "client.py",
     _REPO_ROOT / "fmp_data" / "batch" / "async_client.py",
+)
+_CSV_BYTES = b"symbol\nAAPL\n"
+_REJECT_PAYLOADS = (
+    [{"symbol": "AAPL"}],
+    [b"symbol\nAAPL\n"],
+    "csv",
 )
 
 
@@ -48,6 +55,39 @@ def _bulk_methods(tree: ast.AST) -> list[ast.FunctionDef | ast.AsyncFunctionDef]
         ) and node.name.endswith("_bulk"):
             methods.append(node)
     return methods
+
+
+def _called_names(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Name):
+            names.add(func.id)
+        elif isinstance(func, ast.Attribute):
+            names.add(func.attr)
+    return names
+
+
+def _sync_client(payload: object) -> tuple[BatchClient, Mock]:
+    mock_client = Mock()
+    mock_client.config.validation_mode = "warn"
+    mock_client.request.return_value = payload
+    return BatchClient(mock_client), mock_client
+
+
+def _async_client(payload: object) -> tuple[AsyncBatchClient, Mock]:
+    mock_client = Mock()
+    mock_client.config.validation_mode = "warn"
+    mock_client.request_async = AsyncMock(return_value=payload)
+    return AsyncBatchClient(mock_client), mock_client
+
+
+def _is_t_or_list_t(annotation: object) -> bool:
+    if get_origin(annotation) not in {UnionType, Union}:
+        return False
+    return any(get_origin(arg) is list for arg in get_args(annotation))
 
 
 class TestBulkEndpointBindings:
@@ -84,34 +124,67 @@ class TestRequestCsvIsTheBytesHelper:
         methods = _bulk_methods(tree)
         assert methods, f"expected *_bulk methods in {path.name}"
         for method in methods:
-            body = ast.get_source_segment(source, method)
-            assert body is not None
-            assert "_request_csv" in body, method.name
-            assert "_unwrap_list" not in body, method.name
+            called = _called_names(method)
+            assert "_request_csv" in called, method.name
+            assert "_unwrap_list" not in called, method.name
 
-    def test_request_csv_rejects_non_bytes_payload(self) -> None:
-        mock_client = Mock()
-        mock_client.request.return_value = [{"symbol": "AAPL"}]
-        client = BatchClient(mock_client)
-
+    @pytest.mark.parametrize("payload", _REJECT_PAYLOADS)
+    def test_request_csv_rejects_non_bytes_payload(self, payload: object) -> None:
+        client, _ = _sync_client(payload)
         with pytest.raises(InvalidResponseTypeError, match="expected bytes"):
             client._request_csv(PROFILE_BULK, part="0")
 
-    def test_request_csv_accepts_bytearray(self) -> None:
-        mock_client = Mock()
-        mock_client.request.return_value = bytearray(b"symbol\nAAPL\n")
-        client = BatchClient(mock_client)
+    def test_request_csv_accepts_bytes(self) -> None:
+        client, _ = _sync_client(_CSV_BYTES)
+        result = client._request_csv(PROFILE_BULK, part="0")
+        assert result == _CSV_BYTES
+        assert type(result) is bytes
 
-        assert client._request_csv(PROFILE_BULK, part="0") == b"symbol\nAAPL\n"
+    def test_request_csv_accepts_bytearray(self) -> None:
+        client, _ = _sync_client(bytearray(_CSV_BYTES))
+        result = client._request_csv(PROFILE_BULK, part="0")
+        assert result == _CSV_BYTES
+        assert type(result) is bytes
 
     @pytest.mark.asyncio
-    async def test_async_request_csv_rejects_non_bytes_payload(self) -> None:
-        mock_client = Mock()
-        mock_client.request_async = AsyncMock(return_value=[{"symbol": "AAPL"}])
-        client = AsyncBatchClient(mock_client)
-
+    @pytest.mark.parametrize("payload", _REJECT_PAYLOADS)
+    async def test_async_request_csv_rejects_non_bytes_payload(
+        self, payload: object
+    ) -> None:
+        client, _ = _async_client(payload)
         with pytest.raises(InvalidResponseTypeError, match="expected bytes"):
             await client._request_csv(PROFILE_BULK, part="0")
+
+    @pytest.mark.asyncio
+    async def test_async_request_csv_accepts_bytes(self) -> None:
+        client, _ = _async_client(_CSV_BYTES)
+        result = await client._request_csv(PROFILE_BULK, part="0")
+        assert result == _CSV_BYTES
+        assert type(result) is bytes
+
+    @pytest.mark.asyncio
+    async def test_async_request_csv_accepts_bytearray(self) -> None:
+        client, _ = _async_client(bytearray(_CSV_BYTES))
+        result = await client._request_csv(PROFILE_BULK, part="0")
+        assert result == _CSV_BYTES
+        assert type(result) is bytes
+
+    def test_get_profile_bulk_parses_bytes_not_a_wrapped_file(self) -> None:
+        client, mock_client = _sync_client(_CSV_BYTES)
+        rows = client.get_profile_bulk("0")
+
+        assert [row.symbol for row in rows] == ["AAPL"]
+        assert all(not isinstance(row, bytes) for row in rows)
+        mock_client.request.assert_called_once_with(PROFILE_BULK, part="0")
+
+    @pytest.mark.asyncio
+    async def test_async_get_profile_bulk_parses_bytes_not_a_wrapped_file(self) -> None:
+        client, mock_client = _async_client(_CSV_BYTES)
+        rows = await client.get_profile_bulk("0")
+
+        assert [row.symbol for row in rows] == ["AAPL"]
+        assert all(not isinstance(row, bytes) for row in rows)
+        mock_client.request_async.assert_awaited_once_with(PROFILE_BULK, part="0")
 
     def test_unwrap_list_would_wrap_bytes_as_a_single_row(self) -> None:
         """``isinstance(payload, bytes)`` is true, so unwrap is the wrong helper."""
@@ -122,5 +195,5 @@ class TestRequestCsvIsTheBytesHelper:
 def test_request_signature_stays_union() -> None:
     from fmp_data.base import BaseClient
 
-    source = inspect.getsource(BaseClient.request)
-    assert "-> T | list[T]" in source
+    assert _is_t_or_list_t(get_type_hints(BaseClient.request)["return"])
+    assert _is_t_or_list_t(get_type_hints(BaseClient.request_async)["return"])


### PR DESCRIPTION
Closes #247.

#246 typed batch JSON quote lists as `Endpoint[T]` and put them on `_unwrap_list`. Bulk CSV / bytes downloads (`PROFILE_BULK`, `EOD_BULK`, statement bulks, etc.) were still bare `Endpoint = Endpoint(...)` even though `response_model=bytes` and the methods already go through `_request_csv` → `parse_csv_*`.

Those payloads are `bytes`, not row lists. `_unwrap_list` would treat `isinstance(payload, bytes)` as a lone row and wrap the whole file as `[bytes]`.

## What this does

1. Bind all 18 `*_BULK` endpoints as `Endpoint[bytes]`.
2. Type `_request_csv` / `_parse_csv` as `Endpoint[bytes]` on the sync and async batch clients.
3. Keep `_request_csv` as the only bytes helper. Quote lists stay on `_unwrap_list`.

## What this does not do

- Does not collapse `request()` to `list[T]`.
- Does not enable mypy `type-arg`.
- Does not put bulk-bytes / CSV on `_unwrap_list`.
- Does not retarget `FINANCIAL_REPORTS_XLSX` (company binary download, not a batch CSV helper).

## Tests

- `tests/unit/test_bulk_bytes.py`: every `*_BULK` binds `response_model is bytes` and is annotated `Endpoint[bytes]`; `_request_csv` is `Endpoint[bytes] -> bytes`; bulk methods call `_request_csv` not `_unwrap_list`; non-bytes payloads raise; `request()` stays `T | list[T]`.
- Unit suite: 1604 passed, 19 skipped.

Isolated worktree `fmp-data--feat-bulk-bytes-endpoint-247` off `origin/dev`.