### PR TITLE
fix(ci): drop Claude OIDC and review write on contents

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,10 +27,9 @@ jobs:
 
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       issues: write
-      id-token: write
 
     steps:
       - name: Check whether Claude review is configured

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,7 +30,6 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-      id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,10 @@ None. No FMP path we ship was newly retired by this changelog window.
   (#252 FMP-SEC-010).** ``../../stable/profile`` is rejected; remaining path
   segments are percent-encoded so httpx cannot normalize them into another
   endpoint.
+- **Claude workflows no longer mint an OIDC token (#252 FMP-SEC-012).**
+  Review is ``contents: read`` plus PR/issue write. Interactive Claude keeps
+  ``contents: write`` so it can land commits; both use the OAuth secret, not
+  ``id-token: write``.
 - **Added ``SECURITY.md`` (#252 FMP-SEC-013).** Private disclosure via GitHub
   advisories; supported versions and target response times are documented.
 - **Tag-based TestPyPI builds require the tag to sit on ``main`` or ``dev``


### PR DESCRIPTION
## Summary

Addresses **FMP-SEC-012** on #252.

- Review workflow: `contents: read`, no `id-token: write`.
- Interactive Claude keeps `contents: write` so it can commit; drops `id-token: write` (auth is the OAuth secret).