### PR TITLE
fix(make): drop process-hijack keys from .env export (#273)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,10 @@ None. No FMP path we ship was newly retired by this changelog window.
 
 ### Security
 
+- **Makefile ``.env`` loader drops process-hijack keys (#273).**
+  ``PATH``, ``LD_PRELOAD``, ``PYTHONPATH``, ``DYLD_*``, and similar
+  identifiers are ignored so a trusted local file cannot rewrite the
+  maintainer shell.
 - **Bandit skips are limited to `assert` used in the library (#273).**
   Global `B404` / `B603` / `B607` / `B608` skips are gone. MCP subprocess
   calls keep file-local `nosec` notes; there is no SQL to justify `B608`.

--- a/scripts/export_dotenv.py
+++ b/scripts/export_dotenv.py
@@ -4,7 +4,8 @@
 Used by the Makefile so a crafted ``.env`` cannot run as the maintainer
 (#252 FMP-SEC-011). Values are ``shlex.quote``-d. Lines that are empty,
 comments, or missing ``=`` are ignored. Optional ``export `` prefix is
-stripped. No interpolation, no command substitution.
+stripped. No interpolation, no command substitution. Process-hijack keys
+(``PATH``, ``LD_PRELOAD``, ``PYTHONPATH``, ``DYLD_*``, …) are dropped.
 """
 
 from __future__ import annotations
@@ -12,6 +13,29 @@ from __future__ import annotations
 from pathlib import Path
 import shlex
 import sys
+
+# A trusted .env can still clobber the maintainer shell if we export these.
+_BLOCKED_KEYS = frozenset(
+    {
+        "PATH",
+        "LD_PRELOAD",
+        "LD_LIBRARY_PATH",
+        "DYLD_INSERT_LIBRARIES",
+        "DYLD_LIBRARY_PATH",
+        "DYLD_FRAMEWORK_PATH",
+        "PYTHONPATH",
+        "PYTHONHOME",
+        "PYTHONSTARTUP",
+        "PYTHONBREAKPOINT",
+        "IFS",
+        "PS4",
+        "SHELLOPTS",
+        "BASH_ENV",
+        "ENV",
+        "CDPATH",
+        "PROMPT_COMMAND",
+    }
+)
 
 
 def export_lines(text: str) -> list[str]:
@@ -27,6 +51,8 @@ def export_lines(text: str) -> list[str]:
         key, value = stripped.split("=", 1)
         key = key.strip()
         if not key or not key.isidentifier():
+            continue
+        if key in _BLOCKED_KEYS or key.startswith("DYLD_"):
             continue
         value = value.strip()
         if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:

--- a/tests/unit/test_export_dotenv.py
+++ b/tests/unit/test_export_dotenv.py
@@ -33,3 +33,25 @@ def test_export_lines_quotes_and_ignores_shell() -> None:
     # $(...) is quoted, not executed
     assert any("EVIL=" in line and "$(touch" in line for line in lines)
     assert all(line.startswith("export ") for line in lines)
+
+
+def test_export_lines_drops_process_hijack_keys() -> None:
+    text = "\n".join(
+        [
+            "FMP_API_KEY=keep",
+            "PATH=/tmp/evil",
+            "LD_PRELOAD=/tmp/evil.so",
+            "PYTHONPATH=/tmp/evil",
+            "DYLD_INSERT_LIBRARIES=/tmp/evil.dylib",
+            "DYLD_CUSTOM=also-blocked",
+            "IFS=x",
+        ]
+    )
+    lines = export_dotenv.export_lines(text)
+    joined = "\n".join(lines)
+    assert "export FMP_API_KEY=keep" in joined
+    assert "PATH=" not in joined
+    assert "LD_PRELOAD=" not in joined
+    assert "PYTHONPATH=" not in joined
+    assert "DYLD_" not in joined
+    assert "IFS=" not in joined


### PR DESCRIPTION
## Why

#273 leftover: `scripts/export_dotenv.py` accepts any identifier key because `.env` is a trusted maintainer file. `PATH`, `LD_PRELOAD`, `PYTHONPATH`, and `DYLD_*` can still rewrite the shell that `make` drives.

## What

- Drop a small denylist of process-hijack keys (and any `DYLD_*` name)
- Values stay `shlex.quote`-d; command substitution is still not executed
- Tests pin that those keys never become `export` lines

Isolated from the other #273 leftovers.