### PR TITLE
fix(ci): require TestPyPI tags to sit on main or dev

### DIFF
--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -266,6 +266,19 @@ jobs:
           fetch-depth: 0  # Needed for hatch-vcs versioning
           persist-credentials: false
 
+      - name: Require tag commit reachable from main or dev
+        run: |
+          set -euo pipefail
+          git fetch origin main dev
+          HEAD="$(git rev-parse HEAD)"
+          if git merge-base --is-ancestor "$HEAD" origin/main \
+            || git merge-base --is-ancestor "$HEAD" origin/dev; then
+            echo "Tag $HEAD is reachable from origin/main or origin/dev"
+          else
+            echo "::error::Tag commit $HEAD is not an ancestor of origin/main or origin/dev (#252 FMP-SEC-003)"
+            exit 1
+          fi
+
       - name: 🐍  Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,6 +236,8 @@ None. No FMP path we ship was newly retired by this changelog window.
   endpoint.
 - **Added ``SECURITY.md`` (#252 FMP-SEC-013).** Private disclosure via GitHub
   advisories; supported versions and target response times are documented.
+- **Tag-based TestPyPI builds require the tag to sit on ``main`` or ``dev``
+  (#252 FMP-SEC-003).** A tag of an unrelated commit no longer publishes.
 
 ## [2.6.0] - 2026-08-10
 


### PR DESCRIPTION
## Summary

Addresses the remaining **FMP-SEC-003** hole on #252.

Tag-based TestPyPI builds fail unless the tagged commit is an ancestor of `origin/main` or `origin/dev`.