### PR TITLE
feat(client): overload request() for bytes and type report endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,9 +85,9 @@ None. No FMP path we ship was newly retired by this changelog window.
 - **`request(Endpoint[bytes])` is `bytes`; `request_list` refuses bytes
   (#249).** `request()` / `request_async()` overload to `bytes` for file
   downloads and stay `T | list[T]` for every other `T`.
-  `request_list` / `request_async_list` raise `TypeError` on
-  `response_model is bytes` instead of wrapping the file as `[bytes]`.
-  Quote lists still unwrap to `list[T]`.
+  `request_list` / `request_async_list` overload to `NoReturn` and raise
+  `TypeError` on `response_model is bytes` instead of wrapping the file
+  as `[bytes]`. Quote lists still unwrap to `list[T]`.
 
 - **Company financial-report endpoints are `Endpoint[T]` (#250).**
   `FINANCIAL_REPORTS_JSON` is `Endpoint[FinancialReportJSON]`;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,19 @@ None. No FMP path we ship was newly retired by this changelog window.
   `FINANCIAL_REPORTS_XLSX` is unchanged: company XLSX download, still a
   bare `Endpoint`, not `_request_csv`.
 
+- **`request(Endpoint[bytes])` is `bytes`; `request_list` refuses bytes
+  (#249).** `request()` / `request_async()` overload to `bytes` for file
+  downloads and stay `T | list[T]` for every other `T`.
+  `request_list` / `request_async_list` raise `TypeError` on
+  `response_model is bytes` instead of wrapping the file as `[bytes]`.
+  Quote lists still unwrap to `list[T]`.
+
+- **Company financial-report endpoints are `Endpoint[T]` (#250).**
+  `FINANCIAL_REPORTS_JSON` is `Endpoint[FinancialReportJSON]`;
+  `FINANCIAL_REPORTS_XLSX` is `Endpoint[bytes]`. Client methods keep
+  their existing type checks and still return `dict` / `bytes`. XLSX
+  stays off batch `_request_csv`.
+
 ### Added
 
 - **FMP hosted MCP vs `fmp-mcp` positioning (#230).** Docs-only: we are not

--- a/fmp_data/base.py
+++ b/fmp_data/base.py
@@ -40,6 +40,15 @@ T = TypeVar("T")
 ValidationMode = Literal["lenient", "warn", "strict"]
 
 
+def _refuse_bytes_list_request(endpoint: Endpoint[T]) -> None:
+    """``request_list`` is for row lists, not file downloads."""
+    if endpoint.response_model is bytes:
+        raise TypeError(
+            f"{endpoint.name} returns bytes; use request() or a dedicated "
+            "bytes helper, not request_list()"
+        )
+
+
 def _unwrap_list_result(result: T | list[T], model: type[T]) -> list[T]:
     """Normalize ``request()`` output to ``list[T]``.
 
@@ -354,6 +363,12 @@ class BaseClient:
             return exc.response.status_code >= 500
         return False
 
+    @overload
+    def request(self, endpoint: Endpoint[bytes], **kwargs: Any) -> bytes: ...
+
+    @overload
+    def request(self, endpoint: Endpoint[T], **kwargs: Any) -> T | list[T]: ...
+
     @log_api_call()
     def request(self, endpoint: Endpoint[T], **kwargs: Any) -> T | list[T]:
         """
@@ -364,7 +379,8 @@ class BaseClient:
             **kwargs: Arbitrary keyword arguments passed as request parameters.
 
         Returns:
-            Either a single Pydantic model of type T or a list of T.
+            ``bytes`` for ``Endpoint[bytes]``. Otherwise a single model of
+            type T or a list of T.
         """
         _rate_limit_retry_count.set(0)  # Reset counter at start of new request
 
@@ -388,12 +404,19 @@ class BaseClient:
     def request_list(self, endpoint: Endpoint[T], **kwargs: Any) -> list[T]:
         """Request a list-returning endpoint as ``list[T]``.
 
-        ``request`` stays ``Endpoint[T] -> T | list[T]``. Use this helper
+        ``request`` stays ``Endpoint[T] -> T | list[T]`` except for
+        ``Endpoint[bytes]``, which overloads to ``bytes``. Use this helper
         when the caller wants ``list[T]`` directly. Client methods that
         still call ``request()`` (so tests can mock it) should normalize
         with ``EndpointGroup._unwrap_list`` instead of ``_unwrap_single``.
         An empty list stays empty.
+
+        Raises:
+            TypeError: If ``endpoint.response_model is bytes``. A file
+                payload is not a row list; ``isinstance(payload, bytes)``
+                would wrap it as ``[bytes]``.
         """
+        _refuse_bytes_list_request(endpoint)
         return _unwrap_list_result(
             self.request(endpoint, **kwargs),
             endpoint.response_model,
@@ -919,9 +942,21 @@ class BaseClient:
             )
         raise ValueError(f"Unsupported response model: {model!r}")
 
+    @overload
+    async def request_async(
+        self, endpoint: Endpoint[bytes], **kwargs: Any
+    ) -> bytes: ...
+
+    @overload
+    async def request_async(
+        self, endpoint: Endpoint[T], **kwargs: Any
+    ) -> T | list[T]: ...
+
     async def request_async(self, endpoint: Endpoint[T], **kwargs: Any) -> T | list[T]:
         """
-        Make async request with rate limiting and retry logic, returning T or list[T].
+        Make async request with rate limiting and retry logic.
+
+        Returns ``bytes`` for ``Endpoint[bytes]``. Otherwise T or list[T].
         """
         _rate_limit_retry_count.set(0)  # Reset counter at start of new request
 
@@ -944,6 +979,7 @@ class BaseClient:
 
     async def request_async_list(self, endpoint: Endpoint[T], **kwargs: Any) -> list[T]:
         """Async counterpart of :meth:`request_list`."""
+        _refuse_bytes_list_request(endpoint)
         return _unwrap_list_result(
             await self.request_async(endpoint, **kwargs),
             endpoint.response_model,

--- a/fmp_data/base.py
+++ b/fmp_data/base.py
@@ -401,6 +401,12 @@ class BaseClient:
         # This should never be reached due to reraise=True, but satisfies type checker
         raise FMPError("Request failed after all retry attempts")
 
+    @overload
+    def request_list(self, endpoint: Endpoint[bytes], **kwargs: Any) -> NoReturn: ...
+
+    @overload
+    def request_list(self, endpoint: Endpoint[T], **kwargs: Any) -> list[T]: ...
+
     def request_list(self, endpoint: Endpoint[T], **kwargs: Any) -> list[T]:
         """Request a list-returning endpoint as ``list[T]``.
 
@@ -977,8 +983,22 @@ class BaseClient:
         # This should never be reached due to reraise=True
         raise FMPError("Async request failed after all retry attempts")
 
+    @overload
+    async def request_async_list(
+        self, endpoint: Endpoint[bytes], **kwargs: Any
+    ) -> NoReturn: ...
+
+    @overload
+    async def request_async_list(
+        self, endpoint: Endpoint[T], **kwargs: Any
+    ) -> list[T]: ...
+
     async def request_async_list(self, endpoint: Endpoint[T], **kwargs: Any) -> list[T]:
-        """Async counterpart of :meth:`request_list`."""
+        """Async counterpart of :meth:`request_list`.
+
+        Raises:
+            TypeError: If ``endpoint.response_model is bytes``.
+        """
         _refuse_bytes_list_request(endpoint)
         return _unwrap_list_result(
             await self.request_async(endpoint, **kwargs),

--- a/fmp_data/company/async_client.py
+++ b/fmp_data/company/async_client.py
@@ -963,7 +963,7 @@ class AsyncCompanyClient(AsyncEndpointGroup):
             "period": period,
         }
         result = await self.client.request_async(FINANCIAL_REPORTS_JSON, **params)
-        # request_async() is T | list[T]; widen so a mock dict stays legal.
+        # Widen so a mock dict is not an illegal FinancialReportJSON | list.
         payload: object = result
         if isinstance(payload, FinancialReportJSON):
             return payload.model_dump(mode="json")
@@ -994,13 +994,15 @@ class AsyncCompanyClient(AsyncEndpointGroup):
             "period": period,
         }
         result = await self.client.request_async(FINANCIAL_REPORTS_XLSX, **params)
-        if not isinstance(result, bytes | bytearray):
+        # Widen so a mock bytearray stays legal next to the bytes overload.
+        payload: object = result
+        if not isinstance(payload, bytes | bytearray):
             raise InvalidResponseTypeError(
                 endpoint_name="financial_reports_xlsx",
                 expected_type="bytes",
-                actual_type=type(result).__name__,
+                actual_type=type(payload).__name__,
             )
-        return bytes(result)
+        return bytes(payload)
 
     async def get_income_statement_as_reported(
         self, symbol: str, period: str = "annual", limit: int = 10

--- a/fmp_data/company/async_client.py
+++ b/fmp_data/company/async_client.py
@@ -963,15 +963,17 @@ class AsyncCompanyClient(AsyncEndpointGroup):
             "period": period,
         }
         result = await self.client.request_async(FINANCIAL_REPORTS_JSON, **params)
-        if isinstance(result, FinancialReportJSON):
-            return result.model_dump(mode="json")
-        if not isinstance(result, dict):
+        # request_async() is T | list[T]; widen so a mock dict stays legal.
+        payload: object = result
+        if isinstance(payload, FinancialReportJSON):
+            return payload.model_dump(mode="json")
+        if not isinstance(payload, dict):
             raise InvalidResponseTypeError(
                 endpoint_name="financial_reports_json",
                 expected_type="dict or FinancialReportJSON",
-                actual_type=type(result).__name__,
+                actual_type=type(payload).__name__,
             )
-        return result
+        return payload
 
     async def get_financial_reports_xlsx(
         self, symbol: str, year: int, period: str = "FY"

--- a/fmp_data/company/client.py
+++ b/fmp_data/company/client.py
@@ -926,15 +926,17 @@ class CompanyClient(EndpointGroup):
             "period": period,
         }
         result = self.client.request(FINANCIAL_REPORTS_JSON, **params)
-        if isinstance(result, FinancialReportJSON):
-            return result.model_dump(mode="json")
-        if not isinstance(result, dict):
+        # request() is T | list[T]; widen so a mock dict stays legal.
+        payload: object = result
+        if isinstance(payload, FinancialReportJSON):
+            return payload.model_dump(mode="json")
+        if not isinstance(payload, dict):
             raise InvalidResponseTypeError(
                 endpoint_name="financial_reports_json",
                 expected_type="dict or FinancialReportJSON",
-                actual_type=type(result).__name__,
+                actual_type=type(payload).__name__,
             )
-        return result
+        return payload
 
     def get_financial_reports_xlsx(
         self, symbol: str, year: int, period: str = "FY"

--- a/fmp_data/company/client.py
+++ b/fmp_data/company/client.py
@@ -926,7 +926,7 @@ class CompanyClient(EndpointGroup):
             "period": period,
         }
         result = self.client.request(FINANCIAL_REPORTS_JSON, **params)
-        # request() is T | list[T]; widen so a mock dict stays legal.
+        # Widen so a mock dict is not an illegal FinancialReportJSON | list.
         payload: object = result
         if isinstance(payload, FinancialReportJSON):
             return payload.model_dump(mode="json")
@@ -957,13 +957,15 @@ class CompanyClient(EndpointGroup):
             "period": period,
         }
         result = self.client.request(FINANCIAL_REPORTS_XLSX, **params)
-        if not isinstance(result, bytes | bytearray):
+        # Widen so a mock bytearray stays legal next to the bytes overload.
+        payload: object = result
+        if not isinstance(payload, bytes | bytearray):
             raise InvalidResponseTypeError(
                 endpoint_name="financial_reports_xlsx",
                 expected_type="bytes",
-                actual_type=type(result).__name__,
+                actual_type=type(payload).__name__,
             )
-        return bytes(result)
+        return bytes(payload)
 
     def get_income_statement_as_reported(
         self, symbol: str, period: str = "annual", limit: int = 10

--- a/fmp_data/company/endpoints.py
+++ b/fmp_data/company/endpoints.py
@@ -1664,7 +1664,7 @@ FINANCIAL_GROWTH: Endpoint[FinancialGrowth] = Endpoint(
     response_model=FinancialGrowth,
 )
 
-FINANCIAL_REPORTS_JSON: Endpoint = Endpoint(
+FINANCIAL_REPORTS_JSON: Endpoint[FinancialReportJSON] = Endpoint(
     name="financial_reports_json",
     path="financial-reports-json",
     version=APIVersion.STABLE,
@@ -1700,7 +1700,7 @@ FINANCIAL_REPORTS_JSON: Endpoint = Endpoint(
     response_model=FinancialReportJSON,
 )
 
-FINANCIAL_REPORTS_XLSX: Endpoint = Endpoint(
+FINANCIAL_REPORTS_XLSX: Endpoint[bytes] = Endpoint(
     name="financial_reports_xlsx",
     path="financial-reports-xlsx",
     version=APIVersion.STABLE,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -428,6 +428,8 @@ exclude_lines = [
     "def main():",
     "class .*\\(Protocol\\):",
     "@abstractmethod",
+    "@overload",
+    "\\.\\.\\.$",
 ]
 show_missing = true
 fail_under = 80

--- a/tests/unit/test_bulk_bytes.py
+++ b/tests/unit/test_bulk_bytes.py
@@ -11,16 +11,17 @@ import ast
 from pathlib import Path
 from types import UnionType
 from typing import Union, get_args, get_origin, get_type_hints
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from fmp_data.base import _unwrap_list_result
+from fmp_data.base import BaseClient, _unwrap_list_result
 from fmp_data.batch import endpoints as batch_endpoints
 from fmp_data.batch.async_client import AsyncBatchClient
 from fmp_data.batch.client import BatchClient
 from fmp_data.batch.endpoints import BATCH_QUOTE, PROFILE_BULK
 from fmp_data.batch.models import BatchQuote
+from fmp_data.config import ClientConfig
 from fmp_data.exceptions import InvalidResponseTypeError
 from fmp_data.models import Endpoint
 
@@ -190,6 +191,88 @@ class TestRequestCsvIsTheBytesHelper:
         """``isinstance(payload, bytes)`` is true, so unwrap is the wrong helper."""
         raw = b"symbol,name\nAAPL,Apple\n"
         assert _unwrap_list_result(raw, bytes) == [raw]
+
+
+def _base_client() -> BaseClient:
+    return BaseClient(ClientConfig(api_key="test_key", base_url="https://api.test.com"))
+
+
+def _overload_return_annotations(method_name: str) -> list[ast.expr]:
+    source = (_REPO_ROOT / "fmp_data" / "base.py").read_text(encoding="utf-8")
+    tree = ast.parse(source, filename="fmp_data/base.py")
+    returns: list[ast.expr] = []
+    for node in tree.body:
+        if not isinstance(node, ast.ClassDef) or node.name != "BaseClient":
+            continue
+        for item in node.body:
+            if not isinstance(item, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            if item.name != method_name:
+                continue
+            if any(
+                (isinstance(dec, ast.Name) and dec.id == "overload")
+                or (isinstance(dec, ast.Attribute) and dec.attr == "overload")
+                for dec in item.decorator_list
+            ):
+                if item.returns is not None:
+                    returns.append(item.returns)
+    return returns
+
+
+def _annotation_names(expr: ast.expr) -> set[str]:
+    return {node.id for node in ast.walk(expr) if isinstance(node, ast.Name)}
+
+
+class TestRequestBytesOverloadAndListRefusal:
+    """``request(Endpoint[bytes]) -> bytes``; ``request_list`` refuses bytes (#249)."""
+
+    @pytest.mark.parametrize("method_name", ["request", "request_async"])
+    def test_bytes_overload_returns_bytes(self, method_name: str) -> None:
+        returns = _overload_return_annotations(method_name)
+        assert any(
+            isinstance(expr, ast.Name) and expr.id == "bytes" for expr in returns
+        ), f"expected a bytes overload on BaseClient.{method_name}"
+        assert any("list" in _annotation_names(expr) for expr in returns), (
+            f"expected the T | list[T] overload to remain on BaseClient.{method_name}"
+        )
+
+    def test_request_bytes_endpoint_returns_bytes_not_list(self) -> None:
+        client = _base_client()
+        response = Mock()
+        response.status_code = 200
+        response.content = _CSV_BYTES
+        response.close = Mock()
+        with patch.object(client.client, "request", return_value=response):
+            result = client.request(PROFILE_BULK, part="0")
+        assert type(result) is bytes
+        assert result == _CSV_BYTES
+
+    def test_request_list_refuses_profile_bulk(self) -> None:
+        client = _base_client()
+        with (
+            patch.object(client, "request") as request,
+            pytest.raises(TypeError, match="profile_bulk"),
+        ):
+            client.request_list(PROFILE_BULK, part="0")
+        request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_request_async_list_refuses_profile_bulk(self) -> None:
+        client = _base_client()
+        with (
+            patch.object(client, "request_async") as request_async,
+            pytest.raises(TypeError, match="profile_bulk"),
+        ):
+            await client.request_async_list(PROFILE_BULK, part="0")
+        request_async.assert_not_called()
+
+    def test_request_list_still_unwraps_quote_lists(self) -> None:
+        client = _base_client()
+        quote = BatchQuote(symbol="AAPL")
+        with patch.object(client, "request", return_value=quote) as request:
+            result = client.request_list(BATCH_QUOTE, symbols=["AAPL"])
+        assert result == [quote]
+        request.assert_called_once_with(BATCH_QUOTE, symbols=["AAPL"])
 
 
 def test_request_signature_stays_union() -> None:

--- a/tests/unit/test_bulk_bytes.py
+++ b/tests/unit/test_bulk_bytes.py
@@ -229,11 +229,25 @@ class TestRequestBytesOverloadAndListRefusal:
     @pytest.mark.parametrize("method_name", ["request", "request_async"])
     def test_bytes_overload_returns_bytes(self, method_name: str) -> None:
         returns = _overload_return_annotations(method_name)
-        assert any(
-            isinstance(expr, ast.Name) and expr.id == "bytes" for expr in returns
-        ), f"expected a bytes overload on BaseClient.{method_name}"
-        assert any("list" in _annotation_names(expr) for expr in returns), (
+        assert returns, f"expected overloads on BaseClient.{method_name}"
+        first = returns[0]
+        assert isinstance(first, ast.Name) and first.id == "bytes", (
+            f"first BaseClient.{method_name} overload must return bytes"
+        )
+        assert any("list" in _annotation_names(expr) for expr in returns[1:]), (
             f"expected the T | list[T] overload to remain on BaseClient.{method_name}"
+        )
+
+    @pytest.mark.parametrize("method_name", ["request_list", "request_async_list"])
+    def test_list_helper_bytes_overload_is_noreturn(self, method_name: str) -> None:
+        returns = _overload_return_annotations(method_name)
+        assert returns, f"expected overloads on BaseClient.{method_name}"
+        first = returns[0]
+        assert isinstance(first, ast.Name) and first.id == "NoReturn", (
+            f"first BaseClient.{method_name} overload must return NoReturn"
+        )
+        assert any("list" in _annotation_names(expr) for expr in returns[1:]), (
+            f"expected the list[T] overload to remain on BaseClient.{method_name}"
         )
 
     def test_request_bytes_endpoint_returns_bytes_not_list(self) -> None:
@@ -244,6 +258,21 @@ class TestRequestBytesOverloadAndListRefusal:
         response.close = Mock()
         with patch.object(client.client, "request", return_value=response):
             result = client.request(PROFILE_BULK, part="0")
+        assert type(result) is bytes
+        assert result == _CSV_BYTES
+
+    @pytest.mark.asyncio
+    async def test_request_async_bytes_endpoint_returns_bytes_not_list(self) -> None:
+        client = _base_client()
+        response = Mock()
+        response.status_code = 200
+        response.content = _CSV_BYTES
+        response.raise_for_status = Mock()
+        response.aclose = AsyncMock()
+        mock_http = Mock()
+        mock_http.request = AsyncMock(return_value=response)
+        with patch.object(client, "_setup_async_client", return_value=mock_http):
+            result = await client.request_async(PROFILE_BULK, part="0")
         assert type(result) is bytes
         assert result == _CSV_BYTES
 
@@ -273,6 +302,17 @@ class TestRequestBytesOverloadAndListRefusal:
             result = client.request_list(BATCH_QUOTE, symbols=["AAPL"])
         assert result == [quote]
         request.assert_called_once_with(BATCH_QUOTE, symbols=["AAPL"])
+
+    @pytest.mark.asyncio
+    async def test_request_async_list_still_unwraps_quote_lists(self) -> None:
+        client = _base_client()
+        quote = BatchQuote(symbol="AAPL")
+        with patch.object(
+            client, "request_async", new=AsyncMock(return_value=quote)
+        ) as request_async:
+            result = await client.request_async_list(BATCH_QUOTE, symbols=["AAPL"])
+        assert result == [quote]
+        request_async.assert_awaited_once_with(BATCH_QUOTE, symbols=["AAPL"])
 
 
 def test_request_signature_stays_union() -> None:

--- a/tests/unit/test_company_coverage.py
+++ b/tests/unit/test_company_coverage.py
@@ -2,10 +2,11 @@
 
 from datetime import date
 from typing import get_type_hints
-from unittest.mock import patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+from fmp_data.company.async_client import AsyncCompanyClient
 from fmp_data.company.models import (
     AftermarketQuote,
     AftermarketTrade,
@@ -24,7 +25,17 @@ from fmp_data.company.models import (
     SimpleQuote,
     StockPriceChange,
 )
+from fmp_data.exceptions import InvalidResponseTypeError
 from fmp_data.market.models import CompanySearchResult
+
+_XLSX_BYTES = b"PK\x03\x04xlsx"
+_REPORT_DICT = {"symbol": "AAPL", "period": "FY", "year": 2024}
+
+
+def _async_company(payload: object) -> AsyncCompanyClient:
+    mock_base = Mock()
+    mock_base.request_async = AsyncMock(return_value=payload)
+    return AsyncCompanyClient(mock_base)
 
 
 class TestCompanyClientCoverage:
@@ -637,11 +648,59 @@ class TestFinancialReportsEndpointBindings:
         assert hints["FINANCIAL_REPORTS_XLSX"] == Endpoint[bytes]
         assert company_endpoints.FINANCIAL_REPORTS_XLSX.response_model is bytes
 
-        raw = b"PK\x03\x04xlsx"
+        with patch.object(
+            fmp_client.company.client, "request", return_value=_XLSX_BYTES
+        ):
+            result = fmp_client.company.get_financial_reports_xlsx("AAPL", 2024)
+        assert type(result) is bytes
+        assert result == _XLSX_BYTES
+
+    def test_request_xlsx_endpoint_returns_bytes_via_base_client(
+        self, fmp_client
+    ) -> None:
+        from fmp_data.company.endpoints import FINANCIAL_REPORTS_XLSX
+
+        response = Mock()
+        response.status_code = 200
+        response.content = _XLSX_BYTES
+        response.close = Mock()
+        with patch.object(
+            fmp_client.company.client.client, "request", return_value=response
+        ):
+            result = fmp_client.company.client.request(
+                FINANCIAL_REPORTS_XLSX, symbol="AAPL", year=2024, period="FY"
+            )
+        assert type(result) is bytes
+        assert result == _XLSX_BYTES
+
+    def test_sync_xlsx_rejects_non_bytes(self, fmp_client) -> None:
+        with (
+            patch.object(
+                fmp_client.company.client, "request", return_value={"file": 1}
+            ),
+            pytest.raises(InvalidResponseTypeError, match="financial_reports_xlsx"),
+        ):
+            fmp_client.company.get_financial_reports_xlsx("AAPL", 2024)
+
+    @pytest.mark.asyncio
+    async def test_async_xlsx_returns_bytes(self) -> None:
+        result = await _async_company(_XLSX_BYTES).get_financial_reports_xlsx(
+            "AAPL", 2024
+        )
+        assert type(result) is bytes
+        assert result == _XLSX_BYTES
+
+    def test_sync_xlsx_accepts_bytearray(self, fmp_client) -> None:
+        raw = bytearray(_XLSX_BYTES)
         with patch.object(fmp_client.company.client, "request", return_value=raw):
             result = fmp_client.company.get_financial_reports_xlsx("AAPL", 2024)
         assert type(result) is bytes
-        assert result == raw
+        assert result == _XLSX_BYTES
+
+    @pytest.mark.asyncio
+    async def test_async_xlsx_rejects_non_bytes(self) -> None:
+        with pytest.raises(InvalidResponseTypeError, match="financial_reports_xlsx"):
+            await _async_company({"file": 1}).get_financial_reports_xlsx("AAPL", 2024)
 
 
 class TestFinancialReportsJSONClient:
@@ -688,22 +747,41 @@ class TestFinancialReportsJSONClient:
     @pytest.mark.asyncio
     async def test_async_financial_reports_json_model_dump_path(self):
         """Verify async path converts FinancialReportJSON to dict."""
-        from unittest.mock import AsyncMock
-
-        from fmp_data.company.async_client import AsyncCompanyClient
-        from fmp_data.company.models import FinancialReportJSON
-
-        report = FinancialReportJSON.model_validate(
-            {"symbol": "AAPL", "period": "FY", "year": 2024}
-        )
-
-        mock_base = AsyncMock()
-        mock_base.request_async = AsyncMock(return_value=report)
-        async_client = AsyncCompanyClient.__new__(AsyncCompanyClient)
-        async_client._client = mock_base
-
-        result = await async_client.get_financial_reports_json(
+        report = FinancialReportJSON.model_validate(_REPORT_DICT)
+        result = await _async_company(report).get_financial_reports_json(
             "AAPL", 2024, period="FY"
         )
         assert isinstance(result, dict)
         assert result["symbol"] == "AAPL"
+
+    def test_sync_returns_raw_dict_without_model_dump(self, fmp_client) -> None:
+        raw = dict(_REPORT_DICT)
+        with patch.object(fmp_client.company.client, "request", return_value=raw):
+            result = fmp_client.company.get_financial_reports_json(
+                "AAPL", 2024, period="FY"
+            )
+        assert result is raw
+
+    def test_sync_rejects_non_dict_non_model_payload(self, fmp_client) -> None:
+        with (
+            patch.object(
+                fmp_client.company.client, "request", return_value=[_REPORT_DICT]
+            ),
+            pytest.raises(InvalidResponseTypeError, match="financial_reports_json"),
+        ):
+            fmp_client.company.get_financial_reports_json("AAPL", 2024, period="FY")
+
+    @pytest.mark.asyncio
+    async def test_async_returns_raw_dict_without_model_dump(self) -> None:
+        raw = dict(_REPORT_DICT)
+        result = await _async_company(raw).get_financial_reports_json(
+            "AAPL", 2024, period="FY"
+        )
+        assert result is raw
+
+    @pytest.mark.asyncio
+    async def test_async_rejects_non_dict_non_model_payload(self) -> None:
+        with pytest.raises(InvalidResponseTypeError, match="financial_reports_json"):
+            await _async_company([_REPORT_DICT]).get_financial_reports_json(
+                "AAPL", 2024, period="FY"
+            )

--- a/tests/unit/test_company_coverage.py
+++ b/tests/unit/test_company_coverage.py
@@ -1,6 +1,7 @@
 """Additional tests for company client to improve coverage"""
 
 from datetime import date
+from typing import get_type_hints
 from unittest.mock import patch
 
 import pytest
@@ -610,6 +611,37 @@ class TestNewModelFields:
         assert ma.transaction_date == "2024-06-15"
         assert ma.accepted_date == "2024-06-10"
         assert ma.link == "https://sec.gov/filing/123"
+
+
+class TestFinancialReportsEndpointBindings:
+    """Company financial-report downloads are the last bare Endpoints (#250)."""
+
+    def test_json_endpoint_is_parameterized(self) -> None:
+        from fmp_data.company import endpoints as company_endpoints
+        from fmp_data.models import Endpoint
+
+        hints = get_type_hints(company_endpoints)
+        assert hints["FINANCIAL_REPORTS_JSON"] == Endpoint[FinancialReportJSON]
+        assert (
+            company_endpoints.FINANCIAL_REPORTS_JSON.response_model
+            is FinancialReportJSON
+        )
+
+    def test_xlsx_endpoint_is_bytes_and_returns_bytes_not_list(
+        self, fmp_client
+    ) -> None:
+        from fmp_data.company import endpoints as company_endpoints
+        from fmp_data.models import Endpoint
+
+        hints = get_type_hints(company_endpoints)
+        assert hints["FINANCIAL_REPORTS_XLSX"] == Endpoint[bytes]
+        assert company_endpoints.FINANCIAL_REPORTS_XLSX.response_model is bytes
+
+        raw = b"PK\x03\x04xlsx"
+        with patch.object(fmp_client.company.client, "request", return_value=raw):
+            result = fmp_client.company.get_financial_reports_xlsx("AAPL", 2024)
+        assert type(result) is bytes
+        assert result == raw
 
 
 class TestFinancialReportsJSONClient:


### PR DESCRIPTION
Closes #249. Closes #250.

#248 typed all 18 batch `*_BULK` CSV downloads as `Endpoint[bytes]`. That left two holes:

1. `request()` / `request_async()` were still `Endpoint[T] -> T | list[T]`, so a bytes endpoint looked like `bytes | list[bytes]`. `request_list` would wrap a file as `[bytes]` because `isinstance(payload, bytes)` is true.
2. Company `FINANCIAL_REPORTS_JSON` / `FINANCIAL_REPORTS_XLSX` were the last two unparameterized `Endpoint` bindings.

## What this does

1. Overload `request(Endpoint[bytes]) -> bytes` and `request_async(Endpoint[bytes]) -> bytes`.
2. Keep `request()` as `T | list[T]` for every non-bytes `T`.
3. Make `request_list` / `request_async_list` raise `TypeError` on `response_model is bytes` (before calling `request()`).
4. Bind `FINANCIAL_REPORTS_JSON` as `Endpoint[FinancialReportJSON]` and `FINANCIAL_REPORTS_XLSX` as `Endpoint[bytes]`.
5. Keep the existing company client type checks. JSON still returns `dict` after `model_dump`. XLSX stays off batch `_request_csv`.

## What this does not do

- Does not enable mypy `type-arg`.
- Does not collapse `request()` to `list[T]`.
- Does not share a `_request_bytes` helper across batch and company.
- Does not change `_unwrap_list_result` (still wraps a lone `bytes` row if called directly).

## Tests

- `tests/unit/test_bulk_bytes.py`: bytes overloads exist; `request(PROFILE_BULK)` returns `bytes`; `request_list(PROFILE_BULK)` raises and does not call `request`; quote lists still unwrap to `list[T]`.
- `tests/unit/test_company_coverage.py`: report endpoints are parameterized; XLSX still returns `bytes`.
- Unit suite: 1621 passed, 19 skipped.

Isolated worktree `fmp-data--feat-bytes-request-and-report-endpoints-249` off `origin/dev`.