### PR TITLE
fix(config): redact secondary secrets in str/repr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,6 +223,10 @@ None. No FMP path we ship was newly retired by this changelog window.
 - **MCP Claude config is written ``0600`` and the API key is prompted with
   echo off (#252 FMP-SEC-006).** Directory ``0700``; backups ``0600``;
   atomic replace.
+- **Secondary secrets no longer survive ``str``/``repr`` (#252 FMP-SEC-007).**
+  ``embedding_api_key`` and embedding ``api_key`` are ``repr=False``.
+  ``CacheConfig.redis_url`` userinfo is redacted. Nested cache URLs on
+  ``ClientConfig`` are redacted the same way.
 
 ## [2.6.0] - 2026-08-10
 

--- a/fmp_data/cache/config.py
+++ b/fmp_data/cache/config.py
@@ -61,7 +61,34 @@ class CacheConfig(BaseModel):
     cache_dir: Path | None = Field(
         default=None, description="Directory for file-based cache"
     )
-    redis_url: str | None = Field(default=None, description="Redis connection URL")
+    redis_url: str | None = Field(
+        default=None, description="Redis connection URL", repr=False
+    )
+
+    def __str__(self) -> str:
+        from urllib.parse import urlsplit, urlunsplit
+
+        data = self.model_dump()
+        url = data.get("redis_url")
+        if isinstance(url, str) and url:
+            parts = urlsplit(url)
+            if parts.username or parts.password:
+                host = parts.hostname or ""
+                if parts.port:
+                    host = f"{host}:{parts.port}"
+                data["redis_url"] = urlunsplit(
+                    (
+                        parts.scheme,
+                        f"***@{host}",
+                        parts.path,
+                        parts.query,
+                        parts.fragment,
+                    )
+                )
+        return f"CacheConfig({data})"
+
+    def __repr__(self) -> str:
+        return self.__str__()
 
     @model_validator(mode="after")
     def _warn_on_unmatched_ttl_overrides(self) -> CacheConfig:

--- a/fmp_data/config.py
+++ b/fmp_data/config.py
@@ -13,7 +13,7 @@ from collections.abc import Callable
 import os
 from pathlib import Path
 from typing import Any, Literal
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlsplit, urlunsplit
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -27,6 +27,24 @@ def _is_loopback_host(hostname: str | None) -> bool:
         return False
     host = hostname.strip("[]").lower()
     return host in {"localhost", "127.0.0.1", "::1"} or host.startswith("127.")
+
+
+def _mask_secret(value: str) -> str:
+    if len(value) > 4:
+        return f"{value[:4]}***"
+    return "***"
+
+
+def _redact_url_userinfo(url: str) -> str:
+    """Drop userinfo from a URL so ``redis://:hunter2@host`` cannot leak."""
+    parts = urlsplit(url)
+    if not (parts.username or parts.password):
+        return url
+    host = parts.hostname or ""
+    if parts.port:
+        host = f"{host}:{parts.port}"
+    netloc = f"***@{host}" if (parts.username or parts.password) else host
+    return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
 
 
 def _safe_int_from_env(env_var: str, default: int, *, min_val: int = 0) -> int:
@@ -291,12 +309,12 @@ class ClientConfig(BaseModel):
         # Create a copy of the model dict with masked API key
         data = self.model_dump()
         if data.get("api_key"):
-            # Mask the API key, showing only first 4 characters
-            api_key = data["api_key"]
-            if len(api_key) > 4:
-                data["api_key"] = f"{api_key[:4]}***"
-            else:
-                data["api_key"] = "***"
+            data["api_key"] = _mask_secret(str(data["api_key"]))
+        if data.get("embedding_api_key"):
+            data["embedding_api_key"] = _mask_secret(str(data["embedding_api_key"]))
+        cache = data.get("cache")
+        if isinstance(cache, dict) and cache.get("redis_url"):
+            cache["redis_url"] = _redact_url_userinfo(str(cache["redis_url"]))
 
         # Create a string representation from the masked data
         fields = []

--- a/fmp_data/lc/config.py
+++ b/fmp_data/lc/config.py
@@ -24,7 +24,9 @@ class LangChainConfig(ClientConfig):
         default=None, description="Model name for embeddings"
     )
     embedding_api_key: str | None = Field(
-        default=None, description="API key for embedding provider"
+        default=None,
+        description="API key for embedding provider",
+        repr=False,
     )
 
     # Vector store settings

--- a/fmp_data/lc/embedding.py
+++ b/fmp_data/lc/embedding.py
@@ -29,7 +29,9 @@ class EmbeddingConfig(BaseModel):
         default=None, description="Model name for the embedding provider"
     )
     api_key: str | None = Field(
-        default=None, description="API key for the embedding provider"
+        default=None,
+        description="API key for the embedding provider",
+        repr=False,
     )
     additional_kwargs: dict[str, Any] = Field(
         default_factory=dict,

--- a/tests/unit/lc/test_config.py
+++ b/tests/unit/lc/test_config.py
@@ -63,3 +63,13 @@ def test_langchain_config_from_env(lc_env_vars, tmp_path):
     assert config.vector_store_path == str(tmp_path / "vector_store")
     assert config.similarity_threshold == 0.5
     assert config.max_tools == 10
+
+
+def test_embedding_api_key_not_in_repr() -> None:
+    config = LangChainConfig(
+        api_key="fmp-secret",
+        embedding_api_key="openai-secret-key",
+    )
+    assert "openai-secret-key" not in repr(config)
+    assert "openai-secret-key" not in str(config)
+    assert config.embedding_api_key == "openai-secret-key"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -702,3 +702,23 @@ class TestConfigEdgeCases:
         # Modify nested logging config
         config.logging.level = "ERROR"
         assert config.logging.level == "ERROR"
+
+
+def test_cache_and_client_repr_hide_redis_userinfo() -> None:
+    from fmp_data.cache.config import CacheConfig
+
+    cache = CacheConfig(
+        backend="redis",
+        redis_url="redis://:hunter2@localhost:6379/0",
+    )
+    assert "hunter2" not in str(cache)
+    assert "hunter2" not in repr(cache)
+
+    client = ClientConfig(
+        api_key="abcd-secret",
+        cache=cache,
+    )
+    text = str(client)
+    assert "hunter2" not in text
+    assert "abcd-secret" not in text
+    assert "abcd***" in text


### PR DESCRIPTION
## Summary

Addresses **FMP-SEC-007** on #252.

`embedding_api_key` / embedding `api_key` are `repr=False`. Redis URL userinfo is redacted on `CacheConfig` and when nested on `ClientConfig`. Runtime values are unchanged.