### PR TITLE
fix(sec): narrow Bandit skips to library asserts (#273)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,9 @@ None. No FMP path we ship was newly retired by this changelog window.
 
 ### Security
 
+- **Bandit skips are limited to `assert` used in the library (#273).**
+  Global `B404` / `B603` / `B607` / `B608` skips are gone. MCP subprocess
+  calls keep file-local `nosec` notes; there is no SQL to justify `B608`.
 - **API key stays on origin (#252 FMP-SEC-004).** `base_url` must be HTTPS
   except loopback HTTP. The key is sent only as the `apikey` query parameter
   (no client-wide header that a 302 would forward). Cross-origin redirects

--- a/fmp_data/mcp/setup.py
+++ b/fmp_data/mcp/setup.py
@@ -373,10 +373,10 @@ class SetupWizard:
         self.print(f"Found Python: {python_path}", "success")
 
         # Verify it can import fmp_data
-        import subprocess
+        import subprocess  # nosec B404
 
         try:
-            result = subprocess.run(
+            result = subprocess.run(  # nosec B603
                 [python_path, "-c", "import fmp_data"], capture_output=True, timeout=5
             )
             if result.returncode != 0:

--- a/fmp_data/mcp/utils.py
+++ b/fmp_data/mcp/utils.py
@@ -13,7 +13,7 @@ import os
 from pathlib import Path
 import platform
 import shutil
-import subprocess
+import subprocess  # nosec B404
 import sys
 import tempfile
 from typing import Any
@@ -65,12 +65,12 @@ def find_python_executable() -> str:
     # Try common Python commands
     for cmd in ["python3", "python", "python3.10", "python3.11", "python3.12"]:
         try:
-            result = subprocess.run(
+            result = subprocess.run(  # nosec B603
                 [cmd, "--version"], capture_output=True, text=True, timeout=2
             )
             if result.returncode == 0:
                 # Get the full path
-                which_result = subprocess.run(
+                which_result = subprocess.run(  # nosec B603
                     (
                         ["which", cmd]
                         if platform.system() != "Windows"
@@ -273,7 +273,7 @@ def test_mcp_server(api_key: str, manifest_path: str | None = None) -> tuple[boo
 
     try:
         # Try to import and create the app
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603
             [
                 sys.executable,
                 "-c",
@@ -331,7 +331,7 @@ def validate_api_key(api_key: str) -> tuple[bool, str]:
         env = os.environ.copy()
         env["FMP_API_KEY"] = api_key
 
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603
             [
                 sys.executable,
                 "-c",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -463,10 +463,6 @@ exclude_dirs = [
 ]
 skips = [
     "B101",
-    "B404",
-    "B603",
-    "B607",
-    "B608",
 ]
 
 [tool.bandit.assert_used]

--- a/tests/unit/test_bandit_skips.py
+++ b/tests/unit/test_bandit_skips.py
@@ -1,0 +1,18 @@
+"""Bandit skips stay narrow (#273)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+
+def test_bandit_global_skips_are_only_assert_used() -> None:
+    text = PYPROJECT.read_text(encoding="utf-8")
+    start = text.index("[tool.bandit]")
+    end = text.index("[tool.bandit.assert_used]")
+    block = text[start:end]
+    assert '"B101"' in block
+    for code in ("B404", "B603", "B607", "B608"):
+        assert code not in block


### PR DESCRIPTION
## Why

#273 leftover: Bandit skipped `B404` / `B603` / `B607` / `B608` globally. The only remaining subprocess uses are MCP setup helpers with argument lists (no `shell=True`). There is no SQL.

## What

- Keep the global skip for `B101` (`assert` in `fmp_data/base.py`)
- Drop the other four skips
- Add file-local `# nosec B404` / `# nosec B603` on the MCP calls
- Guard the skip list so it cannot widen again

Isolated from the other #273 leftovers (extras coverage, `uv.lock` policy, embedding kwargs, `.env` identifiers).