### PR TITLE
ci: add SHA-pinned CodeQL analysis for the Python tree

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,36 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+  schedule:
+    - cron: "17 5 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze Python
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: 🛎️ Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: 🔍 Initialize CodeQL
+        uses: github/codeql-action/init@f3712979fa5f215279b101dd0a2e3bdfb4353324  # v3.37.7
+        with:
+          languages: python
+          build-mode: none
+
+      - name: 📈 Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@f3712979fa5f215279b101dd0a2e3bdfb4353324  # v3.37.7
+        with:
+          category: "/language:python"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,8 @@
 name: CodeQL
 
+# Advanced setup. GitHub default setup must stay off — the two cannot
+# upload into the same code-scanning slot.
+
 on:
   push:
     branches:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,9 @@ None. No FMP path we ship was newly retired by this changelog window.
   CI no longer skips when VCR cassettes are absent. ``detect-secrets``
   compares the whole tree to ``.secrets.baseline``; dummy keys in tests
   are baselined. Cassettes stay zero-tolerance when present.
+- **CodeQL analyzes the Python tree on every PR (#252 FMP-SEC-008).**
+  Findings upload to GitHub code scanning. The workflow is SHA-pinned
+  and uses ``build-mode: none``.
 
 - **Isolated PyPI publishing and immutable Actions pins (#252).** Release,
   Dev-Release, and Publish-to-TestPyPI now build in a job with no OIDC token

--- a/tests/unit/test_codeql_workflow.py
+++ b/tests/unit/test_codeql_workflow.py
@@ -1,0 +1,28 @@
+"""CodeQL workflow is present, SHA-pinned, and Python-only."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "codeql.yml"
+
+
+def test_codeql_workflow_is_sha_pinned() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "languages: python" in text
+    assert "build-mode: none" in text
+    assert "security-events: write" in text
+    assert "github/codeql-action/init@" in text
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("uses:"):
+            continue
+        _, ref = stripped.split("uses:", 1)
+        ref = ref.strip()
+        if ref.startswith("./"):
+            continue
+        action, _, pin = ref.partition("@")
+        pin = pin.split()[0]
+        assert len(pin) == 40 and all(c in "0123456789abcdef" for c in pin), (
+            f"{action} is not pinned to a 40-char SHA: {pin!r}"
+        )


### PR DESCRIPTION
## Why

#252 FMP-SEC-008: GitHub code scanning produced no alerts because there
was no CodeQL workflow.

## What

- Add `.github/workflows/codeql.yml` on PRs, pushes to `main`/`dev`, and
  a weekly schedule.
- Pin `actions/checkout` and `github/codeql-action` to full SHAs.
- `build-mode: none` (interpreted language).
- Least privilege: workflow `contents: read`; job also
  `security-events: write`.

Does not change Bandit skips or coverage omit lists.

Tracker: #252.