### PR TITLE
fix(mcp): parse manifests as data instead of executing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,15 @@ None. No FMP path we ship was newly retired by this changelog window.
   release**, set the PyPI and TestPyPI Trusted Publisher environment names
   to `pypi` and `testpypi` to match the workflows.
 
+- **MCP manifests are data, not executed code (#252).** `load_manifest_tools`
+  and `fmp-mcp validate` no longer `exec` user-supplied Python. Legacy
+  `TOOLS = ["..."]` files are parsed with a restricted AST (docstring + that
+  assignment only). Imports, calls, and any other statement are rejected.
+  JSON, YAML, and TOML manifests are also accepted (`["spec"]` or
+  `{"tools": ["spec"]}`). Existing generated and example `.py` manifests keep
+  working. A file that previously ran arbitrary code as "validation" now
+  fails closed.
+
 ## [2.6.0] - 2026-08-10
 
 Released from `dev`. A correctness-and-contracts release: the LangChain and MCP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,10 +188,11 @@ None. No FMP path we ship was newly retired by this changelog window.
   and `fmp-mcp validate` no longer `exec` user-supplied Python. Legacy
   `TOOLS = ["..."]` files are parsed with a restricted AST (docstring + that
   assignment only). Imports, calls, and any other statement are rejected.
-  JSON, YAML, and TOML manifests are also accepted (`["spec"]` or
-  `{"tools": ["spec"]}`). Existing generated and example `.py` manifests keep
-  working. A file that previously ran arbitrary code as "validation" now
-  fails closed.
+  JSON and YAML accept a top-level list or `{"tools": ["..."]}`. TOML
+  accepts `tools = ["..."]` only (no top-level array). On Python 3.10
+  TOML uses `tomli` from the `mcp` extra; 3.11+ uses stdlib `tomllib`.
+  Existing generated and example `.py` manifests keep working. A file
+  that previously ran arbitrary code as "validation" now fails closed.
 
 ## [2.6.0] - 2026-08-10
 

--- a/README.md
+++ b/README.md
@@ -184,14 +184,11 @@ Full tool list: [docs/mcp/tools.md](https://github.com/MehdiZare/fmp-data/blob/m
 export FMP_API_KEY=your_api_key_here
 export FMP_MCP_MANIFEST=/path/to/custom/manifest.py
 
-# Custom manifest example (manifest.py)
-TOOLS = [
-    "company.profile",
-    "market.search",
-    "company.quote",
-    "fundamental.income_statement",
-    "fundamental.balance_sheet"
-]
+# Custom manifest example (manifest.json — preferred)
+# { "tools": ["company.profile", "company.quote"] }
+#
+# Legacy Python is parsed as data, not executed:
+# TOOLS = ["company.profile", "company.quote"]
 ```
 
 ### Integration with AI Assistants

--- a/docs/mcp/configurations.md
+++ b/docs/mcp/configurations.md
@@ -117,7 +117,9 @@ Preferred new format:
 ```
 
 YAML (`tools: [company.profile]`) and TOML (`tools = ["company.profile"]`)
-are accepted the same way.
+are accepted the same way. TOML has no top-level array form; use a
+`tools` table. On Python 3.10 the `mcp` extra pulls in `tomli` for that
+parse; 3.11+ uses stdlib `tomllib`.
 
 You can still create a legacy Python manifest by:
 

--- a/docs/mcp/configurations.md
+++ b/docs/mcp/configurations.md
@@ -104,7 +104,22 @@ app.run()
 
 ## Creating Custom Configurations
 
-You can create your own manifest by:
+Manifests are **data**. `fmp-mcp validate` and the server parse them; they
+never import or execute the file. A Python file that is not exactly a
+docstring plus `TOOLS = ["..."]` is rejected.
+
+Preferred new format:
+
+```json
+{
+  "tools": ["company.profile", "company.quote"]
+}
+```
+
+YAML (`tools: [company.profile]`) and TOML (`tools = ["company.profile"]`)
+are accepted the same way.
+
+You can still create a legacy Python manifest by:
 
 1. **Manual creation** - Copy one of these examples and modify:
 ```python

--- a/fmp_data/mcp/cli.py
+++ b/fmp_data/mcp/cli.py
@@ -965,6 +965,9 @@ def validate_manifest(manifest_path: str | Path) -> bool:
     """
     Validate a manifest file for correctness.
 
+    The file is loaded as data (JSON / YAML / TOML / restricted ``TOOLS =``
+    Python). It is never imported or executed.
+
     Parameters
     ----------
     manifest_path
@@ -975,7 +978,7 @@ def validate_manifest(manifest_path: str | Path) -> bool:
     bool
         True if valid, False otherwise
     """
-    import importlib.util
+    from fmp_data.mcp.utils import load_manifest_tools
 
     manifest_path = Path(manifest_path).expanduser().resolve()
 
@@ -983,31 +986,11 @@ def validate_manifest(manifest_path: str | Path) -> bool:
         print(f"Error: Manifest file not found: {manifest_path}", file=sys.stderr)
         return False
 
-    # Try to import the manifest
-    spec = importlib.util.spec_from_file_location("test_manifest", manifest_path)
-    if spec is None or spec.loader is None:
-        print(f"Error: Cannot import manifest: {manifest_path}", file=sys.stderr)
-        return False
-
-    module = importlib.util.module_from_spec(spec)
     try:
-        spec.loader.exec_module(module)
+        tools = load_manifest_tools(manifest_path)
     except Exception as e:
         print(f"Error loading manifest: {e}", file=sys.stderr)
         return False
-
-    tools = getattr(module, "TOOLS", None)
-    if tools is None:
-        print("Error: Manifest does not define TOOLS variable", file=sys.stderr)
-        return False
-    if not isinstance(tools, list):
-        print("Error: TOOLS must be a list", file=sys.stderr)
-        return False
-
-    for tool in tools:
-        if not isinstance(tool, str):
-            print(f"Error: Tool spec must be string, got {type(tool)}", file=sys.stderr)
-            return False
 
     unknown, ambiguous, deprecated, withdrawn = _classify_manifest_entries(tools)
     duplicates, collisions = _manifest_name_clashes(tools)

--- a/fmp_data/mcp/server.py
+++ b/fmp_data/mcp/server.py
@@ -23,7 +23,9 @@ def create_app(tools: ToolIterable | None = None) -> MCPServerType:
     ----------
     tools
         * **None** (default)    - look for env-var ``FMP_MCP_MANIFEST`` or use defaults.
-        * **str | Path**        - path to a *.py* manifest that defines ``TOOLS``.
+        * **str | Path**        - path to a data-only manifest (``.json``,
+          ``.yaml``, ``.toml``, or a restricted ``TOOLS = ["..."]`` ``.py``
+          file). The file is never executed.
         * **Iterable[str]**     - already-constructed list/tuple/etc. of tool specs.
 
     Returns

--- a/fmp_data/mcp/utils.py
+++ b/fmp_data/mcp/utils.py
@@ -477,10 +477,14 @@ def _load_yaml_manifest(path: Path) -> list[str]:
 def _load_toml_manifest(path: Path) -> list[str]:
     try:
         import tomllib
-    except ImportError as exc:  # pragma: no cover - Python 3.10
-        raise RuntimeError(
-            f"Cannot load {path}: TOML manifests require Python 3.11+ (stdlib tomllib)."
-        ) from exc
+    except ImportError:  # pragma: no cover - Python 3.10
+        try:
+            import tomli as tomllib  # type: ignore[no-redef]
+        except ImportError as exc:
+            raise RuntimeError(
+                f"Cannot load {path}: TOML manifests need tomli on Python "
+                "3.10. Install with: pip install 'fmp-data[mcp]'"
+            ) from exc
     try:
         data = tomllib.loads(path.read_text(encoding="utf-8"))
     except tomllib.TOMLDecodeError as exc:
@@ -493,8 +497,10 @@ def load_manifest_tools(manifest_path: str | Path | None) -> list[str]:
     Load tool specs from a data-only manifest, or return defaults.
 
     Python files are parsed as a restricted ``TOOLS = ["..."]`` assignment.
-    They are never imported or executed. JSON, YAML, and TOML files are
-    accepted as a top-level list or an object with a ``tools`` list.
+    They are never imported or executed. JSON and YAML accept a top-level
+    list or an object with a ``tools`` list. TOML accepts only a ``tools``
+    array (no top-level TOML array). On Python 3.10 TOML parsing uses
+    ``tomli`` from the mcp extra.
 
     Parameters
     ----------

--- a/fmp_data/mcp/utils.py
+++ b/fmp_data/mcp/utils.py
@@ -6,8 +6,8 @@ Helper functions for setting up and managing MCP server configuration.
 
 from __future__ import annotations
 
+import ast
 from datetime import datetime
-import importlib.util
 import json
 import os
 from pathlib import Path
@@ -366,14 +366,140 @@ def get_manifest_choices() -> dict[str, str | None]:
     return choices
 
 
+def _coerce_tool_list(data: Any, path: Path) -> list[str]:
+    """Accept a top-level list or an object with a ``tools`` list of strings."""
+    if isinstance(data, list):
+        items = data
+    elif isinstance(data, dict) and "tools" in data:
+        items = data["tools"]
+    else:
+        raise ValueError(
+            f"{path} must be a list of tool specs or an object with a "
+            "'tools' list of strings"
+        )
+    if not isinstance(items, list):
+        raise ValueError(f"{path}: 'tools' must be a list of strings")
+    tools: list[str] = []
+    for item in items:
+        if not isinstance(item, str) or not item:
+            raise ValueError(f"{path}: every tool spec must be a non-empty string")
+        tools.append(item)
+    return tools
+
+
+def _string_list_from_ast(node: ast.AST, path: Path) -> list[str]:
+    if not isinstance(node, ast.List):
+        raise ValueError(
+            f"{path} is not a data-only manifest: TOOLS must be a list of "
+            "string literals. A Python manifest does not execute."
+        )
+    tools: list[str] = []
+    for elt in node.elts:
+        if (
+            not isinstance(elt, ast.Constant)
+            or not isinstance(elt.value, str)
+            or not elt.value
+        ):
+            raise ValueError(
+                f"{path} is not a data-only manifest: TOOLS must contain only "
+                "non-empty string literals. A Python manifest does not execute."
+            )
+        tools.append(elt.value)
+    return tools
+
+
+def _parse_python_manifest(source: str, path: Path) -> list[str]:
+    """Parse a legacy ``TOOLS = ["..."]`` file without executing it."""
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as exc:
+        raise ValueError(f"Invalid Python manifest {path}: {exc}") from exc
+
+    tools: list[str] | None = None
+    for stmt in tree.body:
+        if (
+            isinstance(stmt, ast.Expr)
+            and isinstance(stmt.value, ast.Constant)
+            and isinstance(stmt.value.value, str)
+        ):
+            continue
+        if isinstance(stmt, ast.Assign):
+            if (
+                len(stmt.targets) != 1
+                or not isinstance(stmt.targets[0], ast.Name)
+                or stmt.targets[0].id != "TOOLS"
+            ):
+                raise ValueError(
+                    f"{path} is not a data-only manifest: only a module-level "
+                    "TOOLS = [...] assignment is allowed. A Python manifest "
+                    "does not execute."
+                )
+            if tools is not None:
+                raise ValueError(
+                    f"{path} is not a data-only manifest: TOOLS is assigned "
+                    "more than once. A Python manifest does not execute."
+                )
+            tools = _string_list_from_ast(stmt.value, path)
+            continue
+        raise ValueError(
+            f"{path} is not a data-only manifest: only a docstring and "
+            "TOOLS = [...] are allowed. A Python manifest does not execute."
+        )
+
+    if tools is None:
+        raise AttributeError(f"{path} does not define a global variable 'TOOLS'")
+    return tools
+
+
+def _load_json_manifest(path: Path) -> list[str]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON manifest {path}: {exc}") from exc
+    return _coerce_tool_list(data, path)
+
+
+def _load_yaml_manifest(path: Path) -> list[str]:
+    try:
+        import yaml
+    except ImportError as exc:
+        raise RuntimeError(
+            f"Cannot load {path}: PyYAML is required for YAML manifests. "
+            "Install with: pip install 'fmp-data[mcp]'"
+        ) from exc
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Invalid YAML manifest {path}: {exc}") from exc
+    return _coerce_tool_list(data, path)
+
+
+def _load_toml_manifest(path: Path) -> list[str]:
+    try:
+        import tomllib
+    except ImportError as exc:  # pragma: no cover - Python 3.10
+        raise RuntimeError(
+            f"Cannot load {path}: TOML manifests require Python 3.11+ (stdlib tomllib)."
+        ) from exc
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        raise ValueError(f"Invalid TOML manifest {path}: {exc}") from exc
+    return _coerce_tool_list(data, path)
+
+
 def load_manifest_tools(manifest_path: str | Path | None) -> list[str]:
     """
-    Load tool specs from a manifest file or return defaults.
+    Load tool specs from a data-only manifest, or return defaults.
+
+    Python files are parsed as a restricted ``TOOLS = ["..."]`` assignment.
+    They are never imported or executed. JSON, YAML, and TOML files are
+    accepted as a top-level list or an object with a ``tools`` list.
 
     Parameters
     ----------
     manifest_path
-        Path to a manifest file that defines ``TOOLS``, or None for defaults.
+        Path to a manifest file, or None for defaults.
 
     Returns
     -------
@@ -386,18 +512,18 @@ def load_manifest_tools(manifest_path: str | Path | None) -> list[str]:
         return list(DEFAULT_TOOLS)
 
     path = Path(manifest_path).expanduser().resolve()
-    spec = importlib.util.spec_from_file_location("user_manifest", path)
-    if spec is None or spec.loader is None:
-        raise RuntimeError(f"Cannot import manifest at {path}")
+    if not path.is_file():
+        raise FileNotFoundError(f"Manifest file not found: {path}")
 
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        return _load_json_manifest(path)
+    if suffix in {".yaml", ".yml"}:
+        return _load_yaml_manifest(path)
+    if suffix == ".toml":
+        return _load_toml_manifest(path)
 
-    tools = getattr(module, "TOOLS", None)
-    if tools is None:
-        raise AttributeError(f"{path} does not define a global variable 'TOOLS'")
-
-    return list(tools)
+    return _parse_python_manifest(path.read_text(encoding="utf-8"), path)
 
 
 def restart_claude_desktop_instructions() -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,8 @@ mcp = [
     # security-fixes only).
     "mcp[cli]>=2.0.0",
     "pyyaml>=6.0.3",
+    # stdlib tomllib is 3.11+; keep TOML manifests working on 3.10.
+    "tomli>=2.0.1; python_version < '3.11'",
 ]
 cache-redis = [
     "redis>=8.1.0",
@@ -282,6 +284,8 @@ module = [
     "redis",
     "yaml.*",
     "yaml",
+    "tomli",
+    "tomli.*",
     "rich.*",
     "tqdm.*",
     "pandas.*",

--- a/tests/unit/test_mcp.py
+++ b/tests/unit/test_mcp.py
@@ -1091,14 +1091,77 @@ class TestMCPManifestLoading:
         assert tools == ["company.profile", "market.gainers"]
 
     def test_load_manifest_tools_missing_tools(self, tmp_path):
-        """Missing TOOLS should raise."""
+        """A comment-only Python file has no TOOLS assignment."""
         from fmp_data.mcp.utils import load_manifest_tools
 
         manifest = tmp_path / "manifest.py"
-        manifest.write_text("X = 1")
+        manifest.write_text("# No TOOLS variable\n")
 
         with pytest.raises(AttributeError, match="does not define"):
             load_manifest_tools(manifest)
+
+    def test_load_manifest_refuses_executable_python(self, tmp_path):
+        """A 'manifest' must not run arbitrary code (#252 FMP-SEC-001)."""
+        from fmp_data.mcp.utils import load_manifest_tools
+
+        marker = tmp_path / "executed"
+        manifest = tmp_path / "evil.py"
+        manifest.write_text(
+            f"open({str(marker)!r}, 'w').write('RAN')\nTOOLS = ['company.profile']\n"
+        )
+
+        with pytest.raises(ValueError, match="does not execute"):
+            load_manifest_tools(manifest)
+        assert not marker.exists()
+
+    def test_load_manifest_refuses_imports_and_calls(self, tmp_path):
+        from fmp_data.mcp.utils import load_manifest_tools
+
+        manifest = tmp_path / "importy.py"
+        manifest.write_text(
+            "import os\nTOOLS = [os.getenv('HOME', 'company.profile')]\n"
+        )
+
+        with pytest.raises(ValueError, match="does not execute"):
+            load_manifest_tools(manifest)
+
+    def test_load_manifest_json_list(self, tmp_path):
+        from fmp_data.mcp.utils import load_manifest_tools
+
+        manifest = tmp_path / "manifest.json"
+        manifest.write_text('["company.profile", "market.gainers"]\n')
+
+        assert load_manifest_tools(manifest) == ["company.profile", "market.gainers"]
+
+    def test_load_manifest_json_object(self, tmp_path):
+        from fmp_data.mcp.utils import load_manifest_tools
+
+        manifest = tmp_path / "manifest.json"
+        manifest.write_text('{"tools": ["company.profile"]}\n')
+
+        assert load_manifest_tools(manifest) == ["company.profile"]
+
+    def test_load_manifest_yaml_object(self, tmp_path):
+        from fmp_data.mcp.utils import load_manifest_tools
+
+        manifest = tmp_path / "manifest.yaml"
+        manifest.write_text("tools:\n  - company.profile\n  - market.gainers\n")
+
+        assert load_manifest_tools(manifest) == ["company.profile", "market.gainers"]
+
+    def test_validate_manifest_does_not_execute_python(self, tmp_path, capsys):
+        from fmp_data.mcp.cli import validate_manifest
+
+        marker = tmp_path / "validated"
+        manifest = tmp_path / "evil.py"
+        manifest.write_text(
+            f"open({str(marker)!r}, 'w').write('RAN')\nTOOLS = ['company.profile']\n"
+        )
+
+        assert validate_manifest(manifest) is False
+        assert not marker.exists()
+        err = capsys.readouterr().err
+        assert "does not execute" in err or "ManifestExecutionError" in err
 
 
 @pytest.mark.integration

--- a/tests/unit/test_mcp.py
+++ b/tests/unit/test_mcp.py
@@ -1125,6 +1125,42 @@ class TestMCPManifestLoading:
         with pytest.raises(ValueError, match="does not execute"):
             load_manifest_tools(manifest)
 
+    def test_load_manifest_refuses_call_inside_tools_list(self, tmp_path):
+        """A call as a TOOLS element must not run (#252 FMP-SEC-001)."""
+        from fmp_data.mcp.utils import load_manifest_tools
+
+        marker = tmp_path / "rhs-executed"
+        manifest = tmp_path / "rhs_call.py"
+        manifest.write_text(
+            f"TOOLS = [__import__('pathlib').Path({str(marker)!r}).write_text('RAN')]\n"
+        )
+
+        with pytest.raises(ValueError, match="does not execute"):
+            load_manifest_tools(manifest)
+        assert not marker.exists()
+
+    def test_load_manifest_refuses_fstring_inside_tools_list(self, tmp_path):
+        from fmp_data.mcp.utils import load_manifest_tools
+
+        marker = tmp_path / "fstring-executed"
+        manifest = tmp_path / "rhs_fstring.py"
+        manifest.write_text(
+            'TOOLS = [f"{open(' + repr(str(marker)) + ", 'w').write('RAN')}\"]\n"
+        )
+
+        with pytest.raises(ValueError, match="does not execute"):
+            load_manifest_tools(manifest)
+        assert not marker.exists()
+
+    def test_load_manifest_refuses_non_tools_assignment(self, tmp_path):
+        from fmp_data.mcp.utils import load_manifest_tools
+
+        manifest = tmp_path / "manifest.py"
+        manifest.write_text("X = 1\nTOOLS = ['company.profile']\n")
+
+        with pytest.raises(ValueError, match="does not execute"):
+            load_manifest_tools(manifest)
+
     def test_load_manifest_json_list(self, tmp_path):
         from fmp_data.mcp.utils import load_manifest_tools
 
@@ -1149,6 +1185,22 @@ class TestMCPManifestLoading:
 
         assert load_manifest_tools(manifest) == ["company.profile", "market.gainers"]
 
+    def test_load_manifest_yml_suffix(self, tmp_path):
+        from fmp_data.mcp.utils import load_manifest_tools
+
+        manifest = tmp_path / "manifest.yml"
+        manifest.write_text("- company.profile\n")
+
+        assert load_manifest_tools(manifest) == ["company.profile"]
+
+    def test_load_manifest_toml_object(self, tmp_path):
+        from fmp_data.mcp.utils import load_manifest_tools
+
+        manifest = tmp_path / "manifest.toml"
+        manifest.write_text('tools = ["company.profile", "market.gainers"]\n')
+
+        assert load_manifest_tools(manifest) == ["company.profile", "market.gainers"]
+
     def test_validate_manifest_does_not_execute_python(self, tmp_path, capsys):
         from fmp_data.mcp.cli import validate_manifest
 
@@ -1161,7 +1213,16 @@ class TestMCPManifestLoading:
         assert validate_manifest(manifest) is False
         assert not marker.exists()
         err = capsys.readouterr().err
-        assert "does not execute" in err or "ManifestExecutionError" in err
+        assert "does not execute" in err
+
+    def test_validate_manifest_rejects_malformed_json(self, tmp_path, capsys):
+        from fmp_data.mcp.cli import validate_manifest
+
+        manifest = tmp_path / "broken.json"
+        manifest.write_text("{not json\n")
+
+        assert validate_manifest(manifest) is False
+        assert "Invalid JSON" in capsys.readouterr().err
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary

Closes the High finding **FMP-SEC-001** from #252.

`fmp-mcp validate` and MCP server startup treated user-supplied `.py` manifests as importable modules (`spec.loader.exec_module`). A file that looked like a tool list could run arbitrary code in a process that already has `FMP_API_KEY` in the environment. The command name `validate` implied inspection.

Manifests are now **data**:

- Legacy `TOOLS = ["..."]` Python is parsed with a restricted AST (optional module docstring + that assignment only).
- Imports, calls, starred expressions, and any other statement are rejected. The file is never executed.
- JSON, YAML, and TOML are accepted as a top-level list or an object with a `tools` list.
- Existing generated and example `.py` manifests keep working unchanged.

A local probe of `open(...).write('RAN'); TOOLS = ['profile']` now raises instead of printing `Manifest is valid with 1 tool`.

## Test plan

- [x] New unit tests: executable Python is refused and leaves no side-effect file; imports/calls refused; JSON list + `{tools: []}` load; YAML loads; `validate` returns False without executing.
- [x] Existing example-manifest, generate/validate coherence, and CLI tests still pass (`220 passed` in the MCP unit files).
- [x] Pre-commit: ruff, bandit, mypy, detect-secrets.

## Compatibility

Not breaking for shipped manifests. Breaking only for anyone who used a `.py` manifest as a plugin (imports, function calls, `from ... import DEFAULT_TOOLS`). Those files were never a documented plugin API; they should become JSON/YAML or a plain `TOOLS = [...]` list.