### PR TITLE
fix(client): refuse cross-origin redirects via Location (#252)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -299,7 +303,7 @@
         "filename": "tests/unit/test_base.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 101
+        "line_number": 102
       }
     ],
     "tests/unit/test_base_async.py": [
@@ -521,5 +525,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-13T20:13:58Z"
+  "generated_at": "2026-08-13T23:05:03Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -303,7 +303,7 @@
         "filename": "tests/unit/test_base.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 102
+        "line_number": 103
       }
     ],
     "tests/unit/test_base_async.py": [
@@ -525,5 +525,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-13T23:05:03Z"
+  "generated_at": "2026-08-14T00:51:20Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,7 +237,9 @@ None. No FMP path we ship was newly retired by this changelog window.
 - **API key stays on origin (#252 FMP-SEC-004).** `base_url` must be HTTPS
   except loopback HTTP. The key is sent only as the `apikey` query parameter
   (no client-wide header that a 302 would forward). Cross-origin redirects
-  are refused.
+  are refused by inspecting the `Location` header: httpx only sets
+  `next_request` when `follow_redirects` is false, so a next-request-only
+  check was a no-op in production.
 - **Log redaction applies to child loggers and ``api_key=%s`` (#252 FMP-SEC-005).**
   The filter formats the message before masking, so a ``%s`` value is not
   treated as the secret (which previously crashed logging and printed the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -239,7 +239,8 @@ None. No FMP path we ship was newly retired by this changelog window.
   (no client-wide header that a 302 would forward). Cross-origin redirects
   are refused by inspecting the `Location` header: httpx only sets
   `next_request` when `follow_redirects` is false, so a next-request-only
-  check was a no-op in production.
+  check was a no-op in production. An unparsable `Location` is refused
+  rather than left for httpx to handle after the hook returns.
 - **Log redaction applies to child loggers and ``api_key=%s`` (#252 FMP-SEC-005).**
   The filter formats the message before masking, so a ``%s`` value is not
   treated as the secret (which previously crashed logging and printed the

--- a/fmp_data/base.py
+++ b/fmp_data/base.py
@@ -48,16 +48,53 @@ def _default_http_headers() -> dict[str, str]:
     }
 
 
+def _origin(url: httpx.URL) -> tuple[str, str, int | None]:
+    """Scheme, host, and defaulted port so ``:443`` matches a bare HTTPS URL."""
+    scheme = url.scheme.lower()
+    host = (url.host or "").lower()
+    port = url.port
+    if port is None:
+        if scheme == "https":
+            port = 443
+        elif scheme == "http":
+            port = 80
+    return scheme, host, port
+
+
+def _resolve_redirect_target(response: httpx.Response) -> httpx.URL | None:
+    """Next hop URL. Prefer ``next_request``; else resolve ``Location`` as httpx does.
+
+    With ``follow_redirects=True`` the response hook runs *before* httpx
+    builds ``next_request``, so a Location-only 302 is the production case
+    (#252 FMP-SEC-004).
+    """
+    nxt = response.next_request
+    if nxt is not None:
+        return nxt.url
+    if not response.has_redirect_location:
+        return None
+    try:
+        url = httpx.URL(response.headers["Location"])
+    except httpx.InvalidURL:
+        return None
+    src = response.request.url
+    if url.scheme and not url.host:
+        url = url.copy_with(host=src.host)
+    if url.is_relative_url:
+        url = src.join(url)
+    return url
+
+
 def _reject_cross_origin_redirect(response: httpx.Response) -> None:
     """Refuse a 3xx that would send the next hop to another origin."""
-    nxt = response.next_request
-    if nxt is None:
+    target = _resolve_redirect_target(response)
+    if target is None:
         return
-    src, dst = response.request.url, nxt.url
-    if (src.scheme, src.host, src.port) != (dst.scheme, dst.host, dst.port):
+    src = response.request.url
+    if _origin(src) != _origin(target):
         raise FMPError(
             "Refusing cross-origin redirect "
-            f"from {src.scheme}://{src.host} to {dst.scheme}://{dst.host}"
+            f"from {src.scheme}://{src.host} to {target.scheme}://{target.host}"
         )
 
 

--- a/fmp_data/base.py
+++ b/fmp_data/base.py
@@ -76,7 +76,10 @@ def _resolve_redirect_target(response: httpx.Response) -> httpx.URL | None:
     try:
         url = httpx.URL(response.headers["Location"])
     except httpx.InvalidURL:
-        return None
+        src = response.request.url
+        raise FMPError(
+            f"Refusing redirect with invalid Location from {src.scheme}://{src.host}"
+        ) from None
     src = response.request.url
     if url.scheme and not url.host:
         url = url.copy_with(host=src.host)

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -11,6 +11,7 @@ from fmp_data.base import (
     AsyncEndpointGroup,
     BaseClient,
     EndpointGroup,
+    _reject_cross_origin_redirect,
     _sanitize_error_details,
     _sanitize_error_value,
 )
@@ -1188,28 +1189,132 @@ def test_http_client_does_not_put_apikey_in_default_headers(client_config):
         client.close()
 
 
-def test_reject_cross_origin_redirect():
-    from fmp_data.base import _reject_cross_origin_redirect
+def _redirect_response(src_url: str, location: str) -> httpx.Response:
+    """A 302 as ``follow_redirects=True`` presents it: Location set, no next_request."""
+    src = httpx.Request("GET", src_url)
+    return httpx.Response(302, headers={"location": location}, request=src)
 
-    src = httpx.Request("GET", "https://trusted.test/path")
-    dst = httpx.Request("GET", "https://attacker.test/steal")
-    response = httpx.Response(
-        302, headers={"location": "https://attacker.test/steal"}, request=src
+
+def test_reject_cross_origin_redirect_reads_location_when_next_request_unset():
+    """httpx sets next_request only when follow_redirects is False (#252)."""
+    response = _redirect_response(
+        "https://trusted.test/path?apikey=SECRET",
+        "https://attacker.test/steal",
     )
-    object.__setattr__(response, "next_request", dst)
-
+    assert response.next_request is None
     with pytest.raises(FMPError, match="cross-origin"):
         _reject_cross_origin_redirect(response)
 
 
-def test_same_origin_redirect_is_allowed():
-    from fmp_data.base import _reject_cross_origin_redirect
-
-    src = httpx.Request("GET", "https://trusted.test/old")
-    dst = httpx.Request("GET", "https://trusted.test/new")
-    response = httpx.Response(
-        302, headers={"location": "https://trusted.test/new"}, request=src
+def test_same_origin_location_redirect_is_allowed():
+    response = _redirect_response(
+        "https://trusted.test/old", "https://trusted.test/new"
     )
-    object.__setattr__(response, "next_request", dst)
-
+    assert response.next_request is None
     _reject_cross_origin_redirect(response)
+
+
+def test_scheme_relative_cross_origin_location_is_refused():
+    response = _redirect_response(
+        "https://trusted.test/path?apikey=SECRET",
+        "//attacker.test/steal",
+    )
+    with pytest.raises(FMPError, match="cross-origin"):
+        _reject_cross_origin_redirect(response)
+
+
+def test_https_to_http_same_host_is_refused():
+    response = _redirect_response(
+        "https://trusted.test/path",
+        "http://trusted.test/path",
+    )
+    with pytest.raises(FMPError, match="cross-origin"):
+        _reject_cross_origin_redirect(response)
+
+
+def test_https_default_port_is_same_origin():
+    response = _redirect_response(
+        "https://trusted.test/old",
+        "https://trusted.test:443/new",
+    )
+    _reject_cross_origin_redirect(response)
+
+
+def test_http_client_does_not_follow_cross_origin_302():
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(f"{request.url.scheme}://{request.url.host}{request.url.path}")
+        if request.url.host == "trusted.test":
+            return httpx.Response(
+                302,
+                headers={"location": "https://attacker.test/steal"},
+                request=request,
+            )
+        return httpx.Response(200, content=b"leaked", request=request)
+
+    with httpx.Client(
+        follow_redirects=True,
+        event_hooks={"response": [_reject_cross_origin_redirect]},
+        transport=httpx.MockTransport(handler),
+    ) as client:
+        with pytest.raises(FMPError, match="cross-origin"):
+            client.get("https://trusted.test/path?apikey=SECRET")
+
+    assert seen == ["https://trusted.test/path"]
+
+
+def test_http_client_follows_same_origin_302():
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.url.path)
+        if request.url.path == "/old":
+            return httpx.Response(
+                302,
+                headers={"location": "https://trusted.test/new"},
+                request=request,
+            )
+        return httpx.Response(200, json={"ok": True}, request=request)
+
+    with httpx.Client(
+        follow_redirects=True,
+        event_hooks={"response": [_reject_cross_origin_redirect]},
+        transport=httpx.MockTransport(handler),
+    ) as client:
+        response = client.get("https://trusted.test/old")
+
+    assert response.status_code == 200
+    assert seen == ["/old", "/new"]
+
+
+def test_base_client_installs_hook_that_refuses_cross_origin_302(client_config):
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.url.host)
+        if request.url.host == "api.test.com":
+            return httpx.Response(
+                302,
+                headers={"location": "https://attacker.test/steal"},
+                request=request,
+            )
+        return httpx.Response(200, content=b"leaked", request=request)
+
+    client = BaseClient(client_config)
+    try:
+        hooks = client.client.event_hooks
+        wrapped = httpx.Client(
+            timeout=client.config.timeout,
+            follow_redirects=True,
+            headers=dict(client.client.headers),
+            event_hooks=hooks,
+            transport=httpx.MockTransport(handler),
+        )
+        client.client.close()
+        client.client = wrapped
+        with pytest.raises(FMPError, match="cross-origin"):
+            client.client.get("https://api.test.com/stable/profile?apikey=SECRET")
+        assert seen == ["api.test.com"]
+    finally:
+        client.close()

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -11,6 +11,7 @@ from fmp_data.base import (
     AsyncEndpointGroup,
     BaseClient,
     EndpointGroup,
+    _origin,
     _reject_cross_origin_redirect,
     _sanitize_error_details,
     _sanitize_error_value,
@@ -1232,12 +1233,96 @@ def test_https_to_http_same_host_is_refused():
         _reject_cross_origin_redirect(response)
 
 
+def test_origin_defaults_http_ports_and_leaves_other_schemes():
+    https = httpx.URL("https://trusted.test/path")
+    http = httpx.URL("http://127.0.0.1/path")
+    ftp = httpx.URL("ftp://files.test/x")
+    custom = httpx.URL("https://trusted.test:8443/path")
+    assert _origin(https) == ("https", "trusted.test", 443)
+    assert _origin(http) == ("http", "127.0.0.1", 80)
+    assert _origin(ftp) == ("ftp", "files.test", None)
+    assert _origin(custom) == ("https", "trusted.test", 8443)
+
+
 def test_https_default_port_is_same_origin():
     response = _redirect_response(
         "https://trusted.test/old",
         "https://trusted.test:443/new",
     )
     _reject_cross_origin_redirect(response)
+
+
+def test_http_default_port_is_same_origin():
+    response = _redirect_response(
+        "http://127.0.0.1/old",
+        "http://127.0.0.1:80/new",
+    )
+    _reject_cross_origin_redirect(response)
+
+
+def test_explicit_non_default_port_is_different_origin():
+    response = _redirect_response(
+        "https://trusted.test/old",
+        "https://trusted.test:8443/new",
+    )
+    with pytest.raises(FMPError, match="cross-origin"):
+        _reject_cross_origin_redirect(response)
+
+
+def test_explicit_same_non_default_port_is_allowed():
+    response = _redirect_response(
+        "http://127.0.0.1:8080/old",
+        "http://127.0.0.1:8080/new",
+    )
+    _reject_cross_origin_redirect(response)
+
+
+def test_relative_location_is_same_origin():
+    response = _redirect_response("https://trusted.test/old", "/new")
+    _reject_cross_origin_redirect(response)
+
+
+def test_scheme_relative_same_host_is_allowed():
+    response = _redirect_response(
+        "https://trusted.test/old",
+        "//trusted.test/new",
+    )
+    _reject_cross_origin_redirect(response)
+
+
+def test_malformed_absolute_location_keeps_source_host():
+    """``https:/new`` is scheme+path with no host; httpx copies the source host."""
+    response = _redirect_response("https://trusted.test/old", "https:/new")
+    _reject_cross_origin_redirect(response)
+
+
+def test_non_redirect_response_is_ignored():
+    src = httpx.Request("GET", "https://trusted.test/path")
+    _reject_cross_origin_redirect(httpx.Response(200, request=src))
+
+
+def test_next_request_fallback_is_honored_when_set():
+    src = httpx.Request("GET", "https://trusted.test/path")
+    dst = httpx.Request("GET", "https://attacker.test/steal")
+    response = httpx.Response(
+        302,
+        headers={"location": "https://trusted.test/new"},
+        request=src,
+    )
+    object.__setattr__(response, "next_request", dst)
+    with pytest.raises(FMPError, match="cross-origin"):
+        _reject_cross_origin_redirect(response)
+
+
+def test_invalid_location_is_refused(monkeypatch):
+    response = _redirect_response("https://trusted.test/path", "https://ok.test/x")
+
+    def _boom(_value: str) -> httpx.URL:
+        raise httpx.InvalidURL("bad")
+
+    monkeypatch.setattr("fmp_data.base.httpx.URL", _boom)
+    with pytest.raises(FMPError, match="invalid Location"):
+        _reject_cross_origin_redirect(response)
 
 
 def test_http_client_does_not_follow_cross_origin_302():

--- a/tests/unit/test_base_async.py
+++ b/tests/unit/test_base_async.py
@@ -107,6 +107,20 @@ class TestAsyncClientReuse:
         # Cleanup
         await client.aclose()
 
+    @pytest.mark.asyncio
+    async def test_async_client_installs_cross_origin_redirect_hook(
+        self, client_config
+    ):
+        """Async client uses the same Location-based SEC-004 hook as sync."""
+        from fmp_data.base import BaseClient, _reject_cross_origin_redirect
+
+        client = BaseClient(client_config)
+        try:
+            async_client = client._setup_async_client()
+            assert _reject_cross_origin_redirect in async_client.event_hooks["response"]
+        finally:
+            await client.aclose()
+
 
 class TestAclose:
     """Tests for async close functionality."""


### PR DESCRIPTION
## Why

#252 FMP-SEC-004 claimed cross-origin redirects were refused. The hook only inspected `response.next_request`. In httpx 0.28 that field is set **only** when `follow_redirects=False`. Production clients use `follow_redirects=True`, so the hook always returned and the 302 was followed.

The header leak from the original report stays closed (query-only `apikey`). This PR makes the redirect refusal actually run.

## What

- Resolve `Location` the same way httpx does (absolute, relative, `//host`)
- Compare normalized origin (`scheme`, `host`, default port) before the next hop
- Keep `next_request` as a fallback when it is set
- Replace planted-`next_request` tests with Location-only cases and `MockTransport` tests that assert the attacker host is never contacted

Isolated from the remaining #273 leftovers.

Closes nothing on its own; #252 stays open until the leftovers land.