### PR TITLE
feat(mcp): write generate output from the file suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,14 @@ None. No FMP path we ship was newly retired by this changelog window.
   treated `isinstance(payload, bytes)` as a lone row and returned `[bytes]`.
   Quote-list unwrap is unchanged.
 
+### Changed
+
+- **`fmp-mcp generate` writes JSON / YAML / TOML from the output suffix (#256).**
+  `.json` is preferred (`{"tools": [...]}`). `.yaml` / `.yml` and `.toml` use
+  the same `tools` object. A path with no suffix becomes `<name>.json`.
+  `.py` still writes the restricted `TOOLS = ["..."]` form so existing
+  scripts keep working. Unknown suffixes are refused.
+
 ## [2.6.0] - 2026-08-10
 
 Released from `dev`. A correctness-and-contracts release: the LangChain and MCP

--- a/docs/mcp/configurations.md
+++ b/docs/mcp/configurations.md
@@ -133,19 +133,24 @@ TOOLS = [
 ]
 ```
 
-2. **Using the CLI tool** - Generate a manifest with specific tools:
+2. **Using the CLI tool** - Generate a manifest with specific tools.
+   The suffix chooses the format (``.json`` preferred; ``.yaml`` / ``.toml``
+   / legacy ``.py`` still work):
 ```bash
-# Generate manifest with specific tools
-fmp-mcp generate my_manifest.py --tools company.profile company.quote
+# Generate a JSON manifest (preferred)
+fmp-mcp generate my_manifest.json --tools company.profile company.quote
 
-# Generate manifest without default tools
-fmp-mcp generate my_manifest.py --no-defaults --tools company.quote market.gainers
+# Generate without default tools
+fmp-mcp generate my_manifest.json --no-defaults --tools company.quote market.gainers
 
-# Generate a manifest covering the whole catalog
-fmp-mcp generate everything.py
+# Whole catalog
+fmp-mcp generate everything.json
 
 # Bare keys work too, and are written out in their fully qualified form
-fmp-mcp generate my_manifest.py --no-defaults --tools profile quote gainers
+fmp-mcp generate my_manifest.json --no-defaults --tools profile quote gainers
+
+# Legacy Python (still parsed as data, never executed)
+fmp-mcp generate my_manifest.py --tools company.profile company.quote
 ```
 
 `--tools` accepts the same two entry forms a manifest does — a bare key

--- a/fmp_data/mcp/cli.py
+++ b/fmp_data/mcp/cli.py
@@ -378,6 +378,43 @@ def _manifest_header(
     return "\n".join(lines)
 
 
+_GENERATE_SUFFIXES = {".json", ".yaml", ".yml", ".toml", ".py"}
+
+
+def _normalize_generate_path(path: Path) -> Path:
+    """Choose a write path whose suffix ``load_manifest_tools`` understands."""
+    if path.suffix == "":
+        return path.with_suffix(".json")
+    if path.suffix.lower() not in _GENERATE_SUFFIXES:
+        raise ValueError(f"{path}: generate writes .json, .yaml, .yml, .toml, or .py")
+    return path
+
+
+def _render_generated_manifest(
+    path: Path,
+    tools: list[str],
+    deprecated: list[str],
+    excluded: list[str],
+    collisions: dict[str, list[str]],
+    withdrawn: list[str],
+) -> str:
+    """Serialize ``tools`` in the format implied by ``path.suffix``."""
+    sorted_tools = sorted(tools)
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        return json.dumps({"tools": sorted_tools}, indent=2) + "\n"
+    if suffix in {".yaml", ".yml"}:
+        lines = ["tools:"]
+        lines.extend(f'  - "{spec}"' for spec in sorted_tools)
+        return "\n".join(lines) + "\n"
+    if suffix == ".toml":
+        quoted = ", ".join(json.dumps(spec) for spec in sorted_tools)
+        return f"tools = [{quoted}]\n"
+    header = _manifest_header(deprecated, excluded, collisions, withdrawn)
+    body = "\n".join(f'    "{spec}",' for spec in sorted_tools)
+    return f"{header}\nTOOLS = [\n{body}\n]\n"
+
+
 def _startable_catalog(
     available_specs: set[str],
     excluded: list[str],
@@ -620,7 +657,11 @@ def generate_manifest(
     Parameters
     ----------
     output_path
-        Path to save the manifest file
+        Path to save the manifest. The suffix chooses the format:
+        ``.json`` (preferred), ``.yaml`` / ``.yml``, ``.toml``, or
+        legacy ``.py``. A path with no suffix is written as ``.json``.
+        Other suffixes are refused. A ``.py`` file is still a data-only
+        ``TOOLS = ["..."]`` assignment, never executed.
     tools
         List of tool specs to include (if None, includes the whole catalog)
     include_defaults
@@ -634,6 +675,11 @@ def generate_manifest(
         failed entry has been printed to stderr.
     """
     output_path = Path(output_path)
+    try:
+        output_path = _normalize_generate_path(output_path)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return False
 
     # Get available tools
     available_tools = list_available_tools()
@@ -692,16 +738,14 @@ def generate_manifest(
             )
             return False
 
-    # Generate manifest content
-    manifest_content = (
-        _manifest_header(deprecated, excluded, collisions, withdrawn) + "\nTOOLS = [\n"
+    manifest_content = _render_generated_manifest(
+        output_path,
+        selected_tools,
+        deprecated,
+        excluded,
+        collisions,
+        withdrawn,
     )
-    for tool in sorted(selected_tools):
-        manifest_content += f'    "{tool}",\n'
-
-    manifest_content += "]\n"
-
-    # Save manifest
     output_path.write_text(manifest_content)
     print(f"Manifest saved to: {output_path}")
     print(f"Total tools: {len(selected_tools)}")
@@ -1194,7 +1238,13 @@ def main() -> None:
 
     # Generate manifest command
     gen_parser = subparsers.add_parser("generate", help="Generate manifest file")
-    gen_parser.add_argument("output", help="Output file path")
+    gen_parser.add_argument(
+        "output",
+        help=(
+            "Output file path. Suffix selects the format: .json (preferred), "
+            ".yaml, .toml, or legacy .py. No suffix writes <name>.json."
+        ),
+    )
     gen_parser.add_argument("--tools", nargs="+", help="Specific tools to include")
     gen_parser.add_argument(
         "--no-defaults", action="store_true", help="Exclude default tools"

--- a/tests/unit/test_mcp_cli.py
+++ b/tests/unit/test_mcp_cli.py
@@ -939,6 +939,81 @@ class TestGeneratedManifestIsUsable:
         assert content.endswith("]\n")
 
 
+class TestGenerateManifestFormatFromSuffix:
+    """#256: suffix chooses JSON / YAML / TOML / legacy Python."""
+
+    @staticmethod
+    def _write(
+        tmp_path: Path, name: str
+    ) -> tuple[Path, bool, list[str] | None, str | None]:
+        from fmp_data.mcp.cli import generate_manifest
+        from fmp_data.mcp.utils import load_manifest_tools
+
+        path = tmp_path / name
+        written = generate_manifest(
+            path,
+            tools=["company.profile", "market.gainers"],
+            include_defaults=False,
+        )
+        if not written:
+            return path, written, None, None
+        return path, written, load_manifest_tools(path), path.read_text()
+
+    def test_json_suffix_writes_tools_object(self, tmp_path: Path) -> None:
+        _path, written, tools, content = self._write(tmp_path, "manifest.json")
+        assert written is True
+        assert tools == ["company.profile", "market.gainers"]
+        assert content is not None
+        assert '"tools"' in content
+        assert "TOOLS =" not in content
+        assert content.endswith("\n")
+
+    def test_yaml_suffix_loads(self, tmp_path: Path) -> None:
+        _, written, tools, content = self._write(tmp_path, "manifest.yaml")
+        assert written is True
+        assert tools == ["company.profile", "market.gainers"]
+        assert content is not None
+        assert content.startswith("tools:")
+
+    def test_toml_suffix_loads(self, tmp_path: Path) -> None:
+        _, written, tools, content = self._write(tmp_path, "manifest.toml")
+        assert written is True
+        assert tools == ["company.profile", "market.gainers"]
+        assert content is not None
+        assert content.startswith("tools = [")
+
+    def test_py_suffix_still_writes_tools_assignment(self, tmp_path: Path) -> None:
+        _, written, tools, content = self._write(tmp_path, "manifest.py")
+        assert written is True
+        assert tools == ["company.profile", "market.gainers"]
+        assert content is not None
+        assert "TOOLS = [" in content
+
+    def test_no_suffix_writes_json(self, tmp_path: Path) -> None:
+        from fmp_data.mcp.cli import generate_manifest
+        from fmp_data.mcp.utils import load_manifest_tools
+
+        path = tmp_path / "manifest"
+        written = generate_manifest(
+            path, tools=["company.profile"], include_defaults=False
+        )
+        written_path = tmp_path / "manifest.json"
+        assert written is True
+        assert not path.exists()
+        assert load_manifest_tools(written_path) == ["company.profile"]
+
+    def test_unknown_suffix_is_refused(self, tmp_path: Path, capsys) -> None:
+        from fmp_data.mcp.cli import generate_manifest
+
+        path = tmp_path / "manifest.txt"
+        written = generate_manifest(
+            path, tools=["company.profile"], include_defaults=False
+        )
+        assert written is False
+        assert not path.exists()
+        assert ".json" in capsys.readouterr().err
+
+
 class TestListLabelsAllThreeRetirementConcepts:
     """#158: ``list`` knew only about renames, so withdrawals read as live.
 


### PR DESCRIPTION
## Summary

Closes #256.

`fmp-mcp generate` still wrote a `.py` `TOOLS = [...]` file after #255 made JSON the preferred manifest format. The suffix now selects the writer:

- `.json` (preferred, and the default when the path has no suffix) → `{"tools": [...]}`
- `.yaml` / `.yml` / `.toml` → a `tools` list
- `.py` → the existing restricted `TOOLS = ["..."]` form so current scripts keep working
- anything else is refused (no file written)

Omission notes for catalog generation still go to stdout. The Python header stays on `.py` only.

## Test plan

- [x] New suffix tests in `tests/unit/test_mcp_cli.py`
- [x] Existing generate/validate startable tests still pass
- [x] ruff, mypy