### PR TITLE
fix(company): whitelist intraday interval and encode path params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,6 +230,10 @@ None. No FMP path we ship was newly retired by this changelog window.
 - **VCR sanitization no longer logs the raw API key (#252 FMP-SEC-009).**
   DEBUG logs method/host/path only. Cassette leak assertions name
   file/line/credential type, not the captured value.
+- **Company intraday ``interval`` is whitelisted and path params are encoded
+  (#252 FMP-SEC-010).** ``../../stable/profile`` is rejected; remaining path
+  segments are percent-encoded so httpx cannot normalize them into another
+  endpoint.
 
 ## [2.6.0] - 2026-08-10
 

--- a/fmp_data/company/endpoints.py
+++ b/fmp_data/company/endpoints.py
@@ -283,6 +283,7 @@ INTRADAY_PRICE: Endpoint[IntradayPrice] = Endpoint(
             location=ParamLocation.PATH,
             param_type=ParamType.STRING,
             description="Time interval (1min, 5min, 15min, 30min, 1hour, 4hour)",
+            valid_values=["1min", "5min", "15min", "30min", "1hour", "4hour"],
         ),
         EndpointParam(
             name="symbol",

--- a/fmp_data/models.py
+++ b/fmp_data/models.py
@@ -5,6 +5,7 @@ from datetime import date as dt_date
 from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Annotated, Any, Generic, Literal, TypeVar
+from urllib.parse import quote
 import warnings
 
 from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, model_validator
@@ -14,6 +15,24 @@ from fmp_data.schema import DeprecatedArgModel
 
 if TYPE_CHECKING:
     pass
+
+
+def _safe_path_segment(value: str) -> str:
+    """Percent-encode a path parameter and reject traversal (#252 FMP-SEC-010)."""
+    lowered = value.replace("\\", "/").lower()
+    if (
+        "/" in value
+        or "\\" in value
+        or "%2f" in lowered
+        or "%5c" in lowered
+        or value in {".", ".."}
+        or any(part in {"", ".", ".."} for part in value.replace("\\", "/").split("/"))
+    ):
+        raise _get_validation_error()(
+            f"Invalid path parameter {value!r}: separators and '.' / '..' "
+            "are not allowed"
+        )
+    return quote(value, safe="")
 
 
 def _get_validation_error() -> type[Exception]:
@@ -415,9 +434,11 @@ class Endpoint(BaseModel, Generic[T]):
     def build_url(self, base_url: str, params: dict[str, Any]) -> str:
         """Build the complete URL for the endpoint based on URL type"""
         path = self.path
-        for param in self.mandatory_params:
+        for param in self.mandatory_params + (self.optional_params or []):
             if param.location == ParamLocation.PATH and param.name in params:
-                path = path.replace(f"{{{param.name}}}", str(params[param.name]))
+                path = path.replace(
+                    f"{{{param.name}}}", _safe_path_segment(str(params[param.name]))
+                )
 
         if self.url_type == URLType.API and self.version:
             return f"{base_url}/{self.version.value}/{path}"

--- a/tests/unit/test_path_params.py
+++ b/tests/unit/test_path_params.py
@@ -1,0 +1,32 @@
+"""Path params cannot walk the URL (#252 FMP-SEC-010)."""
+
+from __future__ import annotations
+
+import pytest
+
+from fmp_data.company.endpoints import INTRADAY_PRICE
+from fmp_data.exceptions import ValidationError
+from fmp_data.models import _safe_path_segment
+
+
+def test_company_intraday_interval_is_whitelisted() -> None:
+    assert INTRADAY_PRICE.mandatory_params[0].valid_values == [
+        "1min",
+        "5min",
+        "15min",
+        "30min",
+        "1hour",
+        "4hour",
+    ]
+    with pytest.raises(ValidationError, match="Must be one of"):
+        INTRADAY_PRICE.validate_params(
+            {"interval": "../../stable/profile", "symbol": "AAPL"}
+        )
+
+
+def test_safe_path_segment_rejects_traversal() -> None:
+    with pytest.raises(ValidationError, match="not allowed"):
+        _safe_path_segment("../../stable/profile")
+    with pytest.raises(ValidationError, match="not allowed"):
+        _safe_path_segment("%2e%2e/%2e%2e/stable/profile")
+    assert _safe_path_segment("1min") == "1min"


### PR DESCRIPTION
## Summary

Addresses **FMP-SEC-010** on #252.

Company `interval` uses the same whitelist as crypto/forex/commodity. Path parameters reject `/`, `..`, and encoded separators, then are percent-encoded.