### PR TITLE
fix(test): do not log or reprint API keys in VCR helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,6 +227,9 @@ None. No FMP path we ship was newly retired by this changelog window.
   ``embedding_api_key`` and embedding ``api_key`` are ``repr=False``.
   ``CacheConfig.redis_url`` userinfo is redacted. Nested cache URLs on
   ``ClientConfig`` are redacted the same way.
+- **VCR sanitization no longer logs the raw API key (#252 FMP-SEC-009).**
+  DEBUG logs method/host/path only. Cassette leak assertions name
+  file/line/credential type, not the captured value.
 
 ## [2.6.0] - 2026-08-10
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import re
 import time
 from typing import Any
+from urllib.parse import urlsplit
 
 from dotenv import load_dotenv
 import pytest
@@ -75,7 +76,14 @@ def drop_unauthorized_response(response: dict | None) -> dict | None:
 
 def scrub_api_key(request: Request) -> Request:
     """Remove API key for recording only"""
-    logger.debug(f"Original request URI: {request.uri}")
+    parsed = urlsplit(request.uri)
+    logger.debug(
+        "Scrubbing %s %s://%s%s",
+        request.method,
+        parsed.scheme,
+        parsed.netloc,
+        parsed.path,
+    )
 
     # Don't modify the actual request, just create a scrubbed copy for recording
     scrubbed_uri = request.uri

--- a/tests/unit/test_vcr_sanitization.py
+++ b/tests/unit/test_vcr_sanitization.py
@@ -25,6 +25,21 @@ def test_scrub_api_key_removes_header_and_uri_value() -> None:
     assert "apikey" not in {k.lower() for k in scrubbed.headers}
 
 
+def test_scrub_api_key_debug_log_does_not_include_the_key(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    request = Request(
+        method="GET",
+        uri="https://financialmodelingprep.com/stable/quote?symbol=AAPL&apikey=REAL_KEY",
+        body="",
+        headers={"Accept": ["application/json"]},
+    )
+    caplog.set_level("DEBUG", logger="tests.integration.conftest")
+    scrub_api_key(request)
+    assert "REAL_KEY" not in caplog.text
+    assert "quote" in caplog.text
+
+
 def test_scrub_response_secrets_masks_query_json_and_headers(monkeypatch) -> None:
     monkeypatch.setattr("tests.integration.conftest.VCR_RECORD_MODE", "new_episodes")
     monkeypatch.setenv("FMP_TEST_API_KEY", "SECRET_API_KEY")
@@ -102,16 +117,12 @@ def test_no_api_key_leaks_in_cassettes() -> None:
             for match in _APIKEY_QUERY_RE.finditer(line):
                 value = match.group(1)
                 if value not in _SAFE_API_KEY_VALUES:
-                    violations.append(
-                        f"{relative}:{lineno}  apikey={value} (query string)"
-                    )
+                    violations.append(f"{relative}:{lineno}  query-string apikey")
 
             for match in _APIKEY_JSON_RE.finditer(line):
                 value = match.group(1)
                 if value not in _SAFE_API_KEY_VALUES:
-                    violations.append(
-                        f"{relative}:{lineno}  apikey={value} (JSON body)"
-                    )
+                    violations.append(f"{relative}:{lineno}  JSON-body apikey")
 
     assert not violations, (
         f"Found {len(violations)} API key leak(s) in VCR cassettes:\n"


### PR DESCRIPTION
## Summary

Addresses **FMP-SEC-009** on #252.

DEBUG logs method/host/path only. Cassette leak assertions name file/line/credential type, not the captured value.