### PR TITLE
fix(lc): redact secret-shaped embedding kwargs in repr (#273)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -285,7 +285,7 @@
         "filename": "tests/unit/lc/test_embedding.py",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 33
+        "line_number": 31
       }
     ],
     "tests/unit/test_async_clients.py": [
@@ -525,5 +525,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-14T00:51:20Z"
+  "generated_at": "2026-08-14T00:55:57Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,9 @@ None. No FMP path we ship was newly retired by this changelog window.
 
 ### Security
 
+- **Embedding ``additional_kwargs`` no longer leak secrets in ``repr`` (#273).**
+  Secret-shaped keys are replaced with ``***``; ``api_key`` stays off the
+  default field repr.
 - **Makefile ``.env`` loader drops process-hijack keys (#273).**
   ``PATH``, ``LD_PRELOAD``, ``PYTHONPATH``, ``DYLD_*``, and similar
   identifiers are ignored so a trusted local file cannot rewrite the

--- a/fmp_data/lc/embedding.py
+++ b/fmp_data/lc/embedding.py
@@ -10,6 +10,28 @@ from pydantic import BaseModel, ConfigDict, Field
 from fmp_data.exceptions import ConfigError
 from fmp_data.lc.utils import check_package_dependency
 
+_SECRET_KWARG_TOKENS = (
+    "key",
+    "token",
+    "secret",
+    "password",
+    "passwd",
+    "authorization",
+    "auth",
+)
+
+
+def _redact_kwargs(data: dict[str, Any]) -> dict[str, Any]:
+    """Copy a kwargs map with secret-shaped values replaced."""
+    redacted: dict[str, Any] = {}
+    for key, value in data.items():
+        lowered = key.lower()
+        if any(token in lowered for token in _SECRET_KWARG_TOKENS):
+            redacted[key] = "***"
+        else:
+            redacted[key] = value
+    return redacted
+
 
 class EmbeddingProvider(str, Enum):
     """Supported embedding providers"""
@@ -36,9 +58,19 @@ class EmbeddingConfig(BaseModel):
     additional_kwargs: dict[str, Any] = Field(
         default_factory=dict,
         description="Additional keyword arguments for the embedding provider",
+        repr=False,
     )
 
     model_config = ConfigDict(from_attributes=True, arbitrary_types_allowed=True)
+
+    def __repr__(self) -> str:
+        """Hide API keys and secret-shaped kwargs from ``repr`` (#273)."""
+        return (
+            f"{type(self).__name__}("
+            f"provider={self.provider!r}, "
+            f"model_name={self.model_name!r}, "
+            f"additional_kwargs={_redact_kwargs(self.additional_kwargs)!r})"
+        )
 
     def get_embeddings(self) -> Embeddings:
         """

--- a/fmp_data/lc/embedding.py
+++ b/fmp_data/lc/embedding.py
@@ -25,8 +25,8 @@ def _redact_kwargs(data: dict[str, Any]) -> dict[str, Any]:
     """Copy a kwargs map with secret-shaped values replaced."""
     redacted: dict[str, Any] = {}
     for key, value in data.items():
-        lowered = key.lower()
-        if any(token in lowered for token in _SECRET_KWARG_TOKENS):
+        parts = key.lower().replace("-", "_").split("_")
+        if any(part in _SECRET_KWARG_TOKENS for part in parts):
             redacted[key] = "***"
         else:
             redacted[key] = value

--- a/tests/unit/lc/test_embedding.py
+++ b/tests/unit/lc/test_embedding.py
@@ -25,6 +25,22 @@ def mock_cohere():
         yield mock
 
 
+def test_embedding_config_repr_redacts_secret_kwargs():
+    config = EmbeddingConfig(
+        provider=EmbeddingProvider.OPENAI,
+        api_key="test-key",
+        additional_kwargs={
+            "openai_api_key": "test-provider-key",  # pragma: allowlist secret
+            "timeout": 30,
+        },
+    )
+    text = repr(config)
+    assert "test-key" not in text
+    assert "test-provider-key" not in text
+    assert "timeout" in text
+    assert "30" in text
+
+
 def test_embedding_config_validation():
     """Test embedding configuration validation"""
     # Test valid OpenAI config

--- a/tests/unit/lc/test_embedding.py
+++ b/tests/unit/lc/test_embedding.py
@@ -39,6 +39,12 @@ def test_embedding_config_repr_redacts_secret_kwargs():
     assert "test-provider-key" not in text
     assert "timeout" in text
     assert "30" in text
+    config_with_author = EmbeddingConfig(
+        additional_kwargs={"author": "visible", "http_auth": "hidden"}
+    )
+    author_repr = repr(config_with_author)
+    assert "visible" in author_repr
+    assert "hidden" not in author_repr
 
 
 def test_embedding_config_validation():


### PR DESCRIPTION
## Why

#273 leftover: `EmbeddingConfig.additional_kwargs` is a free-form dict. A provider key placed there survived `repr` even though `api_key` is `repr=False`.

## What

- Custom `repr` that replaces secret-shaped kwargs with `***`
- Keep `api_key` and `additional_kwargs` off Pydantic's default field repr
- Regression test that a dummy provider key does not appear in `repr`

Isolated from the other #273 leftovers.