### PR TITLE
docs: add SECURITY.md with private disclosure path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,8 @@ None. No FMP path we ship was newly retired by this changelog window.
   (#252 FMP-SEC-010).** ``../../stable/profile`` is rejected; remaining path
   segments are percent-encoded so httpx cannot normalize them into another
   endpoint.
+- **Added ``SECURITY.md`` (#252 FMP-SEC-013).** Private disclosure via GitHub
+  advisories; supported versions and target response times are documented.
 
 ## [2.6.0] - 2026-08-10
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Supported |
+| --- | --- |
+| Latest release on PyPI | Yes |
+| `dev` branch | Yes (pre-release) |
+| Older PyPI releases | Best effort; please upgrade |
+
+## Reporting a vulnerability
+
+Do **not** open a public GitHub issue for a security report.
+
+Use GitHub's private advisory form:
+
+https://github.com/MehdiZare/fmp-data/security/advisories/new
+
+Include the affected version or commit, a reproduction, and impact. You should
+hear back within 7 days. A fix, workaround, or reasoned decline will be
+published once we have one; we aim for 30 days on confirmed issues in the
+supported line.
+
+This project is a client library. Most reports will be hardening
+(credential handling, CI, optional extras) rather than remotely exploitable
+flaws in default HTTPS use.


### PR DESCRIPTION
## Summary

Addresses **FMP-SEC-013** on #252.

Adds `SECURITY.md`: private GitHub advisory reporting, supported versions, target response times.