### PR TITLE
fix(client): keep API key on origin and require HTTPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,13 @@ None. No FMP path we ship was newly retired by this changelog window.
   `.py` still writes the restricted `TOOLS = ["..."]` form so existing
   scripts keep working. Unknown suffixes are refused.
 
+### Security
+
+- **API key stays on origin (#252 FMP-SEC-004).** `base_url` must be HTTPS
+  except loopback HTTP. The key is sent only as the `apikey` query parameter
+  (no client-wide header that a 302 would forward). Cross-origin redirects
+  are refused.
+
 ## [2.6.0] - 2026-08-10
 
 Released from `dev`. A correctness-and-contracts release: the LangChain and MCP

--- a/fmp_data/base.py
+++ b/fmp_data/base.py
@@ -40,6 +40,27 @@ T = TypeVar("T")
 ValidationMode = Literal["lenient", "warn", "strict"]
 
 
+def _default_http_headers() -> dict[str, str]:
+    """Headers shared by the sync and async clients. No API key (#252)."""
+    return {
+        "User-Agent": "FMP-Python-Client/1.0",
+        "Accept": "application/json",
+    }
+
+
+def _reject_cross_origin_redirect(response: httpx.Response) -> None:
+    """Refuse a 3xx that would send the next hop to another origin."""
+    nxt = response.next_request
+    if nxt is None:
+        return
+    src, dst = response.request.url, nxt.url
+    if (src.scheme, src.host, src.port) != (dst.scheme, dst.host, dst.port):
+        raise FMPError(
+            "Refusing cross-origin redirect "
+            f"from {src.scheme}://{src.host} to {dst.scheme}://{dst.host}"
+        )
+
+
 def _refuse_bytes_list_request(endpoint: Endpoint[T]) -> None:
     """``request_list`` is for row lists, not file downloads."""
     if endpoint.response_model is bytes:
@@ -188,15 +209,16 @@ class BaseClient:
     def _setup_http_client(self) -> None:
         """
         Setup HTTP client with default configuration.
+
+        The API key travels as the ``apikey`` query parameter only. A
+        client-wide header would be forwarded on a 302 to another origin
+        (#252 FMP-SEC-004). Cross-origin redirects are refused.
         """
         self.client = httpx.Client(
             timeout=self.config.timeout,
             follow_redirects=True,
-            headers={
-                "User-Agent": "FMP-Python-Client/1.0",
-                "Accept": "application/json",
-                "apikey": self.config.api_key,
-            },
+            headers=_default_http_headers(),
+            event_hooks={"response": [_reject_cross_origin_redirect]},
         )
 
     def close(self) -> None:
@@ -218,11 +240,8 @@ class BaseClient:
             self._async_client = httpx.AsyncClient(
                 timeout=self.config.timeout,
                 follow_redirects=True,
-                headers={
-                    "User-Agent": "FMP-Python-Client/1.0",
-                    "Accept": "application/json",
-                    "apikey": self.config.api_key,
-                },
+                headers=_default_http_headers(),
+                event_hooks={"response": [_reject_cross_origin_redirect]},
             )
         return self._async_client
 

--- a/fmp_data/config.py
+++ b/fmp_data/config.py
@@ -21,6 +21,14 @@ from fmp_data.cache.config import CacheConfig
 from fmp_data.exceptions import ConfigError
 
 
+def _is_loopback_host(hostname: str | None) -> bool:
+    """True for localhost / loopback literals used by local test servers."""
+    if not hostname:
+        return False
+    host = hostname.strip("[]").lower()
+    return host in {"localhost", "127.0.0.1", "::1"} or host.startswith("127.")
+
+
 def _safe_int_from_env(env_var: str, default: int, *, min_val: int = 0) -> int:
     """Safely convert environment variable to int, falling back to default."""
     try:
@@ -251,7 +259,12 @@ class ClientConfig(BaseModel):
     @field_validator("base_url")
     @classmethod
     def validate_base_url(cls, v: str) -> str:
-        """Validate base URL format"""
+        """Validate base URL format.
+
+        HTTPS is required except for loopback HTTP (local mocks). A
+        non-loopback ``http://`` origin would send ``apikey`` in the clear
+        (#252 FMP-SEC-004).
+        """
         if not v or not v.strip():
             raise ValueError("Base URL cannot be empty")
 
@@ -262,6 +275,12 @@ class ClientConfig(BaseModel):
                 raise ValueError(f"Invalid URL format: {v}")
             if parsed.scheme not in ("http", "https"):
                 raise ValueError(f"URL scheme must be http or https: {v}")
+            if parsed.scheme == "http" and not _is_loopback_host(parsed.hostname):
+                raise ValueError(
+                    f"base_url must use https except for loopback HTTP: {v}"
+                )
+        except ValueError:
+            raise
         except Exception as e:
             raise ValueError(f"Invalid URL: {v}") from e
 

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -1175,3 +1175,41 @@ class TestRequestList:
                 await base_client.request_async_list(test_endpoint, symbol="AAPL")
                 is items
             )
+
+
+def test_http_client_does_not_put_apikey_in_default_headers(client_config):
+    """Query param is the only key channel (#252 FMP-SEC-004)."""
+    from fmp_data.base import BaseClient
+
+    client = BaseClient(client_config)
+    try:
+        assert "apikey" not in {k.lower() for k in client.client.headers}
+    finally:
+        client.close()
+
+
+def test_reject_cross_origin_redirect():
+    from fmp_data.base import _reject_cross_origin_redirect
+
+    src = httpx.Request("GET", "https://trusted.test/path")
+    dst = httpx.Request("GET", "https://attacker.test/steal")
+    response = httpx.Response(
+        302, headers={"location": "https://attacker.test/steal"}, request=src
+    )
+    object.__setattr__(response, "next_request", dst)
+
+    with pytest.raises(FMPError, match="cross-origin"):
+        _reject_cross_origin_redirect(response)
+
+
+def test_same_origin_redirect_is_allowed():
+    from fmp_data.base import _reject_cross_origin_redirect
+
+    src = httpx.Request("GET", "https://trusted.test/old")
+    dst = httpx.Request("GET", "https://trusted.test/new")
+    response = httpx.Response(
+        302, headers={"location": "https://trusted.test/new"}, request=src
+    )
+    object.__setattr__(response, "next_request", dst)
+
+    _reject_cross_origin_redirect(response)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -418,6 +418,7 @@ class TestClientConfig:
             "https://",
             "",
             "just_text",
+            "http://example.com",
         ]
 
         for url in invalid_urls:


### PR DESCRIPTION
## Summary

Addresses **FMP-SEC-004** on #252.

- `base_url` must be HTTPS except loopback HTTP (`localhost` / `127.0.0.0/8` / `::1`).
- The API key is sent only as the `apikey` query parameter. The client-wide header is gone so a 302 cannot forward it to another origin.
- Cross-origin redirects are refused.

## Test plan

- [x] `tests/unit/test_config.py` (http://example.com rejected; localhost HTTP still allowed)
- [x] header + redirect hook tests in `tests/unit/test_base.py`