### PR TITLE
fix(ci): add extras coverage gate and expand MCP session (#273)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,31 @@ jobs:
           flags: unittests
           fail_ci_if_error: false
 
+  extras-coverage:
+    name: Extras Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛎️  Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: 🐍  Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: "3.14"
+
+      - name: ⚡  Install uv
+        uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d  # v10.0.0
+        with:
+          version: "0.12.3"
+
+      - name: 📊 Extras coverage gate (lc / mcp / Redis)
+        env:
+          NOX_USE_UV: "1"
+          CI: "true"
+        run: |
+          uv tool install nox
+          uv tool run nox -s coverage_extras
+
   secret-scan:
     name: Secret Scan
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,12 +212,12 @@ jobs:
   test-matrix-expected:
     name: Test-MatrixExpected
     runs-on: ubuntu-latest
-    needs: [tests, coverage, secret-scan, actions-shell]
+    needs: [tests, coverage, extras-coverage, secret-scan, actions-shell]
     if: ${{ always() }}
     steps:
       - name: ✅ Verify matrix results
         run: |
-          if [[ "${{ needs.tests.result }}" != "success" || "${{ needs.coverage.result }}" != "success" || "${{ needs.secret-scan.result }}" != "success" || "${{ needs.actions-shell.result }}" != "success" ]]; then
+          if [[ "${{ needs.tests.result }}" != "success" || "${{ needs.coverage.result }}" != "success" || "${{ needs.extras-coverage.result }}" != "success" || "${{ needs.secret-scan.result }}" != "success" || "${{ needs.actions-shell.result }}" != "success" ]]; then
             echo "Upstream checks failed"
             exit 1
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,12 @@ None. No FMP path we ship was newly retired by this changelog window.
 - **CI and local uv are 0.12.3+.** ``setup-uv`` v10 installs uv ``0.12.3``.
   ``[tool.uv] required-version = ">=0.12.3"`` rejects older local
   installs. The action pin remains the v10.0.0 SHA.
+- **Separate extras coverage gate for ``lc`` / ``mcp`` / Redis (#273).**
+  The core 80% report still omits those trees. ``nox -s coverage_extras``
+  (CI job ``extras-coverage``) installs the extras, measures only those
+  files, and fails under 65% (measured baseline 66.78% on 2026-08-13).
+  ``Test-MatrixExpected`` requires that job. The ``mcp-server`` session
+  now runs every ``tests/unit/test_mcp*.py`` file.
 
 ### Security
 
@@ -191,13 +197,6 @@ None. No FMP path we ship was newly retired by this changelog window.
 - **CodeQL analyzes the Python tree on every PR (#252 FMP-SEC-008).**
   Findings upload to GitHub code scanning. The workflow is SHA-pinned
   and uses ``build-mode: none``.
-- **Separate extras coverage gate for ``lc`` / ``mcp`` / Redis (#273).**
-  The core 80% report still omits those trees. ``nox -s coverage_extras``
-  (CI job ``extras-coverage``) installs the extras, measures only those
-  files, and fails under 65% (measured baseline 66.78% on 2026-08-13).
-  The ``mcp-server`` session now runs every ``tests/unit/test_mcp*.py``
-  file. ``uv.lock`` stays uncommitted; ``pip-audit`` still uses a live
-  export (#270).
 
 - **Isolated PyPI publishing and immutable Actions pins (#252).** Release,
   Dev-Release, and Publish-to-TestPyPI now build in a job with no OIDC token

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,13 @@ None. No FMP path we ship was newly retired by this changelog window.
 - **CodeQL analyzes the Python tree on every PR (#252 FMP-SEC-008).**
   Findings upload to GitHub code scanning. The workflow is SHA-pinned
   and uses ``build-mode: none``.
+- **Separate extras coverage gate for ``lc`` / ``mcp`` / Redis (#273).**
+  The core 80% report still omits those trees. ``nox -s coverage_extras``
+  (CI job ``extras-coverage``) installs the extras, measures only those
+  files, and fails under 65% (measured baseline 66.78% on 2026-08-13).
+  The ``mcp-server`` session now runs every ``tests/unit/test_mcp*.py``
+  file. ``uv.lock`` stays uncommitted; ``pip-audit`` still uses a live
+  export (#270).
 
 - **Isolated PyPI publishing and immutable Actions pins (#252).** Release,
   Dev-Release, and Publish-to-TestPyPI now build in a job with no OIDC token

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -101,7 +101,11 @@ def test_api_call(client):
 
 We maintain high test coverage:
 
-- Minimum coverage: 80%
+- Core minimum coverage: 80% (`fmp_data/lc/*`, `fmp_data/mcp/*`, and
+  `fmp_data/cache/redis_backend.py` stay omitted from that number)
+- Extras gate: 65% via `uv tool run nox -s coverage_extras` (or the
+  CI `extras-coverage` job). That session installs langchain / mcp /
+  cache-redis and measures only those trees.
 - Coverage report: `uv run pytest --cov=fmp_data --cov-report=html`
 - View report: `open htmlcov/index.html`
 

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -104,8 +104,9 @@ We maintain high test coverage:
 - Core minimum coverage: 80% (`fmp_data/lc/*`, `fmp_data/mcp/*`, and
   `fmp_data/cache/redis_backend.py` stay omitted from that number)
 - Extras gate: 65% via `uv tool run nox -s coverage_extras` (or the
-  CI `extras-coverage` job). That session installs langchain / mcp /
-  cache-redis and measures only those trees.
+  CI `extras-coverage` job, required by `Test-MatrixExpected`). That
+  session installs langchain / mcp / cache-redis and measures only
+  those trees.
 - Coverage report: `uv run pytest --cov=fmp_data --cov-report=html`
 - View report: `open htmlcov/index.html`
 

--- a/extras.coveragerc
+++ b/extras.coveragerc
@@ -3,9 +3,9 @@
 [run]
 branch = true
 source =
-    fmp_data/lc
-    fmp_data/mcp
-    fmp_data/cache/redis_backend.py
+    fmp_data.lc
+    fmp_data.mcp
+    fmp_data.cache.redis_backend
 
 [report]
 fail_under = 65

--- a/extras.coveragerc
+++ b/extras.coveragerc
@@ -1,0 +1,29 @@
+# Separate extras coverage gate (#273).
+# Core 80% still omits these trees in pyproject.toml.
+[run]
+branch = true
+source =
+    fmp_data/lc
+    fmp_data/mcp
+    fmp_data/cache/redis_backend.py
+
+[report]
+fail_under = 65
+show_missing = true
+precision = 2
+skip_empty = false
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    def __str__
+    raise NotImplementedError
+    if __name__ == ['\"]__main__['\"]:
+    if TYPE_CHECKING:
+    pass
+    raise ImportError
+    except ImportError
+    def main():
+    class .*\\(Protocol\\):
+    @abstractmethod
+    @overload
+    \.\.\.$

--- a/noxfile.py
+++ b/noxfile.py
@@ -105,6 +105,14 @@ def _pytest_xdist_args() -> list[str]:
     return ["-n", "auto"]
 
 
+def _mcp_unit_tests() -> list[str]:
+    """Every ``tests/unit/test_mcp*.py`` file for the mcp-server session."""
+    return sorted(
+        p.relative_to(REPO_ROOT).as_posix()
+        for p in (REPO_ROOT / "tests" / "unit").glob("test_mcp*.py")
+    )
+
+
 # --------------------------------------------------------------------------- #
 #  Sessions                                                                   #
 # --------------------------------------------------------------------------- #
@@ -125,20 +133,18 @@ def tests(session: Session, feature_group: str | None) -> None:
     pytest_args = ["-q", *_pytest_xdist_args()]
 
     if feature_group == "mcp-server":
-        # Check if mcp tests exist and handle gracefully
-        mcp_test_file = Path("tests/unit/test_mcp.py")
-        if mcp_test_file.exists():
-            # Use success_codes to handle no tests collected gracefully
+        mcp_tests = _mcp_unit_tests()
+        if mcp_tests:
             session.run(
                 "pytest",
                 *pytest_args,
-                "tests/unit/test_mcp.py",
+                *mcp_tests,
                 "-m",
                 "not integration",
                 success_codes=[0, 5],  # 0=success, 5=no tests collected
             )
         else:
-            session.log("Skipping mcp-server tests - test_mcp.py not found")
+            session.log("Skipping mcp-server tests - no tests/unit/test_mcp*.py")
     else:
         # For core and langchain, run all tests
         session.run("pytest", *pytest_args, success_codes=[0, 5])
@@ -207,20 +213,19 @@ def coverage_local(session: Session) -> None:
 
         # Handle different feature groups
         if feature_group == "mcp-server":
-            # Check if mcp tests exist first
-            mcp_test_file = Path("tests/unit/test_mcp.py")
-            if mcp_test_file.exists():
+            mcp_tests = _mcp_unit_tests()
+            if mcp_tests:
                 session.run(
                     "pytest",
                     *pytest_args,
-                    "tests/unit/test_mcp.py",
+                    *mcp_tests,
                     "-m",
                     "not integration",
                     env=env,
                     success_codes=[0, 5],  # 0=success, 5=no tests collected
                 )
             else:
-                session.log("Skipping mcp-server tests - test_mcp.py not found")
+                session.log("Skipping mcp-server tests - no tests/unit/test_mcp*.py")
                 # Create minimal coverage file for this feature group
                 session.run(
                     "python",
@@ -258,6 +263,31 @@ cov.save()
     session.run("coverage", "xml")
     session.run("coverage", "html")
     session.run("coverage", "report")
+
+
+@nox.session(python=DEFAULT_PYTHON, tags=["coverage-extras"])
+def coverage_extras(session: Session) -> None:
+    """Separate extras coverage gate for lc / mcp / Redis (#273).
+
+    Core 80% still omits these trees. This session installs the extras,
+    measures only those files, and fails under 65% (baseline 66.78% on
+    2026-08-13). xdist is off so local and CI numbers stay comparable.
+    """
+    _sync_with_uv(
+        session,
+        extras=["dev", "langchain", "mcp-server", "cache-redis"],
+    )
+    session.run(
+        "pytest",
+        "-q",
+        "tests/unit",
+        "--cov=fmp_data.lc",
+        "--cov=fmp_data.mcp",
+        "--cov=fmp_data.cache.redis_backend",
+        "--cov-config=extras.coveragerc",
+        "--cov-report=term-missing",
+        "--cov-fail-under=65",
+    )
 
 
 @nox.session(python=DEFAULT_PYTHON, tags=["test-local"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,7 @@ extend-exclude = [
     "__pycache__",
     "build",
     "dist",
+    "extras.coveragerc",
 ]
 
 [tool.ruff.lint]
@@ -406,6 +407,8 @@ omit = [
     "fmp_data/lc/*",
     "fmp_data/mcp/*",
     "fmp_data/cache/redis_backend.py",
+    # Extras stay omitted from the core 80% gate. extras.coveragerc +
+    # `nox -s coverage_extras` measure them separately (#273).
 ]
 
 [tool.coverage.paths]

--- a/tests/unit/test_deprecated_endpoint_flags.py
+++ b/tests/unit/test_deprecated_endpoint_flags.py
@@ -22,8 +22,8 @@ need no extra beyond pydantic. CI runs the default matrix with no extras, so a
 guard that lives in ``tests/unit/lc/`` is invisible to it. The store-filtering
 behaviour, which genuinely needs langchain, stays in
 ``tests/unit/lc/test_deprecated_endpoints.py``; the MCP-side half of the
-contract lives in ``tests/unit/test_mcp.py``, the only file the ``mcp-server``
-CI job runs.
+contract lives in ``tests/unit/test_mcp.py``, which the ``mcp-server``
+CI job runs as part of ``tests/unit/test_mcp*.py``.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_extras_coverage_gate.py
+++ b/tests/unit/test_extras_coverage_gate.py
@@ -2,7 +2,7 @@
 
 The core 80% report still omits ``lc`` / ``mcp`` / Redis. A dedicated
 config + nox session + CI job fail under the measured extras baseline
-without folding those trees into Test-Matrix.
+without folding those trees into the core 80% job.
 """
 
 from __future__ import annotations
@@ -25,6 +25,23 @@ def _coverage_run_omit_block() -> str:
     return text[start:end]
 
 
+def _coverage_extras_session_source() -> str:
+    text = NOXFILE.read_text(encoding="utf-8")
+    start = text.index("def coverage_extras(")
+    rest = text[start:]
+    next_session = rest.find("\n@nox.session", 1)
+    return rest if next_session == -1 else rest[:next_session]
+
+
+def _test_matrix_expected_job() -> str:
+    text = CI.read_text(encoding="utf-8")
+    start = text.index("  test-matrix-expected:")
+    next_job = text.find("\n  ", start + 1)
+    while next_job != -1 and text[next_job + 3 : next_job + 4] in {" ", "\t"}:
+        next_job = text.find("\n  ", next_job + 1)
+    return text[start:] if next_job == -1 else text[start:next_job]
+
+
 def test_core_coverage_still_omits_extras() -> None:
     block = _coverage_run_omit_block()
     assert '"fmp_data/lc/*"' in block
@@ -37,31 +54,45 @@ def test_extras_coveragerc_gates_the_omitted_trees() -> None:
     parser = configparser.ConfigParser()
     parser.read(EXTRAS_COVERAGERC, encoding="utf-8")
     source = parser.get("run", "source")
-    assert "fmp_data/lc" in source
-    assert "fmp_data/mcp" in source
-    assert "fmp_data/cache/redis_backend.py" in source
+    assert "fmp_data.lc" in source
+    assert "fmp_data.mcp" in source
+    assert "fmp_data.cache.redis_backend" in source
+    assert "fmp_data/cache/redis_backend.py" not in source
     assert parser.getint("report", "fail_under") == 65
 
 
 def test_coverage_extras_session_uses_the_dedicated_config() -> None:
-    source = NOXFILE.read_text(encoding="utf-8")
-    assert "def coverage_extras(" in source
-    assert "extras.coveragerc" in source
+    source = _coverage_extras_session_source()
+    assert "--cov-config=extras.coveragerc" in source
+    assert "--cov-fail-under=65" in source
+    assert "--cov=fmp_data.lc" in source
+    assert "--cov=fmp_data.mcp" in source
+    assert "--cov=fmp_data.cache.redis_backend" in source
     assert "cache-redis" in source
     assert "langchain" in source
-    assert "mcp-server" in source or '"mcp"' in source
+    assert "mcp-server" in source
 
 
 def test_mcp_server_session_collects_every_test_mcp_star() -> None:
     source = NOXFILE.read_text(encoding="utf-8")
     assert 'glob("test_mcp*.py")' in source or "glob('test_mcp*.py')" in source
     assert "_mcp_unit_tests" in source
+    collected = {p.name for p in (REPO_ROOT / "tests" / "unit").glob("test_mcp*.py")}
+    assert {
+        "test_mcp.py",
+        "test_mcp_cli.py",
+        "test_mcp_config_perms.py",
+        "test_mcp_entry_point_coherence.py",
+    } <= collected
 
 
 def test_ci_runs_extras_coverage_separately() -> None:
     text = CI.read_text(encoding="utf-8")
     assert "nox -s coverage_extras" in text
     assert "coverage_local" in text
+    expected = _test_matrix_expected_job()
+    assert "extras-coverage" in expected
+    assert "needs.extras-coverage.result" in expected
 
 
 def test_uv_lock_stays_uncommitted() -> None:

--- a/tests/unit/test_extras_coverage_gate.py
+++ b/tests/unit/test_extras_coverage_gate.py
@@ -1,0 +1,69 @@
+"""Extras coverage stays a separate gate (#273).
+
+The core 80% report still omits ``lc`` / ``mcp`` / Redis. A dedicated
+config + nox session + CI job fail under the measured extras baseline
+without folding those trees into Test-Matrix.
+"""
+
+from __future__ import annotations
+
+import configparser
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+NOXFILE = REPO_ROOT / "noxfile.py"
+CI = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+GITIGNORE = REPO_ROOT / ".gitignore"
+EXTRAS_COVERAGERC = REPO_ROOT / "extras.coveragerc"
+
+
+def _coverage_run_omit_block() -> str:
+    text = PYPROJECT.read_text(encoding="utf-8")
+    start = text.index("[tool.coverage.run]")
+    end = text.index("[tool.coverage.paths]")
+    return text[start:end]
+
+
+def test_core_coverage_still_omits_extras() -> None:
+    block = _coverage_run_omit_block()
+    assert '"fmp_data/lc/*"' in block
+    assert '"fmp_data/mcp/*"' in block
+    assert '"fmp_data/cache/redis_backend.py"' in block
+
+
+def test_extras_coveragerc_gates_the_omitted_trees() -> None:
+    assert EXTRAS_COVERAGERC.is_file()
+    parser = configparser.ConfigParser()
+    parser.read(EXTRAS_COVERAGERC, encoding="utf-8")
+    source = parser.get("run", "source")
+    assert "fmp_data/lc" in source
+    assert "fmp_data/mcp" in source
+    assert "fmp_data/cache/redis_backend.py" in source
+    assert parser.getint("report", "fail_under") == 65
+
+
+def test_coverage_extras_session_uses_the_dedicated_config() -> None:
+    source = NOXFILE.read_text(encoding="utf-8")
+    assert "def coverage_extras(" in source
+    assert "extras.coveragerc" in source
+    assert "cache-redis" in source
+    assert "langchain" in source
+    assert "mcp-server" in source or '"mcp"' in source
+
+
+def test_mcp_server_session_collects_every_test_mcp_star() -> None:
+    source = NOXFILE.read_text(encoding="utf-8")
+    assert 'glob("test_mcp*.py")' in source or "glob('test_mcp*.py')" in source
+    assert "_mcp_unit_tests" in source
+
+
+def test_ci_runs_extras_coverage_separately() -> None:
+    text = CI.read_text(encoding="utf-8")
+    assert "nox -s coverage_extras" in text
+    assert "coverage_local" in text
+
+
+def test_uv_lock_stays_uncommitted() -> None:
+    text = GITIGNORE.read_text(encoding="utf-8")
+    assert "uv.lock" in text

--- a/tests/unit/test_mcp.py
+++ b/tests/unit/test_mcp.py
@@ -1500,8 +1500,8 @@ class TestDeprecationMechanismsStaySeparate:
     These live here, rather than beside the other #137 tests in
     ``tests/unit/lc/``, because they need the ``mcp`` extra and that directory
     is skipped without ``langchain``. No CI job installs both: the ``langchain``
-    job has no ``mcp``, and the ``mcp-server`` job runs only this file
-    (``noxfile.py``). Placed anywhere else, they would never execute.
+    job has no ``mcp``, and the ``mcp-server`` job runs ``tests/unit/test_mcp*.py``
+    (``noxfile.py``). Placed under ``tests/unit/lc/``, they would never execute.
     """
 
     def test_mcp_catalog_still_advertises_the_deprecated_keys(self):


### PR DESCRIPTION
## Summary

- Adds a **separate** extras coverage gate for `fmp_data/lc`, `fmp_data/mcp`, and `fmp_data/cache/redis_backend.py`. Core Test-Matrix stays on the 80% omit list.
- `nox -s coverage_extras` (CI job `extras-coverage`) installs langchain / mcp / cache-redis, measures only those trees, and fails under **65%** (measured baseline 66.78% with xdist / 66.96% without on 2026-08-13).
- Expands the `mcp-server` session from `tests/unit/test_mcp.py` to every `tests/unit/test_mcp*.py` file so `test_mcp_cli.py` actually runs in Test-Matrix.
- Leaves `uv.lock` uncommitted. `pip-audit --strict` still uses the live extras export from #270.

Addresses the remaining #273 leftovers. After this lands, #252's production-ready checklist is met in code (`closes` is inert on a `dev`-base PR).

## Test Plan

- [x] `uv run pytest tests/unit/test_extras_coverage_gate.py` — pins omit list, `extras.coveragerc` fail-under 65, nox session, MCP glob, CI job, and gitignored `uv.lock`
- [x] Extras coverage run (no xdist): 1941 passed, **66.96%** ≥ 65%
- [x] `_mcp_unit_tests()` returns `test_mcp.py`, `test_mcp_cli.py`, `test_mcp_config_perms.py`, `test_mcp_entry_point_coherence.py`
- [x] ruff + mypy on the new/changed Python files
- [ ] CI Test-Matrix `mcp-server` session collects the extra MCP files
- [ ] CI `extras-coverage` job is green and does not change the core 80% coverage job