### PR TITLE
fix(ci): isolate PyPI publish and pin Actions to full SHAs

### DIFF
--- a/.github/requirements-build.txt
+++ b/.github/requirements-build.txt
@@ -1,0 +1,13 @@
+# Locked PEP 517 frontend for publish jobs. Backend (hatchling/hatch-vcs)
+# is resolved by build isolation from pyproject.toml.
+# Regenerate: printf "build==1.5.0\n" | uv pip compile - --generate-hashes --no-header --no-annotate -o .github/requirements-build.txt
+
+build==1.5.0 \
+    --hash=sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f \
+    --hash=sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647
+packaging==26.3 \
+    --hash=sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79 \
+    --hash=sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c
+pyproject-hooks==1.2.0 \
+    --hash=sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8 \
+    --hash=sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,17 +25,17 @@ jobs:
 
     steps:
       - name: 🛎️  Checkout
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
 
       - name: 🐍  Set up Python
-        uses: actions/setup-python@v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: ${{ matrix.python }}
 
       - name: ⚡  Install uv (with cache)
-        uses: astral-sh/setup-uv@v9.0.0
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
         with:
           enable-cache: true
 
@@ -70,15 +70,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛎️  Checkout
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: 🐍  Set up Python
-        uses: actions/setup-python@v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.14"
 
       - name: ⚡  Install uv
-        uses: astral-sh/setup-uv@v9.0.0
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
 
       - name: 📊 Run all tests with coverage
         env:
@@ -88,7 +88,7 @@ jobs:
           uv tool run nox -s coverage_local
 
       - name: 📈 Coverage upload
-        uses: codecov/codecov-action@v7.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
@@ -100,10 +100,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛎️  Checkout
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: 🐍  Set up Python
-        uses: actions/setup-python@v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.14"
 
@@ -160,7 +160,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛎️  Checkout
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: 🔍 ShellCheck composite action scripts
         run: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.auth.outputs.configured == 'true'
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 1
 
@@ -60,7 +60,7 @@ jobs:
         if: steps.auth.outputs.configured == 'true'
         id: claude-review
         continue-on-error: true
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@239e3a730883eeb5c53db12b0fc9573b3024b126  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,13 +34,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@239e3a730883eeb5c53db12b0fc9573b3024b126  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -7,44 +7,54 @@ name: Dev Release
 # Version is unique per workflow run so re-runs and force-pushes cannot
 # silently re-advertise a stale wheel via skip-existing (same failure
 # shape as #204).
+#
+# workflow_dispatch is bound to refs/heads/dev. An arbitrary ref cannot
+# be published under this Trusted Publisher identity (#252 FMP-SEC-003).
 
 on:
   push:
     branches:
       - dev
-  workflow_dispatch:  # Allow manual triggering
+  workflow_dispatch:
 
 permissions:
-  id-token: write              # OIDC → Trusted Publishing
-  contents: read               # Read repository contents
-  pull-requests: read          # Read PR labels for version calculation
+  contents: read
 
 jobs:
-  dev-release:
+  build:
+    if: github.ref == 'refs/heads/dev'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      version: ${{ steps.version.outputs.DEV_VERSION }}
+      head_short: ${{ steps.version.outputs.HEAD_SHORT }}
     env:
       PYTHON_VERSION: "3.12"
 
     steps:
       - name: 🛎️  Checkout repository
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0  # Needed for version calculation
           fetch-tags: true
+          ref: refs/heads/dev
+          persist-credentials: false
 
       - name: 🐍  Set up Python
-        uses: actions/setup-python@v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: ⚡  Install uv (with cache)
-        uses: astral-sh/setup-uv@v9.0.0
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
         with:
           enable-cache: true
 
-      - name: 📦  Install build tools
+      - name: 📦  Install pinned build frontend
         run: |
-          uv pip install --system build hatch
+          uv pip install --system --require-hashes -r .github/requirements-build.txt
 
       - name: 🔍  Check for PR with release labels
         id: pr_labels
@@ -160,10 +170,43 @@ jobs:
           fi
           echo "📋 Built package version matches: $META_VERSION"
 
+          (cd dist && sha256sum ./* > ../SHA256SUMS)
+          cat SHA256SUMS
+
+      - name: 📤 Upload dist artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: python-package-dist
+          path: |
+            dist/
+            SHA256SUMS
+          if-no-files-found: error
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/fmp-data/${{ needs.build.outputs.version }}/
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: 📥 Download dist artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        with:
+          name: python-package-dist
+
+      - name: 🔐 Verify artifact checksums
+        run: |
+          set -euo pipefail
+          (cd dist && sha256sum -c ../SHA256SUMS)
+
       - name: 🧪  Upload to Test PyPI
         # skip-existing OFF: unique version means a collision is a real bug
         # and must fail, not silently succeed with a stale artifact.
-        uses: pypa/gh-action-pypi-publish@v1.14.2
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: dist
@@ -175,11 +218,11 @@ jobs:
           {
             echo "## 🧪 Dev Release Published"
             echo ""
-            echo "**Version:** \`${{ steps.version.outputs.DEV_VERSION }}\`"
-            echo "**Commit:** \`${{ steps.version.outputs.HEAD_SHORT }}\`"
+            echo "**Version:** \`${{ needs.build.outputs.version }}\`"
+            echo "**Commit:** \`${{ needs.build.outputs.head_short }}\`"
             echo ""
             echo "### Installation"
             echo "\`\`\`bash"
-            echo "pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ fmp-data==${{ steps.version.outputs.DEV_VERSION }}"
+            echo "pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ fmp-data==${{ needs.build.outputs.version }}"
             echo "\`\`\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -40,22 +40,22 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: actions/setup-python@v7.0.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9.0.0
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
         with:
           enable-cache: true
 
       - name: Cache uv dependencies
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: |
             ~/.cache/uv
@@ -96,7 +96,7 @@ jobs:
           PACKAGE_VERSION="${{ steps.version.outputs.VERSION }}" uv run mkdocs build --strict
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5.0.0
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
         with:
           path: site
 
@@ -131,7 +131,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5.0.0
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0
 
       - name: Generate deployment summary
         env:

--- a/.github/workflows/guard-main-origin.yml
+++ b/.github/workflows/guard-main-origin.yml
@@ -36,7 +36,7 @@ jobs:
       # cannot omit/weaken the fail-closed contract. Fall back to head's copy
       # only while base has not yet received #210 (first release bootstrap).
       - name: Checkout PR head (for local composite action)
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -15,46 +15,51 @@ on:
       - 'v*.*.*dev*'           # Dev releases (v1.2.3dev1)
 
 permissions:
-  id-token: write              # OIDC → Trusted Publishing
-  pull-requests: write         # Comment on PRs
-  contents: read               # Read repository contents
-  issues: write                # Use Issues API for PR comments
+  contents: read
 
 jobs:
   test-release-build:
-    # Only run for PRs from dev with release labels
+    # Same-repo `dev` only. Forks named `dev` must not mint a TestPyPI OIDC
+    # token even if a maintainer adds a release label (#252 FMP-SEC-003).
     if: |
       github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.head.ref == 'dev' &&
       (contains(github.event.pull_request.labels.*.name, 'release:major') ||
        contains(github.event.pull_request.labels.*.name, 'release:minor') ||
        contains(github.event.pull_request.labels.*.name, 'release:patch'))
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.TEST_VERSION }}
+      head_sha: ${{ steps.version.outputs.HEAD_SHA }}
+      head_short: ${{ steps.version.outputs.HEAD_SHORT }}
     env:
       PYTHON_VERSION: "3.12"
 
     steps:
       - name: 🛎️  Checkout repository
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0  # Needed for version calculation
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: 🐍  Set up Python
-        uses: actions/setup-python@v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: ⚡  Install uv
-        uses: astral-sh/setup-uv@v9.0.0
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
         with:
           enable-cache: false
 
-      - name: 📦  Install build tools
+      - name: 📦  Install pinned build frontend
         run: |
-          uv pip install --system build hatch
+          uv pip install --system --require-hashes -r .github/requirements-build.txt
 
       - name: 🏷️  Calculate and create test version tag
         id: version
@@ -138,11 +143,46 @@ jobs:
           fi
           echo "📋 Built package version matches: $META_VERSION"
 
+          (cd dist && sha256sum ./* > ../SHA256SUMS)
+          cat SHA256SUMS
+
+      - name: 📤 Upload dist artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: test-release-dist
+          path: |
+            dist/
+            SHA256SUMS
+          if-no-files-found: error
+
+  test-release-publish:
+    needs: test-release-build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/fmp-data/${{ needs.test-release-build.outputs.version }}/
+    permissions:
+      id-token: write
+      pull-requests: write
+      issues: write
+      contents: read
+
+    steps:
+      - name: 📥 Download dist artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        with:
+          name: test-release-dist
+
+      - name: 🔐 Verify artifact checksums
+        run: |
+          set -euo pipefail
+          (cd dist && sha256sum -c ../SHA256SUMS)
+
       - name: 🧪  Upload to Test PyPI
         # skip-existing is intentionally OFF. With a unique version there is
         # nothing legitimate to skip; a collision must fail loudly rather than
         # report success while leaving a stale wheel installed. See #204.
-        uses: pypa/gh-action-pypi-publish@v1.14.2
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: dist
@@ -151,12 +191,12 @@ jobs:
           print-hash: true
 
       - name: 📝  Comment on PR
-        uses: actions/github-script@v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
-            const version = '${{ steps.version.outputs.TEST_VERSION }}';
-            const sha = '${{ steps.version.outputs.HEAD_SHA }}';
-            const short = '${{ steps.version.outputs.HEAD_SHORT }}';
+            const version = '${{ needs.test-release-build.outputs.version }}';
+            const sha = '${{ needs.test-release-build.outputs.head_sha }}';
+            const short = '${{ needs.test-release-build.outputs.head_short }}';
             const comment = `## 🧪 Test Release Published
 
             A test version has been published to TestPyPI for verification.
@@ -211,38 +251,73 @@ jobs:
               });
             }
 
-  # Original job for tag-based releases
-  publish-prerelease:
+  prerelease-build:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       PYTHON_VERSION: "3.12"
 
     steps:
       - name: 🛎️  Checkout repository
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0  # Needed for hatch-vcs versioning
           persist-credentials: false
 
       - name: 🐍  Set up Python
-        uses: actions/setup-python@v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: ⚡  Install uv
-        uses: astral-sh/setup-uv@v9.0.0
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
         with:
           enable-cache: false
 
       - name: 📦  Build wheel & sdist
         run: |
-          uv pip install --system build hatch
+          set -euo pipefail
+          uv pip install --system --require-hashes -r .github/requirements-build.txt
           python -m build --wheel --sdist
+          (cd dist && sha256sum ./* > ../SHA256SUMS)
+          cat SHA256SUMS
+
+      - name: 📤 Upload dist artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: prerelease-dist
+          path: |
+            dist/
+            SHA256SUMS
+          if-no-files-found: error
+
+  prerelease-publish:
+    needs: prerelease-build
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: 📥 Download dist artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        with:
+          name: prerelease-dist
+
+      - name: 🔐 Verify artifact checksums
+        run: |
+          set -euo pipefail
+          (cd dist && sha256sum -c ../SHA256SUMS)
 
       - name: 🚀  Upload to Test PyPI
-        uses: pypa/gh-action-pypi-publish@v1.14.2
+        # skip-existing OFF: a colliding prerelease tag is a real bug, not
+        # a reason to advertise whatever was already on TestPyPI (#252).
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: dist
-          skip-existing: true
+          skip-existing: false

--- a/.github/workflows/rebase-reminder.yml
+++ b/.github/workflows/rebase-reminder.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.event.pull_request.head.repo.fork == false
     steps:
       - name: Checkout PR head
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
@@ -33,7 +33,7 @@ jobs:
 
       - name: Comment if behind
         if: steps.check.outputs.behind != '0'
-        uses: peter-evans/create-or-update-comment@v5.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9  # v5.0.0
         with:
           issue-number: ${{ github.event.pull_request.number }}
           # Update the existing bot comment instead of posting a new one on

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
           ref: dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,13 @@ on:
     branches:
       - main
 
+# Least privilege at workflow scope. Each job raises only what it needs.
+# Build/tag/GitHub Release: contents: write. Publish: id-token: write only.
 permissions:
-  contents: write
-  id-token: write
-  pull-requests: read
+  contents: read
 
 jobs:
-  release:
+  build:
     # Only run if PR was merged and has a release label
     if: |
       github.event.pull_request.merged == true &&
@@ -21,12 +21,18 @@ jobs:
        contains(github.event.pull_request.labels.*.name, 'release:patch'))
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    outputs:
+      version: ${{ steps.version.outputs.VERSION }}
+      version_number: ${{ steps.version.outputs.VERSION_NUMBER }}
     env:
       PYTHON_VERSION: "3.14"
 
     steps:
       - name: 🛎️ Checkout repository
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0  # Fetch all history for proper versioning
           # Prefer the merge/squash commit on main so the tag points at what
@@ -35,18 +41,18 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🐍 Set up Python
-        uses: actions/setup-python@v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: ⚡ Install uv
-        uses: astral-sh/setup-uv@v9.0.0
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
         with:
           enable-cache: false
 
-      - name: 📦 Install dependencies
+      - name: 📦 Install pinned build frontend
         run: |
-          uv pip install --system build hatch
+          uv pip install --system --require-hashes -r .github/requirements-build.txt
 
       - name: 🏷️ Determine version bump type
         id: bump_type
@@ -140,10 +146,35 @@ jobs:
           git push origin "$RELEASE_TAG"
 
       - name: 📦 Build distribution
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.VERSION_NUMBER }}
         run: |
+          set -euo pipefail
           python -m build --wheel --sdist
           echo "Built artifacts:"
           ls -la dist/
+
+          shopt -s nullglob
+          sdists=(dist/*.tar.gz)
+          if [ "${#sdists[@]}" -eq 0 ]; then
+            echo "::error::No sdist found in dist/"
+            exit 1
+          fi
+          SDIST="${sdists[0]}"
+          META_VERSION=$(tar -xOf "$SDIST" --wildcards '*/PKG-INFO' 2>/dev/null \
+            | awk -F': ' '/^Version:/{print $2; exit}')
+          if [ -z "${META_VERSION:-}" ]; then
+            echo "::error::Could not read Version: from sdist PKG-INFO"
+            exit 1
+          fi
+          if [ "$META_VERSION" != "$EXPECTED_VERSION" ]; then
+            echo "::error::Built version '${META_VERSION}' != expected '${EXPECTED_VERSION}'"
+            exit 1
+          fi
+          echo "📋 Built package version matches: $META_VERSION"
+
+          (cd dist && sha256sum ./* > ../SHA256SUMS)
+          cat SHA256SUMS
 
       - name: 📋 Generate release notes from PR
         id: release_notes
@@ -215,11 +246,43 @@ jobs:
             --title "Release $RELEASE_TAG" \
             --notes-file release-notes.md
 
+      - name: 📤 Upload dist artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: python-package-dist
+          path: |
+            dist/
+            SHA256SUMS
+          if-no-files-found: error
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/fmp-data/${{ needs.build.outputs.version_number }}/
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: 📥 Download dist artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        with:
+          name: python-package-dist
+
+      - name: 🔐 Verify artifact checksums
+        run: |
+          set -euo pipefail
+          # SHA256SUMS was written from inside dist/, so verify there.
+          (cd dist && sha256sum -c ../SHA256SUMS)
+          ls -la dist
+
       - name: 🚀 Publish to PyPI
         # skip-existing OFF for real releases. A collision means the version
         # is already on PyPI; reporting success while leaving that older
         # artifact installed is the same silent-success class as #204.
-        uses: pypa/gh-action-pypi-publish@v1.14.2
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           packages-dir: dist/
           skip-existing: false

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
           # PAT preferred so pushes and PRs are not GITHUB_TOKEN-attributed (#206).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,20 @@ None. No FMP path we ship was newly retired by this changelog window.
   had made every unsigned automation commit need `--admin` despite green checks;
   required Test-Matrix jobs, no force-push, and no branch deletion remain.
 
+### Security
+
+- **Isolated PyPI publishing and immutable Actions pins (#252).** Release,
+  Dev-Release, and Publish-to-TestPyPI now build in a job with no OIDC token
+  and publish from a second job that only downloads hashed artifacts. Publish
+  jobs use the `pypi` / `testpypi` GitHub environments. All external
+  `uses:` entries are pinned to full commit SHAs. The PEP 517 frontend is
+  installed from `.github/requirements-build.txt` with `--require-hashes`.
+  `workflow_dispatch` on Dev-Release is bound to `refs/heads/dev`. The
+  TestPyPI PR path requires `head.repo.full_name == github.repository`.
+  Tag-based TestPyPI publishes no longer `skip-existing`. **Before the next
+  release**, set the PyPI and TestPyPI Trusted Publisher environment names
+  to `pypi` and `testpypi` to match the workflows.
+
 ## [2.6.0] - 2026-08-10
 
 Released from `dev`. A correctness-and-contracts release: the LangChain and MCP

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -123,10 +123,16 @@ the overlay in a hotfix-shaped PR.
 
 - **Dev Release** (`dev-release.yml`) publishes a unique TestPyPI build on
   every push to `dev` (`X.Y.Z.devN` with `N = run_id * 1000 + run_attempt`).
-  Re-runs never silently re-serve a previous wheel.
-- **Release** (`release.yml`) tags, creates the GitHub Release, and publishes
-  to PyPI after a labeled `dev → main` merge. Existing tags / releases / PyPI
-  versions fail the job instead of being skipped.
+  Re-runs never silently re-serve a previous wheel. Build and publish are
+  separate jobs; only publish holds `id-token: write`, behind the `testpypi`
+  environment. `workflow_dispatch` is bound to `refs/heads/dev`.
+- **Release** (`release.yml`) tags and creates the GitHub Release in a
+  `contents: write` build job, then publishes to PyPI from a second job that
+  only downloads the hashed artifacts and has `id-token: write` (environment
+  `pypi`). Existing tags / releases / PyPI versions fail the job instead of
+  being skipped.
+- External Actions are pinned to full commit SHAs. The PEP 517 frontend is
+  installed from `.github/requirements-build.txt` with `--require-hashes`.
 - **Claude Code Review** is advisory: missing or expired OAuth tokens do not
   fail the PR. Required gates live in `ci.yml` / the branch rulesets.
 
@@ -136,7 +142,7 @@ the overlay in a hotfix-shaped PR.
 |---|---|
 | `GH_TOKEN` | Fine-scoped PAT (or App token) for Release-PR / Sync-Main-to-Dev `gh pr create`, automation branch pushes, and sync-PR auto-merge so `pull_request` CI runs on open (#206) and the history-sync PR can land without a babysitter. Not the same as the automatic `GITHUB_TOKEN`. |
 | `GITHUB_TOKEN` | Automatic job token; used as fallback and for jobs that must not re-trigger workflows. |
-| OIDC / PyPI trusted publishing | Real and Test PyPI uploads (no long-lived PyPI token required when configured). |
+| OIDC / PyPI trusted publishing | Real and Test PyPI uploads (no long-lived PyPI token required when configured). The GitHub environments **must** be named `pypi` and `testpypi` in the matching PyPI / TestPyPI Trusted Publisher entries, or the OIDC exchange will fail. |
 
 ### Branch protection notes (sync PR)
 


### PR DESCRIPTION
## Summary

Closes the High finding **FMP-SEC-002** (and the leftover TestPyPI trigger holes from FMP-SEC-003) in #252.

Publishing previously resolved unlocked `build`/`hatch` and ran mutable Action tags in the same job that held `id-token: write` (and, for production, `contents: write`). A compromised tag or yanked build dependency could mint a PyPI token or push a release.

### What changed

- **Job split.** `release.yml`, `dev-release.yml`, and `publish-testpypi.yml` now **build** with `contents: read` (or `write` only where a tag/GitHub Release is created) and **no OIDC**. A second job downloads artifacts, checks SHA-256 digests, and is the only one with `id-token: write`.
- **Environments.** Publish jobs use GitHub environments `pypi` and `testpypi` (created, no reviewer lock — the Release trigger is `pull_request` closed, whose ref is `refs/pull/N/merge`).
- **Immutable Actions.** All 42 external `uses:` entries are pinned to full commit SHAs with a version comment. Local composite actions are unchanged.
- **Locked frontend.** `.github/requirements-build.txt` pins `build==1.5.0` and its deps with hashes; install uses `--require-hashes`. Hatch is no longer installed in publish jobs (`python -m build` is enough; hatchling/hatch-vcs come from PEP 517 isolation).
- **TestPyPI triggers.** `workflow_dispatch` on Dev-Release is bound to `refs/heads/dev`. The labeled PR path requires `head.repo.full_name == github.repository`. Tag-based TestPyPI no longer `skip-existing`.

## Merge blocker — Trusted Publisher environment names

**Before the next real or TestPyPI publish**, update the PyPI and TestPyPI Trusted Publisher entries so their GitHub environment names are `pypi` and `testpypi`. If they stay blank, OIDC exchange will fail closed. That is intentional.

PyPI: https://pypi.org/manage/project/fmp-data/settings/publishing/
TestPyPI: https://test.pypi.org/manage/project/fmp-data/settings/publishing/

Optional next step (not in this PR): add required reviewers on those environments once the publisher config is updated.

## Test plan

- [x] Pre-commit: yaml, detect-secrets, mypy.
- [x] `actionlint` on the rewritten publish workflows (only pre-existing `sync-main-to-dev` heredoc noise remains).
- [ ] After merge: confirm one Dev-Release / TestPyPI run publishes successfully **after** the Trusted Publisher environment name is set.
- [ ] Confirm a `workflow_dispatch` from a non-`dev` ref is skipped.

Refs #252