### PR TITLE
fix(mcp): write Claude config as 0600 and hide key prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,6 +220,9 @@ None. No FMP path we ship was newly retired by this changelog window.
   treated as the secret (which previously crashed logging and printed the
   raw key). The filter is attached to each handler and each child logger.
   JSON extras and exception text are redacted.
+- **MCP Claude config is written ``0600`` and the API key is prompted with
+  echo off (#252 FMP-SEC-006).** Directory ``0700``; backups ``0600``;
+  atomic replace.
 
 ## [2.6.0] - 2026-08-10
 

--- a/fmp_data/mcp/setup.py
+++ b/fmp_data/mcp/setup.py
@@ -100,6 +100,12 @@ class SetupWizard:
             else:
                 print(message)
 
+    def prompt_secret(self, message: str) -> str:
+        """Read a secret with echo disabled."""
+        import getpass
+
+        return getpass.getpass(f"{self._redact_sensitive(message)}: ").strip()
+
     def prompt(self, message: str, default: str | None = None) -> str:
         """
         Prompt user for input.
@@ -241,7 +247,7 @@ class SetupWizard:
         )
 
         while True:
-            api_key = self.prompt("Enter your FMP API key").strip()
+            api_key = self.prompt_secret("Enter your FMP API key")
 
             if not api_key:
                 self.print("API key is required", "error")

--- a/fmp_data/mcp/utils.py
+++ b/fmp_data/mcp/utils.py
@@ -15,6 +15,7 @@ import platform
 import shutil
 import subprocess
 import sys
+import tempfile
 from typing import Any
 
 
@@ -140,6 +141,32 @@ def load_claude_config() -> dict[str, Any]:
     return {}
 
 
+def _chmod_user_only(path: Path, mode: int) -> None:
+    """Best-effort owner-only mode. Windows chmod is a no-op for this bit."""
+    if os.name == "nt":
+        return
+    try:
+        os.chmod(path, mode)
+    except OSError:
+        return
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write JSON via a temp file, then ``os.replace``, mode ``0600``."""
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2)
+            handle.write("\n")
+        _chmod_user_only(tmp_path, 0o600)
+        os.replace(tmp_path, path)
+        _chmod_user_only(path, 0o600)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
 def save_claude_config(config: dict[str, Any], backup: bool = True) -> Path | None:
     """
     Save the Claude Desktop configuration.
@@ -161,17 +188,16 @@ def save_claude_config(config: dict[str, Any], backup: bool = True) -> Path | No
 
     # Create directory if it doesn't exist
     config_path.parent.mkdir(parents=True, exist_ok=True)
+    _chmod_user_only(config_path.parent, 0o700)
 
     # Create backup if requested and file exists
     if backup and config_path.exists():
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         backup_path = config_path.with_suffix(f".backup_{timestamp}.json")
         shutil.copy2(config_path, backup_path)
+        _chmod_user_only(backup_path, 0o600)
 
-    # Save configuration
-    with open(config_path, "w") as f:
-        json.dump(config, f, indent=2)
-
+    _atomic_write_json(config_path, config)
     return backup_path
 
 

--- a/tests/unit/test_mcp_config_perms.py
+++ b/tests/unit/test_mcp_config_perms.py
@@ -1,0 +1,42 @@
+"""Claude config writes must be owner-only (#252 FMP-SEC-006)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from fmp_data.mcp.utils import save_claude_config
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
+def test_save_claude_config_is_owner_only(tmp_path: Path) -> None:
+    target = tmp_path / "claude" / "config.json"
+    with patch("fmp_data.mcp.utils.get_claude_config_path", return_value=target):
+        backup = save_claude_config({"mcpServers": {}}, backup=False)
+
+    assert backup is None
+    assert target.is_file()
+    assert stat_mode(target) == 0o600
+    assert stat_mode(target.parent) == 0o700
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
+def test_save_claude_config_backup_is_owner_only(tmp_path: Path) -> None:
+    target = tmp_path / "claude" / "config.json"
+    target.parent.mkdir()
+    target.write_text("{}\n", encoding="utf-8")
+    os.chmod(target, 0o644)
+
+    with patch("fmp_data.mcp.utils.get_claude_config_path", return_value=target):
+        backup = save_claude_config({"ok": True}, backup=True)
+
+    assert backup is not None and backup.is_file()
+    assert stat_mode(target) == 0o600
+    assert stat_mode(backup) == 0o600
+
+
+def stat_mode(path: Path) -> int:
+    return path.stat().st_mode & 0o777


### PR DESCRIPTION
## Summary

Addresses **FMP-SEC-006** on #252.

- Atomic JSON write, file/backup `0600`, directory `0700`.
- API key prompt uses `getpass` (echo off). Other prompts stay visible.