### PR TITLE
fix(ci): scan the committed tree for secrets, not only cassettes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
           fail_ci_if_error: false
 
   secret-scan:
-    name: Secret Scan (cassettes)
+    name: Secret Scan
     runs-on: ubuntu-latest
     steps:
       - name: 🛎️  Checkout
@@ -110,24 +110,23 @@ jobs:
       - name: 🔐 Install detect-secrets
         run: pip install detect-secrets
 
-      # pragma: allowlist secret — step scans VCR cassettes for leaked API keys
-      - name: 🔍 Scan cassettes for leaked credentials
+      # pragma: allowlist secret — whole-tree scan vs committed baseline
+      - name: 🔍 Scan committed tree against baseline
         run: |
           set -euo pipefail
-          CASSETTE_DIR="tests/integration/vcr_cassettes"
+          # Fail closed on any new finding. Known dummy keys live in
+          # .secrets.baseline (including tests). The previous job only
+          # scanned gitignored VCR cassettes and skipped when they were
+          # absent, so CI never looked at the committed tree (#252 FMP-SEC-008).
+          git ls-files -z | xargs -0 detect-secrets-hook --baseline .secrets.baseline
 
-          # Skip scan when no cassettes are checked in
+          CASSETTE_DIR="tests/integration/vcr_cassettes"
           if [ ! -d "$CASSETTE_DIR" ] || [ -z "$(find "$CASSETTE_DIR" -name '*.yaml' 2>/dev/null)" ]; then
-            echo "No cassette YAML files found — skipping credential scan."
+            echo "No cassette YAML files present — baseline tree scan is the gate."
             exit 0
           fi
 
-          # Scan cassette YAML only. Cassettes must never contain live API keys;
-          # any finding is a hard failure. (Previously --baseline was passed and
-          # the Python step claimed to filter "NEW" findings, but it never
-          # compared hashes against the baseline — it failed on any result.
-          # Baseline is for the rest of the tree via pre-commit; cassettes are
-          # zero-tolerance.)
+          # Cassettes are gitignored and must never contain live keys.
           detect-secrets scan \
             "$CASSETTE_DIR" \
             --exclude-files '.*\.py$' \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,6 @@ repos:
     hooks:
       - id: detect-secrets
         args: ['--baseline', '.secrets.baseline']
-        exclude: tests/.*\.py$
 
   # ───────── Local nox-powered helpers ────────────────────────────────────
   - repo: local

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,10 +91,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -128,7 +124,7 @@
     {
       "path": "detect_secrets.filters.regex.should_exclude_file",
       "pattern": [
-        "tests/.*\\.py$"
+        "\\.secrets\\.baseline$"
       ]
     }
   ],
@@ -223,7 +219,307 @@
         "is_verified": false,
         "line_number": 102
       }
+    ],
+    "tests/integration/conftest.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/integration/conftest.py",
+        "hashed_secret": "d739b41c66d3ff46d4960fdff2f97db084e338b4",
+        "is_verified": false,
+        "line_number": 252
+      }
+    ],
+    "tests/unit/conftest.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/conftest.py",
+        "hashed_secret": "767ef7376d44bb6e52b390ddcd12c1cb1b3902a4",
+        "is_verified": false,
+        "line_number": 17
+      }
+    ],
+    "tests/unit/lc/test_config.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/lc/test_config.py",
+        "hashed_secret": "069707669944455c5c27d2850571f21f88d4c967",
+        "is_verified": false,
+        "line_number": 16
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/lc/test_config.py",
+        "hashed_secret": "75ddfb45216fe09680dfe70eda4f559a910c832c",
+        "is_verified": false,
+        "line_number": 17
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/lc/test_config.py",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 33
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/lc/test_config.py",
+        "hashed_secret": "46e9122567abad042837c395bc98095a6cd417b3",
+        "is_verified": false,
+        "line_number": 70
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/lc/test_config.py",
+        "hashed_secret": "e242ca24e021d3f3906758434300a2241bd5554f",
+        "is_verified": false,
+        "line_number": 71
+      }
+    ],
+    "tests/unit/lc/test_embedding.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/lc/test_embedding.py",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 33
+      }
+    ],
+    "tests/unit/test_async_clients.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_async_clients.py",
+        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
+        "is_verified": false,
+        "line_number": 3126
+      }
+    ],
+    "tests/unit/test_base.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_base.py",
+        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
+        "is_verified": false,
+        "line_number": 101
+      }
+    ],
+    "tests/unit/test_base_async.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_base_async.py",
+        "hashed_secret": "767ef7376d44bb6e52b390ddcd12c1cb1b3902a4",
+        "is_verified": false,
+        "line_number": 25
+      }
+    ],
+    "tests/unit/test_base_coverage.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_base_coverage.py",
+        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
+        "is_verified": false,
+        "line_number": 27
+      }
+    ],
+    "tests/unit/test_bulk_bytes.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_bulk_bytes.py",
+        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
+        "is_verified": false,
+        "line_number": 205
+      }
+    ],
+    "tests/unit/test_cache_integration.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_cache_integration.py",
+        "hashed_secret": "1e7772b7ee7a12f8dbb12351cabcb9dcd43221e8",
+        "is_verified": false,
+        "line_number": 52
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_cache_integration.py",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 78
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_cache_integration.py",
+        "hashed_secret": "517d5a7240861ec297fa07542a7bf7470bb604fe",
+        "is_verified": false,
+        "line_number": 79
+      }
+    ],
+    "tests/unit/test_client.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_client.py",
+        "hashed_secret": "767ef7376d44bb6e52b390ddcd12c1cb1b3902a4",
+        "is_verified": false,
+        "line_number": 26
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_client.py",
+        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
+        "is_verified": false,
+        "line_number": 34
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_client.py",
+        "hashed_secret": "bb5e31f5e4adb0f4343409954e3dfe95accd3004",
+        "is_verified": false,
+        "line_number": 120
+      }
+    ],
+    "tests/unit/test_config.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_config.py",
+        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
+        "is_verified": false,
+        "line_number": 369
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_config.py",
+        "hashed_secret": "172ce43af039f34e03db145738088d0addc715d9",
+        "is_verified": false,
+        "line_number": 432
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_config.py",
+        "hashed_secret": "bb5e31f5e4adb0f4343409954e3dfe95accd3004",
+        "is_verified": false,
+        "line_number": 476
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_config.py",
+        "hashed_secret": "5daae97f0240d1a05e6f1767e81a8d1ad60383ac",
+        "is_verified": false,
+        "line_number": 688
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_config.py",
+        "hashed_secret": "a9014473b8f457d319c2702f5970452513306608",
+        "is_verified": false,
+        "line_number": 718
+      }
+    ],
+    "tests/unit/test_export_dotenv.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_export_dotenv.py",
+        "hashed_secret": "b3511debb778c2ff2a901c2aed66f84dd85fdadb",
+        "is_verified": false,
+        "line_number": 20
+      }
+    ],
+    "tests/unit/test_logger.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_logger.py",
+        "hashed_secret": "1e7772b7ee7a12f8dbb12351cabcb9dcd43221e8",
+        "is_verified": false,
+        "line_number": 53
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_logger.py",
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_verified": false,
+        "line_number": 89
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_logger.py",
+        "hashed_secret": "3b96880b8e11758bbf9796b9cd90aaa3ab4bab6e",
+        "is_verified": false,
+        "line_number": 103
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_logger.py",
+        "hashed_secret": "b4a76d8860918aa1332fb0aca06d2672d438eff7",
+        "is_verified": false,
+        "line_number": 126
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_logger.py",
+        "hashed_secret": "9749f120d973f95fcd9b26e5a575d83a1abcf1a1",
+        "is_verified": false,
+        "line_number": 164
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_logger.py",
+        "hashed_secret": "c753ca619f884268db1b142408217819016e9ceb",
+        "is_verified": false,
+        "line_number": 184
+      }
+    ],
+    "tests/unit/test_mcp.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_mcp.py",
+        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
+        "is_verified": false,
+        "line_number": 30
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_mcp.py",
+        "hashed_secret": "075568fb26363695457c78be6687de14b2045550",
+        "is_verified": false,
+        "line_number": 1270
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_mcp.py",
+        "hashed_secret": "9f236d443728347ad5bafb9297fab60376a1732a",
+        "is_verified": false,
+        "line_number": 1366
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_mcp.py",
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_verified": false,
+        "line_number": 1389
+      }
+    ],
+    "tests/unit/test_mcp_cli.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_mcp_cli.py",
+        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
+        "is_verified": false,
+        "line_number": 474
+      }
+    ],
+    "tests/unit/test_vcr_sanitization.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_vcr_sanitization.py",
+        "hashed_secret": "375d4780e6f98b5260fcb0711f722e3e52cd6060",
+        "is_verified": false,
+        "line_number": 57
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_vcr_sanitization.py",
+        "hashed_secret": "d739b41c66d3ff46d4960fdff2f97db084e338b4",
+        "is_verified": false,
+        "line_number": 72
+      }
     ]
   },
-  "generated_at": "2026-08-10T12:14:23Z"
+  "generated_at": "2026-08-13T20:13:58Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,10 @@ None. No FMP path we ship was newly retired by this changelog window.
   committed hashed lock — a ``pyproject.toml`` floor bump is enough to
   pick up newer deps. Nox installs the ``dev`` group from pyproject
   instead of a second, stale pin list.
+- **Secret scan covers the committed tree, including tests (#252 FMP-SEC-008).**
+  CI no longer skips when VCR cassettes are absent. ``detect-secrets``
+  compares the whole tree to ``.secrets.baseline``; dummy keys in tests
+  are baselined. Cassettes stay zero-tolerance when present.
 
 - **Isolated PyPI publishing and immutable Actions pins (#252).** Release,
   Dev-Release, and Publish-to-TestPyPI now build in a job with no OIDC token

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This project uses UV as the primary package management tool for several key bene
 - Automatic retries with exponential backoff
 - 85%+ test coverage with comprehensive test suite
 - VCR cassette-backed integration tests with 100% endpoint contract validation
-- Automated API key leak scanning across all cassettes (pre-commit + CI)
+- Automated secret scanning of the committed tree (pre-commit + CI)
 - Secure API key handling
 - 100% coverage of FMP stable endpoints
 - Detailed error messages

--- a/tests/unit/test_secret_scan_ci.py
+++ b/tests/unit/test_secret_scan_ci.py
@@ -1,0 +1,21 @@
+"""CI secret scan must inspect the committed tree, not only cassettes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+CI = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "ci.yml"
+PRECOMMIT = Path(__file__).resolve().parents[2] / ".pre-commit-config.yaml"
+
+
+def test_secret_scan_job_uses_baseline_hook() -> None:
+    text = CI.read_text(encoding="utf-8")
+    assert "detect-secrets-hook --baseline .secrets.baseline" in text
+    assert "Secret Scan (cassettes)" not in text
+    assert "skipping credential scan" not in text
+
+
+def test_pre_commit_detect_secrets_includes_tests() -> None:
+    text = PRECOMMIT.read_text(encoding="utf-8")
+    assert "detect-secrets" in text
+    assert r"exclude: tests/.*\.py$" not in text


### PR DESCRIPTION
## Why

#252 FMP-SEC-008: the Test-Matrix `secret-scan` job only looked at
`tests/integration/vcr_cassettes`, which is gitignored. In CI it always
skipped. Pre-commit also excluded `tests/*.py`.

## What

- CI runs `detect-secrets-hook` against the committed tree and
  `.secrets.baseline`.
- Baseline updated to include dummy keys in tests/docs/examples.
- Pre-commit no longer excludes tests.
- Cassette YAML stays zero-tolerance when present locally.

Not in this PR: GitHub secret-scanning non-provider patterns (repo
setting), history rewrite, or committing `uv.lock`.

Tracker: #252.