### PR TITLE
chore(ci): pin uv 0.12.3 locally and in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: ⚡  Install uv (with cache)
         uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d  # v10.0.0
         with:
-          version: latest
+          version: "0.12.3"
           enable-cache: true
 
       - name: ▶️  Run Tests
@@ -81,7 +81,7 @@ jobs:
       - name: ⚡  Install uv
         uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d  # v10.0.0
         with:
-          version: latest
+          version: "0.12.3"
 
       - name: 📊 Run all tests with coverage
         env:

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -50,7 +50,7 @@ jobs:
       - name: ⚡  Install uv (with cache)
         uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d  # v10.0.0
         with:
-          version: latest
+          version: "0.12.3"
           enable-cache: true
 
       - name: 📦  Install build frontend and backend (version floors)

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d  # v10.0.0
         with:
-          version: latest
+          version: "0.12.3"
           enable-cache: true
 
       - name: Cache uv dependencies

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -55,7 +55,7 @@ jobs:
       - name: ⚡  Install uv
         uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d  # v10.0.0
         with:
-          version: latest
+          version: "0.12.3"
           enable-cache: false
 
       - name: 📦  Install build frontend and backend (version floors)
@@ -288,7 +288,7 @@ jobs:
       - name: ⚡  Install uv
         uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d  # v10.0.0
         with:
-          version: latest
+          version: "0.12.3"
           enable-cache: false
 
       - name: 📦  Build wheel & sdist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - name: ⚡ Install uv
         uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d  # v10.0.0
         with:
-          version: latest
+          version: "0.12.3"
           enable-cache: false
 
       - name: 📦 Install build frontend and backend (version floors)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,9 +172,9 @@ None. No FMP path we ship was newly retired by this changelog window.
 
 ### Changed
 
-- **CI installs the latest ``uv`` via ``setup-uv`` v10.** The action pin
-  is the v10.0.0 SHA (repo requires SHA-pinned actions). ``version:
-  latest`` lets uv itself move without another workflow edit.
+- **CI and local uv are 0.12.3+.** ``setup-uv`` v10 installs uv ``0.12.3``.
+  ``[tool.uv] required-version = ">=0.12.3"`` rejects older local
+  installs. The action pin remains the v10.0.0 SHA.
 
 ### Security
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,8 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
 ```
 
+This repo requires uv 0.12.3 or newer (`uv self update` if yours is older).
+
 3. **Install dependencies:**
 ```bash
 # Quick setup with make

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,9 @@ mcp = [
     "pyyaml>=6.0.3",
 ]
 
+[tool.uv]
+required-version = ">=0.12.3"
+
 [tool.hatch.version]
 source = "vcs"
 

--- a/tests/unit/test_setup_uv_pin.py
+++ b/tests/unit/test_setup_uv_pin.py
@@ -1,4 +1,4 @@
-"""setup-uv is SHA-pinned at v10 and asks for the latest uv."""
+"""setup-uv is SHA-pinned at v10 and installs uv 0.12.3."""
 
 from __future__ import annotations
 
@@ -22,5 +22,16 @@ def test_setup_uv_is_v10_and_tracks_latest_uv() -> None:
             assert all(char in "0123456789abcdef" for char in pin)
             assert "v9.0.0" not in line
             assert "v10.0.0" in line
-        assert "version: latest" in text
+        assert 'version: "0.12.3"' in text
     assert seen >= 1
+
+
+def test_pyproject_requires_current_uv() -> None:
+    text = (
+        Path(__file__)
+        .resolve()
+        .parents[2]
+        .joinpath("pyproject.toml")
+        .read_text(encoding="utf-8")
+    )
+    assert 'required-version = ">=0.12.3"' in text


### PR DESCRIPTION
## Why

Local uv is already **0.12.3** (current latest). CI was on `setup-uv` v10
with `version: latest`, which is not a version you can see in the tree.

## What

- `[tool.uv] required-version = ">=0.12.3"` so an older local uv fails closed.
- Every `setup-uv` job installs `0.12.3` (not `latest`).
- CONTRIBUTING notes the floor.

The action SHA stays at v10.0.0.

## Local

```
uv self update   # already 0.12.3 on this machine
uv --version     # uv 0.12.3
```