### PR TITLE
fix(client): refuse bytes in _unwrap_list_result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,13 @@ None. No FMP path we ship was newly retired by this changelog window.
   Existing generated and example `.py` manifests keep working. A file
   that previously ran arbitrary code as "validation" now fails closed.
 
+### Fixed
+
+- **`_unwrap_list_result` refuses a bytes file (#253).** `request_list` already
+  raised `TypeError` for `Endpoint[bytes]`, but the shared unwrap helper still
+  treated `isinstance(payload, bytes)` as a lone row and returned `[bytes]`.
+  Quote-list unwrap is unchanged.
+
 ## [2.6.0] - 2026-08-10
 
 Released from `dev`. A correctness-and-contracts release: the LangChain and MCP

--- a/fmp_data/base.py
+++ b/fmp_data/base.py
@@ -60,7 +60,16 @@ def _unwrap_list_result(result: T | list[T], model: type[T]) -> list[T]:
     ``model`` is a type witness for ``T``. A value that is already an
     instance of ``model`` is wrapped first so a list-like row type is
     not treated as an already-unwrapped ``list[T]``.
+
+    ``model is bytes`` is refused. ``isinstance(payload, bytes)`` is
+    true, so the wrap-first branch would turn a CSV/XLSX body into
+    ``[bytes]``. Use ``request()`` or a dedicated bytes helper.
     """
+    if model is bytes:
+        raise TypeError(
+            "bytes is not a list row type; use request() or a dedicated "
+            "bytes helper, not _unwrap_list"
+        )
     if isinstance(result, model):
         return [result]
     if isinstance(result, list):

--- a/tests/unit/test_bulk_bytes.py
+++ b/tests/unit/test_bulk_bytes.py
@@ -187,10 +187,18 @@ class TestRequestCsvIsTheBytesHelper:
         assert all(not isinstance(row, bytes) for row in rows)
         mock_client.request_async.assert_awaited_once_with(PROFILE_BULK, part="0")
 
-    def test_unwrap_list_would_wrap_bytes_as_a_single_row(self) -> None:
-        """``isinstance(payload, bytes)`` is true, so unwrap is the wrong helper."""
+    def test_unwrap_list_refuses_bytes(self) -> None:
+        """``isinstance(payload, bytes)`` is true; unwrap must not wrap a file."""
         raw = b"symbol,name\nAAPL,Apple\n"
-        assert _unwrap_list_result(raw, bytes) == [raw]
+        with pytest.raises(TypeError, match="not a list row type"):
+            _unwrap_list_result(raw, bytes)
+
+    def test_endpoint_group_unwrap_list_refuses_bytes(self) -> None:
+        from fmp_data.base import EndpointGroup
+
+        raw = b"PK\x03\x04xlsx"
+        with pytest.raises(TypeError, match="not a list row type"):
+            EndpointGroup._unwrap_list(raw, bytes)
 
 
 def _base_client() -> BaseClient:


### PR DESCRIPTION
## Summary

Closes #253.

`request_list` already raised `TypeError` for `Endpoint[bytes]`. `_unwrap_list_result` (used by `EndpointGroup._unwrap_list` / `AsyncEndpointGroup._unwrap_list`) still treated `isinstance(payload, bytes)` as a lone row and returned `[bytes]`. A mistaken `self._unwrap_list(self.client.request(FINANCIAL_REPORTS_XLSX, ...), bytes)` was silent.

The helper now refuses `model is bytes`. Quote-list unwrap is unchanged. `request_list` still fails before `request()`.

## Test plan

- [x] `tests/unit/test_bulk_bytes.py` (66 passed)
- [x] ruff, mypy