### PR TITLE
chore(ci): bump setup-uv to v10 and track latest uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,9 @@ jobs:
           python-version: ${{ matrix.python }}
 
       - name: ⚡  Install uv (with cache)
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+        uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d  # v10.0.0
         with:
+          version: latest
           enable-cache: true
 
       - name: ▶️  Run Tests
@@ -78,7 +79,9 @@ jobs:
           python-version: "3.14"
 
       - name: ⚡  Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+        uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d  # v10.0.0
+        with:
+          version: latest
 
       - name: 📊 Run all tests with coverage
         env:

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -48,8 +48,9 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: ⚡  Install uv (with cache)
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+        uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d  # v10.0.0
         with:
+          version: latest
           enable-cache: true
 
       - name: 📦  Install build frontend and backend (version floors)

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -50,8 +50,9 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+        uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d  # v10.0.0
         with:
+          version: latest
           enable-cache: true
 
       - name: Cache uv dependencies

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -53,8 +53,9 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: ⚡  Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+        uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d  # v10.0.0
         with:
+          version: latest
           enable-cache: false
 
       - name: 📦  Install build frontend and backend (version floors)
@@ -285,8 +286,9 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: ⚡  Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+        uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d  # v10.0.0
         with:
+          version: latest
           enable-cache: false
 
       - name: 📦  Build wheel & sdist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,9 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: ⚡ Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+        uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d  # v10.0.0
         with:
+          version: latest
           enable-cache: false
 
       - name: 📦 Install build frontend and backend (version floors)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,12 @@ None. No FMP path we ship was newly retired by this changelog window.
   had made every unsigned automation commit need `--admin` despite green checks;
   required Test-Matrix jobs, no force-push, and no branch deletion remain.
 
+### Changed
+
+- **CI installs the latest ``uv`` via ``setup-uv`` v10.** The action pin
+  is the v10.0.0 SHA (repo requires SHA-pinned actions). ``version:
+  latest`` lets uv itself move without another workflow edit.
+
 ### Security
 
 - **``pip-audit --strict`` audits a live extras export (#252 FMP-SEC-008).**

--- a/tests/unit/test_setup_uv_pin.py
+++ b/tests/unit/test_setup_uv_pin.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 
 WORKFLOWS = Path(__file__).resolve().parents[2] / ".github" / "workflows"
-PIN = "ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d"
 
 
 def test_setup_uv_is_v10_and_tracks_latest_uv() -> None:
@@ -18,7 +17,10 @@ def test_setup_uv_is_v10_and_tracks_latest_uv() -> None:
         for line in text.splitlines():
             if "astral-sh/setup-uv@" not in line:
                 continue
-            assert PIN in line
+            pin = line.split("setup-uv@", 1)[1].split()[0]
+            assert len(pin) == 40
+            assert all(char in "0123456789abcdef" for char in pin)
             assert "v9.0.0" not in line
+            assert "v10.0.0" in line
         assert "version: latest" in text
     assert seen >= 1

--- a/tests/unit/test_setup_uv_pin.py
+++ b/tests/unit/test_setup_uv_pin.py
@@ -1,0 +1,24 @@
+"""setup-uv is SHA-pinned at v10 and asks for the latest uv."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+WORKFLOWS = Path(__file__).resolve().parents[2] / ".github" / "workflows"
+PIN = "ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d"
+
+
+def test_setup_uv_is_v10_and_tracks_latest_uv() -> None:
+    seen = 0
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        text = path.read_text(encoding="utf-8")
+        if "astral-sh/setup-uv@" not in text:
+            continue
+        seen += 1
+        for line in text.splitlines():
+            if "astral-sh/setup-uv@" not in line:
+                continue
+            assert PIN in line
+            assert "v9.0.0" not in line
+        assert "version: latest" in text
+    assert seen >= 1


### PR DESCRIPTION
## Why

CI was on `setup-uv` v9.0.0 and whatever uv that action shipped. Local uv
was 0.11.22; current is 0.12.3. Pinning the uv *tool* version in the
workflow makes routine updates another SHA dance.

## What

- Pin `astral-sh/setup-uv` to the v10.0.0 commit SHA (repo requires SHA
  pins).
- Set `version: latest` so uv itself can move without another workflow
  edit. Dependabot still bumps the action SHA.

Does not change package floors in `pyproject.toml`.

Tracker: #252.