### PR TITLE
fix(ci): install publish backends from version floors

### DIFF
--- a/.github/requirements-build.txt
+++ b/.github/requirements-build.txt
@@ -1,43 +1,7 @@
-# Locked PEP 517 frontend *and* backend for publish jobs.
-# hatchling/hatch-vcs are installed here and builds use --no-isolation so
-# PEP 517 isolation cannot pull an unpinned backend from PyPI (#252 leftover).
-# Regenerate:
-#   printf "build==1.5.0\nhatchling==1.32.0\nhatch-vcs==0.5.0\n" | \
-#     uv pip compile - --generate-hashes --no-header --no-annotate \
-#     --python-version 3.14 -o .github/requirements-build.txt
-build==1.5.0 \
-    --hash=sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f \
-    --hash=sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647
-hatch-vcs==0.5.0 \
-    --hash=sha256:0395fa126940340215090c344a2bf4e2a77bcbe7daab16f41b37b98c95809ff9 \
-    --hash=sha256:b49677dbdc597460cc22d01b27ab3696f5e16a21ecf2700fb01bc28e1f2a04a7
-hatchling==1.32.0 \
-    --hash=sha256:0bdbde4a52b06c37e3eca395f85a762bf0ef06fe374fd8ae429dc6be10230f5f \
-    --hash=sha256:0e17c9c3b9aa7c625acc8d0f5b622f107d5049af9ecf5ada4de1aada5be7cdbc
-packaging==26.3 \
-    --hash=sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79 \
-    --hash=sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c
-pathspec==1.1.1 \
-    --hash=sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a \
-    --hash=sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189
-pluggy==1.6.0 \
-    --hash=sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3 \
-    --hash=sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
-pyproject-hooks==1.2.0 \
-    --hash=sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8 \
-    --hash=sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913
-setuptools==84.0.0 \
-    --hash=sha256:51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670 \
-    --hash=sha256:f4695c21257f0d9b537ec2692c941d02ee143b7cc1276941349a546573b2ef73
-setuptools-scm==10.2.1 \
-    --hash=sha256:4fa7dd82cf8c800df59c9a288c90299b1657ff1ecfc3f5cc00287c5dbf5e27a9 \
-    --hash=sha256:b7c82f4102d389ee57dc66ccdb4f9b4bca3c40ba83b43f1f63d68ccd72db2580
-tomlkit==0.15.1 \
-    --hash=sha256:177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304 \
-    --hash=sha256:e25bbf38843005246210a12982776f27f99cb9be67160e14434d0c0d21ee1e97
-trove-classifiers==2026.6.1.19 \
-    --hash=sha256:ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3 \
-    --hash=sha256:c5132b4b61a829d11cfbd2d72e97f20a45ed6edb95e45c5efdeb5e00836b2745
-vcs-versioning==2.2.4 \
-    --hash=sha256:48ffea8a6a175c37a718c7ee2e5f508d0e500c2cf3371791f7948bccb2b44628 \
-    --hash=sha256:ed718fdee42170e128a8add6f23f53aa64dc7d9ab2de87d3083a691df881a809
+# Floors only — not a hashed lock. Publish jobs install this with uv so a
+# floor bump (or a newer compatible release) is enough to pick up updates.
+# Builds then run `python -m build --no-isolation` so PEP 517 isolation
+# cannot pull a different backend than what we just installed.
+build>=1.5.0
+hatchling>=1.31.0
+hatch-vcs>=0.5.0

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -52,9 +52,9 @@ jobs:
         with:
           enable-cache: true
 
-      - name: 📦  Install pinned build frontend and backend
+      - name: 📦  Install build frontend and backend (version floors)
         run: |
-          uv pip install --system --require-hashes -r .github/requirements-build.txt
+          uv pip install --system -r .github/requirements-build.txt
 
       - name: 🔍  Check for PR with release labels
         id: pr_labels

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -79,8 +79,8 @@ jobs:
           uv sync --group docs
 
           # Install git for version detection
-          echo "📦 Installing hashed hatchling/hatch-vcs for versioning"
-          uv pip install --system --require-hashes -r .github/requirements-build.txt
+          echo "📦 Installing hatchling/hatch-vcs (version floors) for versioning"
+          uv pip install --system -r .github/requirements-build.txt
 
       - name: Get package version
         id: version

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -57,9 +57,9 @@ jobs:
         with:
           enable-cache: false
 
-      - name: 📦  Install pinned build frontend and backend
+      - name: 📦  Install build frontend and backend (version floors)
         run: |
-          uv pip install --system --require-hashes -r .github/requirements-build.txt
+          uv pip install --system -r .github/requirements-build.txt
 
       - name: 🏷️  Calculate and create test version tag
         id: version
@@ -292,7 +292,7 @@ jobs:
       - name: 📦  Build wheel & sdist
         run: |
           set -euo pipefail
-          uv pip install --system --require-hashes -r .github/requirements-build.txt
+          uv pip install --system -r .github/requirements-build.txt
           python -m build --no-isolation --wheel --sdist
           (cd dist && sha256sum ./* > ../SHA256SUMS)
           cat SHA256SUMS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,9 +50,9 @@ jobs:
         with:
           enable-cache: false
 
-      - name: 📦 Install pinned build frontend and backend
+      - name: 📦 Install build frontend and backend (version floors)
         run: |
-          uv pip install --system --require-hashes -r .github/requirements-build.txt
+          uv pip install --system -r .github/requirements-build.txt
 
       - name: 🏷️ Determine version bump type
         id: bump_type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,8 +192,9 @@ None. No FMP path we ship was newly retired by this changelog window.
   jobs use the `pypi` / `testpypi` GitHub environments. All external
   `uses:` entries are pinned to full commit SHAs. The PEP 517 frontend
   (`build`) and backend (`hatchling`, `hatch-vcs`) are installed from
-  `.github/requirements-build.txt` with `--require-hashes`, and builds run
-  `--no-isolation` so isolation cannot fetch an unpinned backend.
+  version floors in `.github/requirements-build.txt` (not a hashed lock),
+  and builds run `--no-isolation` so isolation cannot fetch a different
+  backend than the one just installed.
   `workflow_dispatch` on Dev-Release is bound to `refs/heads/dev`. The
   TestPyPI PR path requires `head.repo.full_name == github.repository`.
   Tag-based TestPyPI publishes no longer `skip-existing`. **Before the next

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -133,9 +133,9 @@ the overlay in a hotfix-shaped PR.
   being skipped.
 - External Actions are pinned to full commit SHAs. The PEP 517 frontend
   (`build`) and backend (`hatchling`, `hatch-vcs`) are installed from
-  `.github/requirements-build.txt` with `--require-hashes`. Publish jobs
-  run `python -m build --no-isolation` so PEP 517 isolation cannot pull
-  an unpinned backend from PyPI.
+  version floors in `.github/requirements-build.txt` (not a hashed lock).
+  Publish jobs run `python -m build --no-isolation` so isolation cannot
+  pull a different backend than the one just installed.
 - **Claude Code Review** is advisory: missing or expired OAuth tokens do not
   fail the PR. Required gates live in `ci.yml` / the branch rulesets.
 

--- a/tests/unit/test_publish_pins.py
+++ b/tests/unit/test_publish_pins.py
@@ -1,4 +1,4 @@
-"""Publish jobs pin hatchling/hatch-vcs and build without PEP 517 isolation."""
+"""Publish jobs install build backends from version floors, not a hashed lock."""
 
 from __future__ import annotations
 
@@ -9,11 +9,21 @@ WORKFLOWS = REPO_ROOT / ".github" / "workflows"
 REQUIREMENTS = REPO_ROOT / ".github" / "requirements-build.txt"
 
 
-def test_requirements_build_pins_backend_with_hashes() -> None:
+def test_requirements_build_uses_version_floors() -> None:
     text = REQUIREMENTS.read_text(encoding="utf-8")
-    for package in ("build==", "hatchling==", "hatch-vcs=="):
+    for package in ("build>=", "hatchling>=", "hatch-vcs>="):
         assert package in text
-    assert "--hash=sha256:" in text
+    assert "==" not in text
+    assert "--hash=" not in text
+
+
+def test_publish_installs_without_require_hashes() -> None:
+    offenders: list[str] = []
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        text = path.read_text(encoding="utf-8")
+        if "requirements-build.txt" in text and "--require-hashes" in text:
+            offenders.append(str(path.relative_to(REPO_ROOT)))
+    assert offenders == []
 
 
 def test_publish_builds_use_no_isolation() -> None:


### PR DESCRIPTION
## Why

#269 landed a hashed exact pin file for `build` / `hatchling` / `hatch-vcs`.
That made updates a full recompile. We still want `--no-isolation` so PEP 517
isolation cannot pull a *different* backend than the one we installed.

## What

- Replace the hashed lock with version floors (`build>=1.5.0`,
  `hatchling>=1.31.0`, `hatch-vcs>=0.5.0`).
- Install without `--require-hashes`.
- Keep `--no-isolation`.

A floor bump (or a newer compatible release) is enough to update.

Tracker: #252.