### PR TITLE
fix(make): load .env as KEY=VALUE data, not shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,9 @@ None. No FMP path we ship was newly retired by this changelog window.
   advisories; supported versions and target response times are documented.
 - **Tag-based TestPyPI builds require the tag to sit on ``main`` or ``dev``
   (#252 FMP-SEC-003).** A tag of an unrelated commit no longer publishes.
+- **Makefile loads ``.env`` as data, not as shell (#252 FMP-SEC-011).**
+  ``test`` / integration targets call ``scripts/export_dotenv.py`` instead of
+  ``set -a; . ./.env``.
 
 ## [2.6.0] - 2026-08-10
 

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ venv: .venv/.installed ## Create .venv and install dev dependencies if missing
 
 test: venv ## Run tests
 	@echo "$(BOLD)$(BLUE)🧪 Running tests...$(RESET)"
-	@set -a; [ -f .env ] && . ./.env; set +a; \
+	@eval "$$(python3 scripts/export_dotenv.py .env)"; \
 		if [ -z "$$FMP_TEST_API_KEY" ] && [ -n "$$FMP_API_KEY" ]; then export FMP_TEST_API_KEY="$$FMP_API_KEY"; fi; \
 		if [ -z "$$FMP_API_KEY" ] && [ -n "$$FMP_TEST_API_KEY" ]; then export FMP_API_KEY="$$FMP_TEST_API_KEY"; fi; \
 		. .venv/bin/activate && pytest -q $(PYTEST_XDIST_ARGS)
@@ -140,7 +140,7 @@ test-integration: test-integration-replay ## Alias for replay integration tests
 
 test-integration-replay: venv ## Run integration tests using VCR replay mode (fast, deterministic)
 	@echo "$(BOLD)$(BLUE)🧪 Running integration tests (VCR replay)...$(RESET)"
-	@set -a; [ -f .env ] && . ./.env; set +a; \
+	@eval "$$(python3 scripts/export_dotenv.py .env)"; \
 		if [ -z "$$FMP_TEST_API_KEY" ] && [ -n "$$FMP_API_KEY" ]; then export FMP_TEST_API_KEY="$$FMP_API_KEY"; fi; \
 		if [ -z "$$FMP_API_KEY" ] && [ -n "$$FMP_TEST_API_KEY" ]; then export FMP_API_KEY="$$FMP_TEST_API_KEY"; fi; \
 		export FMP_VCR_RECORD=none; \
@@ -148,7 +148,7 @@ test-integration-replay: venv ## Run integration tests using VCR replay mode (fa
 
 test-integration-record: venv ## Record/update integration VCR cassettes (set TESTS=path/to/test.py for targeted refresh)
 	@echo "$(BOLD)$(YELLOW)🎥 Recording integration cassettes...$(RESET)"
-	@set -a; [ -f .env ] && . ./.env; set +a; \
+	@eval "$$(python3 scripts/export_dotenv.py .env)"; \
 		if [ -z "$$FMP_TEST_API_KEY" ] && [ -n "$$FMP_API_KEY" ]; then export FMP_TEST_API_KEY="$$FMP_API_KEY"; fi; \
 		if [ -z "$$FMP_API_KEY" ] && [ -n "$$FMP_TEST_API_KEY" ]; then export FMP_API_KEY="$$FMP_TEST_API_KEY"; fi; \
 		if [ -z "$$FMP_TEST_API_KEY" ]; then echo "$(YELLOW)FMP_TEST_API_KEY is required for recording.$(RESET)" && exit 1; fi; \

--- a/scripts/export_dotenv.py
+++ b/scripts/export_dotenv.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Print ``export KEY=value`` lines from a .env file without executing it.
+
+Used by the Makefile so a crafted ``.env`` cannot run as the maintainer
+(#252 FMP-SEC-011). Values are ``shlex.quote``-d. Lines that are empty,
+comments, or missing ``=`` are ignored. Optional ``export `` prefix is
+stripped. No interpolation, no command substitution.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import shlex
+import sys
+
+
+def export_lines(text: str) -> list[str]:
+    lines: list[str] = []
+    for raw in text.splitlines():
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("export "):
+            stripped = stripped[len("export ") :].lstrip()
+        if "=" not in stripped:
+            continue
+        key, value = stripped.split("=", 1)
+        key = key.strip()
+        if not key or not key.isidentifier():
+            continue
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+            value = value[1:-1]
+        lines.append(f"export {key}={shlex.quote(value)}")
+    return lines
+
+
+def main(argv: list[str]) -> int:
+    path = Path(argv[1] if len(argv) > 1 else ".env")
+    if not path.is_file():
+        return 0
+    for line in export_lines(path.read_text(encoding="utf-8")):
+        print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/unit/test_export_dotenv.py
+++ b/tests/unit/test_export_dotenv.py
@@ -1,0 +1,35 @@
+"""Makefile .env loader is data, not shell (#252 FMP-SEC-011)."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "export_dotenv.py"
+_SPEC = importlib.util.spec_from_file_location("export_dotenv", _SCRIPT)
+assert _SPEC and _SPEC.loader
+export_dotenv = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(export_dotenv)
+
+
+def test_export_lines_quotes_and_ignores_shell() -> None:
+    text = "\n".join(
+        [
+            "# comment",
+            "FMP_API_KEY=plain",
+            'FMP_TEST_API_KEY="quoted value"',
+            "EVIL=$(touch /tmp/pwned)",
+            "export ALSO=ok",
+            "not-a-key=nope",
+            "",
+        ]
+    )
+    lines = export_dotenv.export_lines(text)
+    joined = "\n".join(lines)
+    assert "export FMP_API_KEY=plain" in joined
+    assert "quoted value" in joined
+    assert "export ALSO=ok" in joined
+    assert "not-a-key" not in joined
+    # $(...) is quoted, not executed
+    assert any("EVIL=" in line and "$(touch" in line for line in lines)
+    assert all(line.startswith("export ") for line in lines)


### PR DESCRIPTION
## Summary

Addresses **FMP-SEC-011** on #252.

`make test` / integration targets no longer `source .env`. Values are parsed as data and `shlex.quote`-d by `scripts/export_dotenv.py`.