### PR TITLE
fix(sec): repair async client, tag guard, and CI enforcement gaps (#252, #273, #282)

### DIFF
--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -270,10 +270,21 @@ jobs:
       - name: Require tag commit reachable from main or dev
         run: |
           set -euo pipefail
-          git fetch origin main dev
+          # Fully-qualified refs only. `origin/main` is an *unqualified* rev:
+          # git resolves refs/tags/<name> BEFORE refs/remotes/<name>, and
+          # checkout with fetch-depth:0 mirrors every tag verbatim
+          # (+refs/tags/*:refs/tags/*). A tag literally named "origin/main"
+          # therefore shadowed the remote-tracking branch and this guard
+          # compared HEAD against an attacker-chosen commit, passing with only
+          # a "refname is ambiguous" warning. --no-tags plus an explicit
+          # refspec keeps the comparison targets under refs/remotes/
+          # (#252 FMP-SEC-003).
+          git fetch --no-tags --force origin \
+            "+refs/heads/main:refs/remotes/origin/main" \
+            "+refs/heads/dev:refs/remotes/origin/dev"
           HEAD="$(git rev-parse HEAD)"
-          if git merge-base --is-ancestor "$HEAD" origin/main \
-            || git merge-base --is-ancestor "$HEAD" origin/dev; then
+          if git merge-base --is-ancestor "$HEAD" refs/remotes/origin/main \
+            || git merge-base --is-ancestor "$HEAD" refs/remotes/origin/dev; then
             echo "Tag $HEAD is reachable from origin/main or origin/dev"
           else
             echo "::error::Tag commit $HEAD is not an ancestor of origin/main or origin/dev (#252 FMP-SEC-003)"

--- a/.gitignore
+++ b/.gitignore
@@ -27,11 +27,16 @@ env/
 venv/
 ENV/
 
-# Lock files (trade-off: size vs reproducibility)
-# uv.lock (878KB) excluded to avoid GitHub's 500KB warning threshold
-# Trade-off: Accepts potential dependency drift for smaller repo size
-# CI regenerates from pyproject.toml - version constraints provide partial reproducibility
-# Users generate locally via: uv sync
+# Lock files — deliberately not committed (#273).
+# fmp-data ships as a library, so the compatibility contract is the version
+# floors in pyproject.toml; installers resolve against those and never read a
+# committed lock. Freezing one here would only pin CI, at the cost of a ~1MB
+# blob and a multi-thousand-line diff on every dependency bump.
+# Drift is caught rather than frozen: `nox -s security` exports the live
+# extras graph and audits it with `pip-audit --strict`, and the Actions used
+# by CI/publish are SHA-pinned (#252 FMP-SEC-002/008). See CONTRIBUTING.md
+# "Lock file policy".
+# Generate locally with: uv sync
 uv.lock
 poetry.lock
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -312,7 +312,7 @@
         "filename": "tests/unit/test_base_async.py",
         "hashed_secret": "767ef7376d44bb6e52b390ddcd12c1cb1b3902a4",
         "is_verified": false,
-        "line_number": 25
+        "line_number": 26
       }
     ],
     "tests/unit/test_base_coverage.py": [
@@ -525,5 +525,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-14T00:55:57Z"
+  "generated_at": "2026-08-14T04:30:11Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,6 +225,17 @@ None. No FMP path we ship was newly retired by this changelog window.
 
 ### Fixed
 
+- **Async requests work again (#252 FMP-SEC-004).** `httpx.AsyncClient` *awaits*
+  every response hook (`await hook(response)`), while `httpx.Client` calls it
+  plainly. The cross-origin redirect guard added for FMP-SEC-004 was a plain
+  `def` registered on both clients, so httpx awaited `None` and **every**
+  successful async response raised
+  `TypeError: object NoneType can't be used in 'await' expression` — not only
+  redirects. `_areject_cross_origin_redirect` now wraps the check for the async
+  client. Unreleased regression: it never shipped in a tagged version. The async
+  tests replaced the client with `AsyncMock` and asserted only hook membership,
+  so nothing exercised the real send path; they now drive
+  `httpx.MockTransport` and assert the hook is a coroutine function.
 - **`_unwrap_list_result` refuses a bytes file (#253).** `request_list` already
   raised `TypeError` for `Endpoint[bytes]`, but the shared unwrap helper still
   treated `isinstance(payload, bytes)` as a lone row and returned `[bytes]`.
@@ -232,6 +243,23 @@ None. No FMP path we ship was newly retired by this changelog window.
 
 ### Changed
 
+- **Extras coverage gate raised to 80% and made a required check (#273, #282).**
+  Dedicated tests for `cache/redis_backend.py`, `lc/validation.py`,
+  `lc/__init__.py`, `mcp/utils.py` and `mcp/setup.py` took the measured extras
+  number from 66.78% to 86.99%, so `nox -s coverage_extras` now fails under 80
+  with ~7 points of headroom. `Extras Coverage`, `coverage`, `Secret Scan`,
+  `Actions shell checks` and `Test-MatrixExpected` are now required status
+  checks on **Protect Dev** and **Protect Main**; previously only
+  `tests (3.10–3.14)` were required, so a red extras or secret scan could not
+  block a merge. Also fixed the `Protocol` exclusion in `extras.coveragerc`,
+  which had been copied from TOML with `\\(` and so never matched.
+- **`uv.lock` stays uncommitted, by decision (#273).** Recorded in
+  `CONTRIBUTING.md` under "Lock file policy": this is a library, so the
+  compatibility contract is the floors in `pyproject.toml`; drift is caught by
+  `nox -s security` auditing a live `uv export` with `pip-audit --strict`
+  rather than frozen behind stale pins. The old `.gitignore` rationale cited a
+  non-existent "GitHub 500KB warning" (that threshold is pre-commit's
+  `check-added-large-files` default) and has been replaced.
 - **`fmp-mcp generate` writes JSON / YAML / TOML from the output suffix (#256).**
   `.json` is preferred (`{"tools": [...]}`). `.yaml` / `.yml` and `.toml` use
   the same `tools` object. A path with no suffix becomes `<name>.json`.
@@ -240,6 +268,31 @@ None. No FMP path we ship was newly retired by this changelog window.
 
 ### Security
 
+- **TestPyPI tag guard cannot be shadowed by a tag (#252 FMP-SEC-003).** The
+  ancestry check compared against the *unqualified* rev `origin/main`. Git
+  resolves `refs/tags/<name>` before `refs/remotes/<name>`, and
+  `actions/checkout` with `fetch-depth: 0` mirrors every tag verbatim, so a tag
+  literally named `origin/main` shadowed the remote-tracking branch and the
+  guard compared HEAD against an attacker-chosen commit — passing with only a
+  "refname is ambiguous" warning, which `set -euo pipefail` does not trap. Both
+  comparisons now use `refs/remotes/origin/{main,dev}` and the guard fetches
+  with `--no-tags` and an explicit refspec.
+- **Bandit actually runs in CI (#273).** #278 replaced the blanket `B404` /
+  `B603` / `B607` / `B608` skips with narrow file-local `# nosec` notes, but
+  bandit was only wired into `.pre-commit-config.yaml` and there is no
+  pre-commit CI job — so the narrowing was unenforced and a new `subprocess`
+  call could land unreviewed. `nox -s security` now runs bandit over the
+  library before the dependency audit. Current tree: 0 findings.
+  `examples/mcp/claude_desktop/setup_claude_desktop.py` also picked up the
+  same file-local notes: #278 dropped the global skips without annotating it,
+  which left `pre-commit run --all-files` failing on the example.
+- **Embedding ``additional_kwargs`` redaction is recursive (#273).** The
+  top-level scan copied nested containers by reference, so a credential under a
+  real provider kwarg — `default_headers={"Authorization": ...}` or
+  `model_kwargs={"api_key": ...}`, both accepted by `OpenAIEmbeddings` and
+  splatted straight through — was printed verbatim by `repr`. Nested dicts,
+  lists, tuples and sets are now walked (depth-bounded); the live kwargs are
+  left unmutated.
 - **Embedding ``additional_kwargs`` no longer leak secrets in ``repr`` (#273).**
   Secret-shaped keys are replaced with ``***``; ``api_key`` stays off the
   default field repr.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -253,6 +253,35 @@ make deps-update
 make deps-check
 ```
 
+### Lock file policy
+
+`uv.lock` is **not committed**, and that is a deliberate decision (#273), not
+an oversight:
+
+- **This is a library, not an application.** The compatibility contract users
+  install against is the version floors in `pyproject.toml`. `pip`/`uv`
+  resolve against those; nothing downstream ever reads a lock file we commit.
+- **Drift is audited, not frozen.** `nox -s security` exports the live extras
+  graph (`uv export --extra langchain --extra mcp --extra cache-redis`) and
+  audits that resolution with `pip-audit --strict`. A committed lock would
+  make CI reproducible while quietly hiding new advisories behind stale pins.
+- **Supply-chain risk is pinned where it matters.** Every GitHub Action is
+  pinned to a 40-char SHA and the repo requires SHA-pinned actions; publish
+  runs as an isolated least-privilege job behind protected `pypi`/`testpypi`
+  environments (#252 FMP-SEC-002).
+- **Cost.** The lock is ~1&nbsp;MB and would add a multi-thousand-line diff to
+  every dependency bump, for no consumer benefit.
+
+Generate one locally whenever you want a reproducible dev environment:
+
+```bash
+uv sync   # writes uv.lock locally; it stays untracked
+```
+
+If CI breaks because a transitive dependency published a bad release, fix it
+by raising the floor (or adding an upper bound) in `pyproject.toml` — that is
+the fix users get too. Pinning CI alone would only hide the breakage.
+
 ### Pre-commit Hooks
 
 Pre-commit hooks run automatically on commit. To run manually:

--- a/examples/mcp/claude_desktop/setup_claude_desktop.py
+++ b/examples/mcp/claude_desktop/setup_claude_desktop.py
@@ -16,7 +16,12 @@ import json
 import os
 from pathlib import Path
 import platform
-import subprocess
+
+# Every call below passes an argument list (never shell=True) built from
+# sys.executable and literals, so there is no shell to inject into. #278
+# narrowed the global B404/B603 skips to file-local notes; this file follows
+# the same convention as fmp_data/mcp/setup.py (#273).
+import subprocess  # nosec B404
 import sys
 
 
@@ -65,7 +70,7 @@ def install_fmp_data():
     """Install fmp-data package with MCP support."""
     print("\n📦 Installing fmp-data with MCP support...")
     try:
-        subprocess.run(
+        subprocess.run(  # nosec B603
             [sys.executable, "-m", "pip", "install", "fmp-data[mcp]"], check=True
         )
         print("✅ Successfully installed fmp-data[mcp]")
@@ -162,7 +167,7 @@ def test_mcp_server(api_key):
 
     try:
         # Try to import and create the app
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603
             [
                 sys.executable,
                 "-c",

--- a/extras.coveragerc
+++ b/extras.coveragerc
@@ -8,7 +8,12 @@ source =
     fmp_data.cache.redis_backend
 
 [report]
-fail_under = 65
+# Baseline was 66.78% when this gate landed (#273); dedicated tests for
+# redis_backend / lc.validation / lc.__init__ / mcp.utils / mcp.setup took
+# it to 86.99% (#282). 80 keeps ~7 points of headroom so an ordinary
+# uncovered addition does not block merges the moment this becomes a
+# required check.
+fail_under = 80
 show_missing = true
 precision = 2
 skip_empty = false
@@ -23,7 +28,9 @@ exclude_lines =
     raise ImportError
     except ImportError
     def main():
-    class .*\\(Protocol\\):
+    # Single backslashes: this is an INI file, not TOML. The double-escaped
+    # copy (`\\(Protocol\\)`) asked for a literal backslash and never matched.
+    class .*\(Protocol\):
     @abstractmethod
     @overload
     \.\.\.$

--- a/fmp_data/base.py
+++ b/fmp_data/base.py
@@ -101,6 +101,20 @@ def _reject_cross_origin_redirect(response: httpx.Response) -> None:
         )
 
 
+async def _areject_cross_origin_redirect(response: httpx.Response) -> None:
+    """Async event-hook wrapper for :func:`_reject_cross_origin_redirect`.
+
+    ``httpx.AsyncClient`` *awaits* every response hook it invokes
+    (``await hook(response)`` in ``httpx._client``), while ``httpx.Client``
+    calls it plainly. Registering the sync function on the async client made
+    httpx await ``None`` and raised ``TypeError: object NoneType can't be
+    used in 'await' expression`` on **every** async response, not just
+    redirects. The check itself does no I/O, so the async hook simply
+    delegates (#252 FMP-SEC-004).
+    """
+    _reject_cross_origin_redirect(response)
+
+
 def _refuse_bytes_list_request(endpoint: Endpoint[T]) -> None:
     """``request_list`` is for row lists, not file downloads."""
     if endpoint.response_model is bytes:
@@ -281,7 +295,8 @@ class BaseClient:
                 timeout=self.config.timeout,
                 follow_redirects=True,
                 headers=_default_http_headers(),
-                event_hooks={"response": [_reject_cross_origin_redirect]},
+                # Must be the async wrapper: httpx awaits async-client hooks.
+                event_hooks={"response": [_areject_cross_origin_redirect]},
             )
         return self._async_client
 

--- a/fmp_data/lc/embedding.py
+++ b/fmp_data/lc/embedding.py
@@ -21,16 +21,44 @@ _SECRET_KWARG_TOKENS = (
 )
 
 
+def _is_secret_key(key: str) -> bool:
+    """True when a kwargs key name looks like it holds a credential."""
+    parts = key.lower().replace("-", "_").split("_")
+    return any(part in _SECRET_KWARG_TOKENS for part in parts)
+
+
+def _redact_value(value: Any, depth: int = 0) -> Any:
+    """Redact secret-shaped entries inside nested containers.
+
+    Recursion matters: providers take credential-bearing *nested* kwargs --
+    ``OpenAIEmbeddings`` accepts ``default_headers={"Authorization": ...}``
+    and ``model_kwargs={"api_key": ...}``, and both are splatted straight
+    into the provider below. A top-level-only scan copied those dicts by
+    reference, so ``repr`` printed the secret verbatim (#273).
+
+    ``depth`` bounds pathological nesting; deeper values are elided rather
+    than walked.
+    """
+    if depth >= 6:
+        return "..."
+    if isinstance(value, dict):
+        return {
+            key: ("***" if _is_secret_key(str(key)) else _redact_value(item, depth + 1))
+            for key, item in value.items()
+        }
+    if isinstance(value, list | tuple):
+        return type(value)(_redact_value(item, depth + 1) for item in value)
+    if isinstance(value, set):
+        return {_redact_value(item, depth + 1) for item in value}
+    return value
+
+
 def _redact_kwargs(data: dict[str, Any]) -> dict[str, Any]:
-    """Copy a kwargs map with secret-shaped values replaced."""
-    redacted: dict[str, Any] = {}
-    for key, value in data.items():
-        parts = key.lower().replace("-", "_").split("_")
-        if any(part in _SECRET_KWARG_TOKENS for part in parts):
-            redacted[key] = "***"
-        else:
-            redacted[key] = value
-    return redacted
+    """Copy a kwargs map with secret-shaped values replaced, recursively."""
+    return {
+        key: ("***" if _is_secret_key(key) else _redact_value(value))
+        for key, value in data.items()
+    }
 
 
 class EmbeddingProvider(str, Enum):

--- a/noxfile.py
+++ b/noxfile.py
@@ -270,8 +270,12 @@ def coverage_extras(session: Session) -> None:
     """Separate extras coverage gate for lc / mcp / Redis (#273).
 
     Core 80% still omits these trees. This session installs the extras,
-    measures only those files, and fails under 65% (baseline 66.78% on
-    2026-08-13). xdist is off so local and CI numbers stay comparable.
+    measures only those files, and fails under 80%. The baseline was 66.78%
+    when the gate landed; dedicated tests for ``redis_backend``,
+    ``lc.validation``, ``lc.__init__``, ``mcp.utils`` and ``mcp.setup``
+    raised it to 86.99%, which is the headroom that makes this safe to
+    require at the ruleset layer (#282). xdist is off so local and CI
+    numbers stay comparable.
     """
     _sync_with_uv(
         session,
@@ -286,7 +290,7 @@ def coverage_extras(session: Session) -> None:
         "--cov=fmp_data.cache.redis_backend",
         "--cov-config=extras.coveragerc",
         "--cov-report=term-missing",
-        "--cov-fail-under=65",
+        "--cov-fail-under=80",
     )
 
 
@@ -336,13 +340,22 @@ def typecheck(session: Session) -> None:
 
 @nox.session(python=DEFAULT_PYTHON, tags=["security"])
 def security(session: Session) -> None:
-    """Audit the published extra graph for known CVEs.
+    """Static-analyse the source and audit the extra graph for known CVEs.
 
-    Resolve extras from ``pyproject.toml`` at session time (no committed
-    hashed lock) and audit that pin set. A floor bump in pyproject is
-    enough to pick up newer deps (#252 FMP-SEC-008).
+    Two halves:
+
+    * ``bandit`` over the library. #278 replaced the global ``B404`` /
+      ``B603`` / ``B607`` / ``B608`` skips with narrow, documented
+      file-local ``# nosec`` notes, but bandit only ran from
+      ``.pre-commit-config.yaml`` — there is no pre-commit CI job, so the
+      narrowing was unenforced on CI and a new ``subprocess`` call could
+      land unreviewed (#273).
+    * ``pip-audit`` over the extras resolved from ``pyproject.toml`` at
+      session time (no committed hashed lock), so a floor bump is enough
+      to pick up newer deps (#252 FMP-SEC-008).
     """
-    session.install("uv", "pip-audit>=2.10.1")
+    session.install("uv", "pip-audit>=2.10.1", "bandit[toml]>=1.8.0")
+    session.run("bandit", "-c", "pyproject.toml", "-r", PACKAGE_NAME)
     export = Path(session.create_tmp()) / "requirements-audit.txt"
     session.run(
         "uv",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -331,6 +331,15 @@ module = [
 disallow_untyped_defs = false
 disallow_incomplete_defs = false
 ignore_missing_imports = true
+# Tests are type-checked in two different dependency environments: the
+# `typecheck` nox session installs core + dev only, while a local
+# `--all-extras` run resolves langchain/mcp/redis types. An ignore that is
+# required when a stub is passed to a fully-typed langchain signature is
+# therefore redundant when that package is absent (the signature degrades to
+# Any), and vice versa. Warning on unused ignores makes those two envs
+# mutually unsatisfiable, so it stays off for tests only; the library keeps
+# the strict global setting.
+warn_unused_ignores = false
 disable_error_code = [
     "import-untyped",
     "import-not-found",

--- a/tests/unit/lc/test_embedding.py
+++ b/tests/unit/lc/test_embedding.py
@@ -47,6 +47,50 @@ def test_embedding_config_repr_redacts_secret_kwargs():
     assert "hidden" not in author_repr
 
 
+def test_embedding_config_repr_redacts_nested_secret_kwargs():
+    """Nested kwargs must be walked, not copied by reference (#273).
+
+    ``OpenAIEmbeddings`` really takes ``default_headers`` and
+    ``model_kwargs``, and this config splats them straight into the
+    provider, so credentials legitimately live one level down. A
+    top-level-only scan printed them verbatim.
+    """
+    config = EmbeddingConfig(
+        additional_kwargs={
+            "default_headers": {"Authorization": "Bearer nested-bearer"},
+            "model_kwargs": {"api_key": "nested-apikey"},  # pragma: allowlist secret
+            "deeply": {"a": {"b": {"token": "nested-deep"}}},
+            "in_a_list": [{"password": "nested-in-list"}],  # pragma: allowlist secret
+            "harmless": {"temperature": 0.2},
+        },
+    )
+    text = repr(config)
+
+    for secret in (
+        "nested-bearer",
+        "nested-apikey",
+        "nested-deep",
+        "nested-in-list",
+    ):
+        assert secret not in text, f"{secret} leaked into repr: {text}"
+
+    # Non-secret nested data must survive so the repr stays useful.
+    assert "temperature" in text
+    assert "0.2" in text
+
+
+def test_embedding_config_repr_does_not_mutate_the_original_kwargs():
+    """Redaction returns a copy; the live kwargs still reach the provider."""
+    kwargs = {"default_headers": {"Authorization": "Bearer keep-me"}}
+    config = EmbeddingConfig(additional_kwargs=kwargs)
+
+    repr(config)
+
+    assert config.additional_kwargs["default_headers"]["Authorization"] == (
+        "Bearer keep-me"
+    )
+
+
 def test_embedding_config_validation():
     """Test embedding configuration validation"""
     # Test valid OpenAI config

--- a/tests/unit/lc/test_package_init.py
+++ b/tests/unit/lc/test_package_init.py
@@ -1,0 +1,915 @@
+"""Behaviour of the ``fmp_data.lc`` package module itself.
+
+``fmp_data/lc/__init__.py`` defers every heavy LangChain import to
+``__getattr__`` so that domain mapping modules (and MCP discovery) can import
+``fmp_data.lc.models`` without the ``langchain`` extra. That laziness, the
+registry/vector-store convenience helpers next to it, and their failure paths
+are what this module pins.
+
+Not covered here (already pinned elsewhere, do not duplicate):
+
+* ``tests/unit/lc/test_imports.py`` -- ``langchain_core`` import paths used by
+  ``fmp_data.lc.vector_store``.
+* ``tests/unit/test_vector_store_error_contract.py`` -- the
+  ``VectorStoreCreationError`` contract and ``setup_registry`` against the real
+  endpoint catalog.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from typing import Any, cast
+
+import pytest
+
+from fmp_data.lc import registry as lc_registry
+from fmp_data.lc.models import (
+    EndpointSemantics,
+    ResponseFieldInfo,
+    SemanticCategory,
+)
+from fmp_data.models import APIVersion, Endpoint, HTTPMethod, URLType
+
+# Dummy credentials used throughout this module. Defined once so the
+# literals live on a single annotated line each.
+DUMMY_FMP_KEY = "fmp-key"  # pragma: allowlist secret
+DUMMY_OPENAI_KEY = "openai-key"  # pragma: allowlist secret
+DUMMY_ENV_FMP_KEY = "env-fmp"  # pragma: allowlist secret
+DUMMY_ENV_OPENAI_KEY = "env-openai"  # pragma: allowlist secret
+DUMMY_ARG_FMP_KEY = "arg-fmp"  # pragma: allowlist secret
+DUMMY_ARG_OPENAI_KEY = "arg-openai"  # pragma: allowlist secret
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _endpoint(name: str) -> Endpoint[Any]:
+    """A minimal, parameter-free endpoint definition."""
+    return Endpoint(
+        name=name,
+        path=f"{name}/path",
+        version=APIVersion.STABLE,
+        url_type=URLType.API,
+        method=HTTPMethod.GET,
+        description=f"Endpoint {name}",
+        mandatory_params=[],
+        optional_params=None,
+        response_model=dict,
+        arg_model=None,
+    )
+
+
+def _semantics(method_name: str) -> EndpointSemantics:
+    """Semantics with no parameter hints, matching ``_endpoint``."""
+    return EndpointSemantics(
+        client_name="fake",
+        method_name=method_name,
+        natural_description="A fabricated endpoint used by the unit tests.",
+        example_queries=["show me the fake data"],
+        related_terms=["fake"],
+        category=SemanticCategory.MARKET_DATA,
+        parameter_hints={},
+        response_hints={
+            "value": ResponseFieldInfo(
+                description="A value",
+                examples=["1"],
+                related_terms=["value"],
+            )
+        },
+        use_cases=["testing"],
+    )
+
+
+def _group(
+    endpoint_map: dict[str, Endpoint[Any]],
+    semantics_map: dict[str, EndpointSemantics],
+) -> dict[str, Any]:
+    """A ``GroupConfig``-shaped dict.
+
+    ``category`` and ``client`` are read by ``EndpointRegistry`` when it builds
+    its validation rules from the same group table, so they are not optional.
+    """
+    return {
+        "endpoint_map": endpoint_map,
+        "semantics_map": semantics_map,
+        "category": SemanticCategory.MARKET_DATA,
+        "client": "fake",
+    }
+
+
+class _StubRegistry:
+    """Stand-in for ``EndpointRegistry``; only ``list_endpoints`` is consumed."""
+
+    def __init__(self, names: list[str]) -> None:
+        self._names = names
+
+    def list_endpoints(self) -> dict[str, object]:
+        return {name: object() for name in self._names}
+
+
+def _store_class(
+    *,
+    validates: bool = True,
+    indexed: int = 0,
+    ctor_error: Exception | None = None,
+) -> tuple[type, list[Any]]:
+    """Build a fresh ``EndpointVectorStore`` stand-in plus its instance log.
+
+    A new class per call keeps the recorded instances out of module state, so
+    the tests stay order-independent.
+    """
+    created: list[Any] = []
+
+    class FakeVectorStore:
+        def __init__(self, **kwargs: Any) -> None:
+            if ctor_error is not None:
+                raise ctor_error
+            self.kwargs = kwargs
+            self.added: list[list[str]] = []
+            self.saves = 0
+            created.append(self)
+
+        def validate(self) -> bool:
+            return validates
+
+        def add_endpoints(self, names: list[str]) -> int:
+            self.added.append(list(names))
+            return indexed
+
+        def save(self) -> None:
+            self.saves += 1
+
+    return FakeVectorStore, created
+
+
+class _RecordingEmbeddingConfig:
+    """Stand-in for ``EmbeddingConfig`` that records how it was built."""
+
+    calls: list[dict[str, Any]]
+
+    def __init__(self, **kwargs: Any) -> None:
+        type(self).calls.append(kwargs)
+        self.kwargs = kwargs
+
+    def get_embeddings(self) -> str:
+        return "sentinel-embeddings"
+
+
+class _RecordingClient:
+    """Stand-in for ``FMPDataClient`` that keeps the key it was built with.
+
+    Two reasons not to build the real thing here:
+
+    * ``FMPDataClient.__init__`` calls ``FMPLogger().configure(...)``, which
+      installs a handler on the process-wide ``fmp_data`` logger and pins its
+      level -- global state these tests would leak to whatever runs next.
+    * The real client owns an ``httpx`` client that nothing closes, so the
+      instances only go away when ``__del__`` happens to run.
+
+    ``setup_registry`` never touches the client; ``create_vector_store`` only
+    forwards it to the store, which is exactly what the assertions check.
+    """
+
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
+
+
+@pytest.fixture
+def embedding_config(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Replace ``EmbeddingConfig`` and hand back the recorded kwargs list."""
+    calls: list[dict[str, Any]] = []
+    cls = type("RecordingEmbeddingConfig", (_RecordingEmbeddingConfig,), {})
+    cls.calls = calls  # type: ignore[attr-defined]
+    monkeypatch.setattr("fmp_data.lc.embedding.EmbeddingConfig", cls)
+    return calls
+
+
+@pytest.fixture
+def recording_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Swap the client ``create_vector_store`` builds for a recording stub."""
+    monkeypatch.setattr("fmp_data.client.FMPDataClient", _RecordingClient)
+
+
+@pytest.fixture
+def empty_catalog(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make ``setup_registry`` build an empty registry without the real catalog."""
+    monkeypatch.setattr(lc_registry, "get_endpoint_groups", dict)
+
+
+# ---------------------------------------------------------------------------
+# lazy attribute access
+# ---------------------------------------------------------------------------
+
+
+def test_lazy_getattr_returns_the_real_embedding_provider() -> None:
+    import fmp_data.lc as lc
+    from fmp_data.lc.embedding import EmbeddingProvider
+
+    assert lc.EmbeddingProvider is EmbeddingProvider
+    assert lc.EmbeddingProvider.OPENAI.value == "openai"
+
+
+def test_lazy_getattr_returns_the_real_vector_store_class() -> None:
+    import fmp_data.lc as lc
+    from fmp_data.lc.vector_store import EndpointVectorStore
+
+    assert lc.EndpointVectorStore is EndpointVectorStore
+
+
+def test_lazy_getattr_returns_the_real_langchain_config() -> None:
+    from fmp_data.config import ClientConfig
+    import fmp_data.lc as lc
+    from fmp_data.lc.config import LangChainConfig
+
+    assert lc.LangChainConfig is LangChainConfig
+    assert issubclass(lc.LangChainConfig, ClientConfig)
+
+
+def test_endpoint_stays_reachable_although_it_is_not_exported() -> None:
+    """Pre-lazy-import code did ``from fmp_data.lc import Endpoint``."""
+    import fmp_data.lc as lc
+    from fmp_data.models import Endpoint as CoreEndpoint
+
+    assert lc.Endpoint is CoreEndpoint
+    assert "Endpoint" not in lc.__all__
+
+
+def test_embeddings_stays_reachable_although_it_is_not_exported() -> None:
+    """Same backwards-compatibility promise for ``Embeddings``."""
+    from langchain_core.embeddings import Embeddings
+
+    import fmp_data.lc as lc
+
+    assert lc.Embeddings is Embeddings
+    assert "Embeddings" not in lc.__all__
+
+
+def test_unknown_attribute_error_names_module_and_attribute() -> None:
+    import fmp_data.lc as lc
+
+    with pytest.raises(AttributeError) as excinfo:
+        lc.no_such_symbol  # noqa: B018
+
+    message = str(excinfo.value)
+    assert "fmp_data.lc" in message
+    assert "no_such_symbol" in message
+
+
+def test_unknown_attribute_error_survives_getattr_default() -> None:
+    """``getattr(mod, name, default)`` must fall back, not blow up."""
+    import fmp_data.lc as lc
+
+    assert getattr(lc, "no_such_symbol", "fallback") == "fallback"
+
+
+def test_every_exported_name_resolves() -> None:
+    import fmp_data.lc as lc
+
+    unresolved = [name for name in lc.__all__ if not hasattr(lc, name)]
+    assert unresolved == []
+
+
+def test_all_has_no_duplicates_and_stays_sorted() -> None:
+    import fmp_data.lc as lc
+
+    assert len(lc.__all__) == len(set(lc.__all__))
+    assert lc.__all__ == sorted(lc.__all__)
+
+
+def test_dir_advertises_the_lazy_names() -> None:
+    """Completion has to see names that ``globals()`` does not hold yet."""
+    import fmp_data.lc as lc
+
+    listed = dir(lc)
+    assert listed == sorted(listed)
+    assert set(lc.__all__) <= set(listed)
+    assert {"Endpoint", "Embeddings"} <= set(listed)
+
+
+def test_lazy_import_failure_is_not_swallowed_as_an_attribute_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing extra must surface as an ImportError naming the module.
+
+    ``None`` in ``sys.modules`` reproduces a missing ``langchain_core`` without
+    unloading the real one, so the test is order-independent.
+
+    Reported separately, and deliberately *not* asserted here: unlike
+    ``init_langchain``, ``__getattr__`` adds no ``pip install
+    'fmp-data[langchain]'`` hint. Pinning that absence would make the test fail
+    the day someone adds one.
+    """
+    import fmp_data.lc as lc
+
+    monkeypatch.setitem(sys.modules, "langchain_core.embeddings", None)
+
+    with pytest.raises(ImportError) as excinfo:
+        lc.Embeddings  # noqa: B018
+
+    # ``pytest.raises(ImportError)`` is the load-bearing half: a ``__getattr__``
+    # that mapped the missing extra onto ``AttributeError`` -- the usual way
+    # this goes wrong -- would fail here rather than silently look absent.
+    assert "langchain_core.embeddings" in str(excinfo.value)
+
+
+def test_lazy_config_import_failure_propagates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The same for a first-party lazy target, so the module is not swallowing."""
+    import fmp_data.lc as lc
+
+    monkeypatch.setitem(sys.modules, "fmp_data.lc.config", None)
+
+    with pytest.raises(ImportError) as excinfo:
+        lc.LangChainConfig  # noqa: B018
+
+    assert "fmp_data.lc.config" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# init_langchain
+# ---------------------------------------------------------------------------
+
+
+def test_init_langchain_true_when_dependencies_present(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    import fmp_data.lc as lc
+
+    monkeypatch.setattr(lc, "is_langchain_available", lambda: True)
+
+    with caplog.at_level(logging.WARNING, logger="fmp_data.lc"):
+        assert lc.init_langchain() is True
+
+    assert caplog.records == [], (
+        f"unexpected log output: {[r.getMessage() for r in caplog.records]}"
+    )
+
+
+def test_init_langchain_warns_with_the_install_hint_when_missing(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The only place the module tells a user how to fix a missing extra."""
+    import fmp_data.lc as lc
+
+    monkeypatch.setattr(lc, "is_langchain_available", lambda: False)
+
+    with caplog.at_level(logging.WARNING, logger="fmp_data.lc"):
+        assert lc.init_langchain() is False
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert len(messages) == 1, f"expected one warning, got {messages}"
+    assert "pip install 'fmp-data[langchain]'" in messages[0]
+
+
+# ---------------------------------------------------------------------------
+# validate_api_keys
+# ---------------------------------------------------------------------------
+
+
+def test_validate_api_keys_prefers_arguments_over_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from fmp_data.lc import validate_api_keys
+
+    monkeypatch.setenv("FMP_API_KEY", DUMMY_ENV_FMP_KEY)
+    monkeypatch.setenv("OPENAI_API_KEY", DUMMY_ENV_OPENAI_KEY)
+
+    assert validate_api_keys(DUMMY_ARG_FMP_KEY, DUMMY_ARG_OPENAI_KEY) == (
+        DUMMY_ARG_FMP_KEY,
+        DUMMY_ARG_OPENAI_KEY,
+    )
+
+
+def test_validate_api_keys_falls_back_to_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from fmp_data.lc import validate_api_keys
+
+    monkeypatch.setenv("FMP_API_KEY", DUMMY_ENV_FMP_KEY)
+    monkeypatch.setenv("OPENAI_API_KEY", DUMMY_ENV_OPENAI_KEY)
+
+    assert validate_api_keys() == (DUMMY_ENV_FMP_KEY, DUMMY_ENV_OPENAI_KEY)
+
+
+def test_validate_api_keys_rejects_a_missing_fmp_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from fmp_data.lc import validate_api_keys
+
+    monkeypatch.delenv("FMP_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", DUMMY_ENV_OPENAI_KEY)
+
+    with pytest.raises(ValueError, match="FMP API key required"):
+        validate_api_keys()
+
+
+def test_validate_api_keys_rejects_a_missing_openai_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The second guard: an FMP key alone is not enough for embeddings."""
+    from fmp_data.lc import validate_api_keys
+
+    monkeypatch.setenv("FMP_API_KEY", DUMMY_ENV_FMP_KEY)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="OpenAI API key required"):
+        validate_api_keys(fmp_api_key=DUMMY_ARG_FMP_KEY)
+
+
+def test_validate_api_keys_treats_empty_strings_as_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``""`` is falsy, so it must not slip through as a usable key."""
+    from fmp_data.lc import validate_api_keys
+
+    monkeypatch.delenv("FMP_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="FMP API key required"):
+        validate_api_keys(fmp_api_key="", openai_api_key="k")
+
+
+# ---------------------------------------------------------------------------
+# setup_registry
+# ---------------------------------------------------------------------------
+
+
+def test_setup_registry_skips_endpoints_without_semantics(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    from fmp_data.lc import setup_registry
+
+    groups = {"fake": _group({"get_orphan": _endpoint("get_orphan")}, {})}
+    monkeypatch.setattr(lc_registry, "get_endpoint_groups", lambda: groups)
+
+    with caplog.at_level(logging.WARNING, logger="fmp_data.lc"):
+        result = setup_registry(client=None)  # type: ignore[arg-type]
+
+    assert result.registry.list_endpoints() == {}
+    assert result.failures == {}
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("No semantics found for endpoint: get_orphan" in m for m in messages), (
+        f"missing warning in {messages}"
+    )
+
+
+def test_setup_registry_skips_the_batch_for_a_group_with_no_endpoints(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An empty group must not reach ``register_batch`` at all.
+
+    ``register_batch({})`` returns ``{}`` and logs nothing, so the registry and
+    the failure dict look identical either way; the ``Registered 0/0 endpoints
+    from ...`` debug line is the only thing that tells the guard apart from its
+    absence, which is why this asserts on the log rather than the return value
+    alone.
+    """
+    from fmp_data.lc import setup_registry
+
+    group_name = "solo_empty_group"
+    groups = {group_name: _group({}, {})}
+    monkeypatch.setattr(lc_registry, "get_endpoint_groups", lambda: groups)
+
+    with caplog.at_level(logging.DEBUG, logger="fmp_data.lc"):
+        registry, failures = setup_registry(client=None)  # type: ignore[arg-type]
+
+    assert registry.list_endpoints() == {}
+    assert failures == {}
+    messages = [record.getMessage() for record in caplog.records]
+    assert not any(group_name in message for message in messages), (
+        f"the empty group was still batched: {messages}"
+    )
+
+
+def test_setup_registry_reports_invalid_endpoints_as_failures(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A drifted endpoint is skipped individually and named in ``failures``."""
+    from fmp_data.lc import setup_registry
+
+    groups = {
+        "fake": _group(
+            {"get_drifted": _endpoint("get_drifted")},
+            # Semantics claim a different method name -> validation rejects it.
+            {"get_drifted": _semantics("get_something_else")},
+        )
+    }
+    monkeypatch.setattr(lc_registry, "get_endpoint_groups", lambda: groups)
+
+    with caplog.at_level(logging.WARNING, logger="fmp_data.lc"):
+        registry, failures = setup_registry(client=None)  # type: ignore[arg-type]
+
+    assert registry.list_endpoints() == {}
+    assert list(failures) == ["get_drifted"]
+    assert "Method name mismatch" in failures["get_drifted"]
+    assert any(
+        "Skipped 1 invalid fake endpoints: get_drifted" in record.getMessage()
+        for record in caplog.records
+    ), f"missing summary warning in {[r.getMessage() for r in caplog.records]}"
+
+
+def test_setup_registry_merges_failures_across_groups(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Failures from every group land in one dict, not just the last one's."""
+    from fmp_data.lc import setup_registry
+
+    groups = {
+        "first": _group(
+            {"get_one": _endpoint("get_one")},
+            {"get_one": _semantics("mismatch_one")},
+        ),
+        "second": _group(
+            {"get_two": _endpoint("get_two")},
+            {"get_two": _semantics("mismatch_two")},
+        ),
+    }
+    monkeypatch.setattr(lc_registry, "get_endpoint_groups", lambda: groups)
+
+    _registry, failures = setup_registry(client=None)  # type: ignore[arg-type]
+
+    assert sorted(failures) == ["get_one", "get_two"]
+
+
+def test_setup_registry_resolves_semantics_through_the_get_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``get_x`` finds the ``x`` semantics entry and actually registers."""
+    from fmp_data.lc import setup_registry
+
+    groups = {
+        "fake": _group(
+            {"get_quote": _endpoint("get_quote")},
+            {"quote": _semantics("get_quote")},
+        )
+    }
+    monkeypatch.setattr(lc_registry, "get_endpoint_groups", lambda: groups)
+
+    registry, failures = setup_registry(client=None)  # type: ignore[arg-type]
+
+    assert failures == {}
+    assert list(registry.list_endpoints()) == ["get_quote"]
+
+
+# ---------------------------------------------------------------------------
+# try_load_existing_store
+# ---------------------------------------------------------------------------
+
+
+def test_try_load_existing_store_returns_a_validated_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from fmp_data.lc import try_load_existing_store
+
+    store_cls, created = _store_class(validates=True)
+    monkeypatch.setattr("fmp_data.lc.vector_store.EndpointVectorStore", store_cls)
+
+    registry = _StubRegistry([])
+    store = try_load_existing_store(
+        client="client",  # type: ignore[arg-type]
+        registry=registry,  # type: ignore[arg-type]
+        embeddings="embeddings",  # type: ignore[arg-type]
+        cache_dir="/some/cache",
+        store_name="custom_store",
+    )
+
+    assert store is created[0]
+    assert store.kwargs == {
+        "client": "client",
+        "registry": registry,
+        "embeddings": "embeddings",
+        "cache_dir": "/some/cache",
+        "store_name": "custom_store",
+    }
+
+
+def test_try_load_existing_store_returns_none_when_validation_fails(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    from fmp_data.lc import try_load_existing_store
+
+    store_cls, _created = _store_class(validates=False)
+    monkeypatch.setattr("fmp_data.lc.vector_store.EndpointVectorStore", store_cls)
+
+    with caplog.at_level(logging.WARNING, logger="fmp_data.lc"):
+        store = try_load_existing_store(
+            client="client",  # type: ignore[arg-type]
+            registry=_StubRegistry([]),  # type: ignore[arg-type]
+            embeddings="embeddings",  # type: ignore[arg-type]
+            cache_dir=None,
+            store_name="fmp_endpoints",
+        )
+
+    assert store is None
+    assert any(
+        "Existing vector store validation failed" in record.getMessage()
+        for record in caplog.records
+    ), f"missing warning in {[r.getMessage() for r in caplog.records]}"
+
+
+def test_try_load_existing_store_swallows_construction_errors(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A corrupt cache must degrade to "rebuild", not crash the caller."""
+    from fmp_data.lc import try_load_existing_store
+
+    store_cls, _created = _store_class(ctor_error=OSError("index file is corrupt"))
+    monkeypatch.setattr("fmp_data.lc.vector_store.EndpointVectorStore", store_cls)
+
+    with caplog.at_level(logging.WARNING, logger="fmp_data.lc"):
+        store = try_load_existing_store(
+            client="client",  # type: ignore[arg-type]
+            registry=_StubRegistry([]),  # type: ignore[arg-type]
+            embeddings="embeddings",  # type: ignore[arg-type]
+            cache_dir=None,
+            store_name="fmp_endpoints",
+        )
+
+    assert store is None
+    assert any(
+        "index file is corrupt" in record.getMessage() for record in caplog.records
+    ), f"error text lost from {[r.getMessage() for r in caplog.records]}"
+
+
+# ---------------------------------------------------------------------------
+# create_new_store
+# ---------------------------------------------------------------------------
+
+
+def test_create_new_store_indexes_every_registered_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from fmp_data.lc import create_new_store
+
+    store_cls, created = _store_class(indexed=3)
+    monkeypatch.setattr("fmp_data.lc.vector_store.EndpointVectorStore", store_cls)
+
+    registry = _StubRegistry(["a", "b", "c"])
+    store = create_new_store(
+        client="client",  # type: ignore[arg-type]
+        registry=registry,  # type: ignore[arg-type]
+        embeddings="embeddings",  # type: ignore[arg-type]
+        cache_dir="/some/cache",
+        store_name="fresh_store",
+    )
+
+    assert store is created[0]
+    assert store.added == [["a", "b", "c"]]
+    assert store.saves == 1
+    # The destination matters as much as the contents: a rebuild that quietly
+    # fell back to the default name/dir would still index all three.
+    assert store.kwargs == {
+        "client": "client",
+        "registry": registry,
+        "embeddings": "embeddings",
+        "cache_dir": "/some/cache",
+        "store_name": "fresh_store",
+    }
+
+
+def test_create_new_store_logs_the_indexed_count_not_the_offered_count(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """#137: deprecated endpoints are dropped on the way in, so the two differ."""
+    from fmp_data.lc import create_new_store
+
+    store_cls, _created = _store_class(indexed=2)
+    monkeypatch.setattr("fmp_data.lc.vector_store.EndpointVectorStore", store_cls)
+
+    with caplog.at_level(logging.INFO, logger="fmp_data.lc"):
+        create_new_store(
+            client="client",  # type: ignore[arg-type]
+            registry=_StubRegistry(["a", "b", "dead"]),  # type: ignore[arg-type]
+            embeddings="embeddings",  # type: ignore[arg-type]
+            cache_dir=None,
+            store_name="fmp_endpoints",
+        )
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("Created new vector store with 2 endpoints" in m for m in messages), (
+        f"expected the indexed count in {messages}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# create_vector_store orchestration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("empty_catalog", "recording_client")
+def test_create_vector_store_reuses_a_valid_existing_store(
+    monkeypatch: pytest.MonkeyPatch, embedding_config: list[dict[str, Any]]
+) -> None:
+    from fmp_data.lc import create_vector_store
+
+    store_cls, created = _store_class(validates=True)
+    monkeypatch.setattr("fmp_data.lc.vector_store.EndpointVectorStore", store_cls)
+
+    store = create_vector_store(
+        fmp_api_key=DUMMY_FMP_KEY,
+        openai_api_key=DUMMY_OPENAI_KEY,
+        cache_dir="/cache",
+        store_name="reused",
+    )
+
+    assert store is created[0]
+    assert len(created) == 1, "a second store was built despite a valid cache"
+    assert store.saves == 0
+    assert store.added == []
+    assert store.kwargs["store_name"] == "reused"
+    assert store.kwargs["cache_dir"] == "/cache"
+    assert store.kwargs["embeddings"] == "sentinel-embeddings"
+    # The FMP key is the client's, not the embeddings': nothing else pins which
+    # of the two keys reaches which collaborator.
+    assert store.kwargs["client"].api_key == DUMMY_FMP_KEY  # pragma: allowlist secret
+
+
+@pytest.mark.usefixtures("empty_catalog", "recording_client")
+def test_create_vector_store_rebuilds_when_the_cache_does_not_validate(
+    monkeypatch: pytest.MonkeyPatch, embedding_config: list[dict[str, Any]]
+) -> None:
+    from fmp_data.lc import create_vector_store
+
+    store_cls, created = _store_class(validates=False, indexed=0)
+    monkeypatch.setattr("fmp_data.lc.vector_store.EndpointVectorStore", store_cls)
+
+    store = create_vector_store(
+        fmp_api_key=DUMMY_FMP_KEY,
+        openai_api_key=DUMMY_OPENAI_KEY,
+        cache_dir="/cache",
+        store_name="rebuilt",
+    )
+
+    assert len(created) == 2, "expected a load attempt followed by a rebuild"
+    assert store is created[1]
+    assert store.saves == 1
+    assert store.added == [[]]
+    # The rebuild has to land where the failed load looked, or the next run
+    # rediscovers the same unusable cache.
+    assert store.kwargs == created[0].kwargs
+
+
+@pytest.mark.usefixtures("empty_catalog", "recording_client")
+def test_create_vector_store_force_create_skips_the_load_attempt(
+    monkeypatch: pytest.MonkeyPatch, embedding_config: list[dict[str, Any]]
+) -> None:
+    """``force_create`` must rebuild even when the cache would have validated."""
+    from fmp_data.lc import create_vector_store
+
+    store_cls, created = _store_class(validates=True)
+    monkeypatch.setattr("fmp_data.lc.vector_store.EndpointVectorStore", store_cls)
+
+    store = create_vector_store(
+        fmp_api_key=DUMMY_FMP_KEY,
+        openai_api_key=DUMMY_OPENAI_KEY,
+        force_create=True,
+    )
+
+    assert len(created) == 1, "the existing store was loaded despite force_create"
+    assert store is created[0]
+    assert store.saves == 1
+
+
+@pytest.mark.usefixtures("empty_catalog", "recording_client")
+def test_create_vector_store_defaults_to_the_openai_embedding_provider(
+    monkeypatch: pytest.MonkeyPatch, embedding_config: list[dict[str, Any]]
+) -> None:
+    from fmp_data.lc import create_vector_store
+    from fmp_data.lc.embedding import EmbeddingProvider
+
+    store_cls, _created = _store_class(validates=True)
+    monkeypatch.setattr("fmp_data.lc.vector_store.EndpointVectorStore", store_cls)
+
+    create_vector_store(
+        fmp_api_key=DUMMY_FMP_KEY,
+        openai_api_key=DUMMY_OPENAI_KEY,
+    )
+
+    assert len(embedding_config) == 1
+    assert embedding_config[0]["provider"] is EmbeddingProvider.OPENAI
+    assert embedding_config[0]["model_name"] is None
+    assert (
+        embedding_config[0]["api_key"] == DUMMY_OPENAI_KEY
+    )  # pragma: allowlist secret
+
+
+@pytest.mark.usefixtures("empty_catalog", "recording_client")
+def test_create_vector_store_passes_an_explicit_provider_and_model_through(
+    monkeypatch: pytest.MonkeyPatch, embedding_config: list[dict[str, Any]]
+) -> None:
+    from fmp_data.lc import create_vector_store
+    from fmp_data.lc.embedding import EmbeddingProvider
+
+    store_cls, _created = _store_class(validates=True)
+    monkeypatch.setattr("fmp_data.lc.vector_store.EndpointVectorStore", store_cls)
+
+    create_vector_store(
+        fmp_api_key=DUMMY_FMP_KEY,
+        openai_api_key=DUMMY_OPENAI_KEY,
+        embedding_provider=EmbeddingProvider.HUGGINGFACE,
+        embedding_model="sentence-transformers/all-mpnet-base-v2",
+    )
+
+    assert embedding_config[0]["provider"] is EmbeddingProvider.HUGGINGFACE
+    assert (
+        embedding_config[0]["model_name"] == "sentence-transformers/all-mpnet-base-v2"
+    )
+
+
+@pytest.mark.usefixtures("recording_client")
+def test_create_vector_store_demands_an_openai_key_for_any_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pins CURRENT behaviour, which looks wrong -- see the reported finding.
+
+    ``EmbeddingConfig(provider=HUGGINGFACE)`` needs no API key at all
+    (``tests/unit/lc/test_embedding.py``), yet ``create_vector_store`` runs
+    ``validate_api_keys`` unconditionally, so a HuggingFace store cannot be
+    built without an unrelated ``OPENAI_API_KEY``.
+    """
+    from fmp_data.exceptions import VectorStoreCreationError
+    from fmp_data.lc import create_vector_store
+    from fmp_data.lc.embedding import EmbeddingProvider
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with pytest.raises(VectorStoreCreationError) as excinfo:
+        create_vector_store(
+            fmp_api_key=DUMMY_FMP_KEY,
+            embedding_provider=EmbeddingProvider.HUGGINGFACE,
+        )
+
+    cause = excinfo.value.cause
+    assert isinstance(cause, ValueError)
+    assert "OpenAI API key required" in str(cause)
+
+
+@pytest.mark.usefixtures("empty_catalog", "recording_client")
+def test_create_vector_store_reads_keys_from_the_environment(
+    monkeypatch: pytest.MonkeyPatch, embedding_config: list[dict[str, Any]]
+) -> None:
+    from fmp_data.lc import create_vector_store
+
+    store_cls, _created = _store_class(validates=True)
+    monkeypatch.setattr("fmp_data.lc.vector_store.EndpointVectorStore", store_cls)
+    monkeypatch.setenv("FMP_API_KEY", DUMMY_ENV_FMP_KEY)
+    monkeypatch.setenv("OPENAI_API_KEY", DUMMY_ENV_OPENAI_KEY)
+
+    store = create_vector_store()
+
+    assert (
+        embedding_config[0]["api_key"] == DUMMY_ENV_OPENAI_KEY
+    )  # pragma: allowlist secret
+    # `store` is the stub from `_store_class`, not a real EndpointVectorStore,
+    # so its recorded ctor kwargs are reached through cast(Any, ...).
+    forwarded_client = cast(Any, store).kwargs["client"]
+    assert forwarded_client.api_key == DUMMY_ENV_FMP_KEY
+
+
+@pytest.mark.usefixtures("empty_catalog", "recording_client")
+def test_create_vector_store_wraps_a_rebuild_failure(
+    monkeypatch: pytest.MonkeyPatch, embedding_config: list[dict[str, Any]]
+) -> None:
+    """A failure after registration still arrives as ``VectorStoreCreationError``."""
+    from fmp_data.exceptions import VectorStoreCreationError
+    from fmp_data.lc import create_vector_store
+
+    boom = RuntimeError("disk full")
+    store_cls, _created = _store_class(ctor_error=boom)
+    monkeypatch.setattr("fmp_data.lc.vector_store.EndpointVectorStore", store_cls)
+
+    with pytest.raises(VectorStoreCreationError) as excinfo:
+        create_vector_store(fmp_api_key=DUMMY_FMP_KEY, openai_api_key=DUMMY_OPENAI_KEY)
+
+    assert excinfo.value.cause is boom
+    assert excinfo.value.failures == {}
+    assert "disk full" in str(excinfo.value)
+
+
+@pytest.mark.usefixtures("recording_client")
+def test_create_vector_store_carries_real_registry_failures(
+    monkeypatch: pytest.MonkeyPatch, embedding_config: list[dict[str, Any]]
+) -> None:
+    """End to end: a genuinely rejected endpoint reaches the caller by name."""
+    from fmp_data.exceptions import VectorStoreCreationError
+    from fmp_data.lc import create_vector_store
+
+    groups = {
+        "fake": _group(
+            {"get_drifted": _endpoint("get_drifted")},
+            {"get_drifted": _semantics("get_something_else")},
+        )
+    }
+    monkeypatch.setattr(lc_registry, "get_endpoint_groups", lambda: groups)
+
+    store_cls, _created = _store_class(ctor_error=RuntimeError("disk full"))
+    monkeypatch.setattr("fmp_data.lc.vector_store.EndpointVectorStore", store_cls)
+
+    with pytest.raises(VectorStoreCreationError) as excinfo:
+        create_vector_store(fmp_api_key=DUMMY_FMP_KEY, openai_api_key=DUMMY_OPENAI_KEY)
+
+    assert list(excinfo.value.failures) == ["get_drifted"]
+    assert "get_drifted" in str(excinfo.value)

--- a/tests/unit/lc/test_validation.py
+++ b/tests/unit/lc/test_validation.py
@@ -1,0 +1,631 @@
+# tests/unit/lc/test_validation.py
+"""Behavioural tests for ``fmp_data.lc.validation``.
+
+``fmp_data.lc.registry`` ships its own, unrelated ``ValidationRuleRegistry``
+(covered by ``test_validation_registry.py``). Everything here exercises the
+standalone rule framework in ``fmp_data/lc/validation.py``: the
+``CommonValidationRule`` template methods and the registry that dispatches to
+them.
+
+Note for future readers: nothing inside ``fmp_data`` imports this module — it
+is importable public API that only third-party subclasses reach. The tests
+below therefore pin the *published* contract, not any internal call path.
+"""
+
+from datetime import date
+import logging
+import re
+from typing import ClassVar
+
+import pytest
+
+from fmp_data.lc.models import SemanticCategory
+from fmp_data.lc.validation import (
+    CommonValidationRule,
+    ValidationRule,
+    ValidationRuleRegistry,
+)
+
+# Mirrors the ClassVar declared on CommonValidationRule.
+PatternMap = dict[str, list[str] | dict[str, list[str] | str | int]]
+
+ISO_DATE = r"^\d{4}-\d{2}-\d{2}$"
+US_DATE = r"^\d{2}/\d{2}/\d{4}$"
+
+
+class MarketRule(CommonValidationRule):
+    """Market rule with flat (list-shaped) date patterns."""
+
+    PARAMETER_PATTERNS: ClassVar[PatternMap] = {"date": [ISO_DATE]}
+
+    ENDPOINTS: ClassVar[dict[str, tuple[str, str]]] = {
+        "get_quote": ("quote", "read"),
+        "historical": ("price", "read"),
+    }
+
+    @property
+    def expected_category(self) -> SemanticCategory:
+        return SemanticCategory.MARKET_DATA
+
+    @property
+    def endpoint_prefixes(self) -> set[str]:
+        return {"get_quote", "historical"}
+
+    @classmethod
+    def get_endpoint_info(cls, method_name: str) -> tuple[str, str] | None:
+        return cls.ENDPOINTS.get(method_name)
+
+
+class NestedCommonRule(MarketRule):
+    """Date patterns nested under the ``common`` key."""
+
+    PARAMETER_PATTERNS: ClassVar[PatternMap] = {"date": {"common": [ISO_DATE]}}
+
+
+class NestedWithoutCommonRule(MarketRule):
+    """Nested date patterns that never declare a ``common`` bucket."""
+
+    PARAMETER_PATTERNS: ClassVar[PatternMap] = {"date": {"quarterly": [ISO_DATE]}}
+
+
+class NestedBadCommonRule(MarketRule):
+    """``common`` holds a bare pattern instead of a list of patterns."""
+
+    PARAMETER_PATTERNS: ClassVar[PatternMap] = {"date": {"common": ISO_DATE}}
+
+
+class NoPatternsRule(MarketRule):
+    """Endpoint table but no parameter patterns at all."""
+
+    PARAMETER_PATTERNS: ClassVar[PatternMap] = {}
+
+
+class UnanchoredDateRule(MarketRule):
+    """Date pattern without a trailing anchor."""
+
+    PARAMETER_PATTERNS: ClassVar[PatternMap] = {"date": [r"\d{4}-\d{2}-\d{2}"]}
+
+
+class MultiFormatDateRule(MarketRule):
+    """Two alternative date formats; a value need only satisfy one."""
+
+    PARAMETER_PATTERNS: ClassVar[PatternMap] = {"date": [ISO_DATE, US_DATE]}
+
+
+class UncompilableDateRule(MarketRule):
+    """A pattern that ``re`` cannot compile at all."""
+
+    PARAMETER_PATTERNS: ClassVar[PatternMap] = {"date": ["(unclosed"]}
+
+
+class MinimalRule(CommonValidationRule):
+    """Only implements the one abstract member; everything else is inherited."""
+
+    @property
+    def expected_category(self) -> SemanticCategory:
+        return SemanticCategory.ECONOMIC
+
+
+class EconomicRule(MinimalRule):
+    """Economic rule owning a single, specific prefix."""
+
+    @property
+    def endpoint_prefixes(self) -> set[str]:
+        return {"get_gdp"}
+
+
+class BroadRule(MinimalRule):
+    """Economic rule with a prefix broad enough to swallow other groups."""
+
+    @property
+    def endpoint_prefixes(self) -> set[str]:
+        return {"get_"}
+
+
+class SnakeCaseRule(CommonValidationRule):
+    """Adds a method-name check on top of the inherited category check."""
+
+    @property
+    def expected_category(self) -> SemanticCategory:
+        return SemanticCategory.MARKET_DATA
+
+    @property
+    def endpoint_prefixes(self) -> set[str]:
+        return {"get_"}
+
+    def validate(
+        self, method_name: str, category: SemanticCategory
+    ) -> tuple[bool, str]:
+        is_valid, message = super().validate(method_name, category)
+        if not is_valid:
+            return False, message
+        if not method_name.islower():
+            return False, f"{method_name} is not snake_case"
+        return True, ""
+
+
+class NoRequirementsRule(MarketRule):
+    """Market rule that never publishes parameter requirements."""
+
+    def get_parameter_requirements(
+        self, method_name: str
+    ) -> dict[str, list[str]] | None:
+        return None
+
+
+@pytest.fixture
+def market_rule() -> MarketRule:
+    return MarketRule()
+
+
+@pytest.fixture
+def registry() -> ValidationRuleRegistry:
+    return ValidationRuleRegistry()
+
+
+class TestAbstractContract:
+    """The ABC layer must refuse incomplete implementations."""
+
+    def test_validation_rule_cannot_be_instantiated(self) -> None:
+        with pytest.raises(TypeError, match="abstract"):
+            ValidationRule()  # type: ignore[abstract]
+
+    def test_subclass_without_expected_category_is_abstract(self) -> None:
+        class HalfBakedRule(CommonValidationRule):
+            pass
+
+        with pytest.raises(TypeError) as exc_info:
+            HalfBakedRule()  # type: ignore[abstract]
+
+        assert "expected_category" in str(exc_info.value)
+
+
+class TestCommonValidationRuleDefaults:
+    """Inherited defaults of CommonValidationRule."""
+
+    def test_endpoint_prefixes_default_to_empty(self) -> None:
+        assert MinimalRule().endpoint_prefixes == set()
+
+    def test_get_endpoint_info_defaults_to_none(self) -> None:
+        assert MinimalRule.get_endpoint_info("get_gdp") is None
+
+    def test_only_historical_has_parameter_requirements(self) -> None:
+        rule = MinimalRule()
+
+        assert rule.get_parameter_requirements("get_gdp") is None
+        assert rule.get_parameter_requirements("historical") == {
+            "start_date": [],
+            "end_date": [],
+        }
+
+
+class TestValidateCategory:
+    """CommonValidationRule.validate compares categories only."""
+
+    def test_matching_category_is_accepted(self, market_rule: MarketRule) -> None:
+        assert market_rule.validate("get_quote", SemanticCategory.MARKET_DATA) == (
+            True,
+            "",
+        )
+
+    def test_unknown_method_still_passes_the_default_check(
+        self, market_rule: MarketRule
+    ) -> None:
+        """The default rule never looks at the method name."""
+        assert market_rule.validate(
+            "method_that_does_not_exist", SemanticCategory.MARKET_DATA
+        ) == (True, "")
+
+    def test_mismatched_category_is_rejected(self, market_rule: MarketRule) -> None:
+        is_valid, message = market_rule.validate("get_quote", SemanticCategory.ECONOMIC)
+
+        assert not is_valid
+        # The message interpolates the enum *member*, not ``.value`` — on
+        # Python >= 3.11 that renders as ``SemanticCategory.MARKET_DATA``.
+        assert message in (
+            "Expected SemanticCategory.MARKET_DATA, got SemanticCategory.ECONOMIC",
+            "Expected Market Data, got Economic Data",
+        )
+
+    def test_subclass_can_extend_validate(self) -> None:
+        rule = SnakeCaseRule()
+
+        assert rule.validate("get_quote", SemanticCategory.MARKET_DATA) == (True, "")
+        assert rule.validate("get_Quote", SemanticCategory.MARKET_DATA) == (
+            False,
+            "get_Quote is not snake_case",
+        )
+
+
+class TestValidateParameters:
+    """CommonValidationRule.validate_parameters."""
+
+    def test_unknown_method_is_rejected(self, market_rule: MarketRule) -> None:
+        assert market_rule.validate_parameters("get_nope", {}) == (
+            False,
+            "Invalid method name: get_nope",
+        )
+
+    def test_method_without_requirements_accepts_anything(
+        self, market_rule: MarketRule
+    ) -> None:
+        assert market_rule.validate_parameters(
+            "get_quote", {"symbol": "AAPL", "limit": 5}
+        ) == (True, "")
+
+    def test_valid_dates_are_accepted(self, market_rule: MarketRule) -> None:
+        assert market_rule.validate_parameters(
+            "historical", {"start_date": "2024-01-01", "end_date": "2024-03-31"}
+        ) == (True, "")
+
+    def test_requirements_do_not_make_parameters_mandatory(
+        self, market_rule: MarketRule
+    ) -> None:
+        """Requirements constrain format, never presence.
+
+        ``get_parameter_requirements`` names ``start_date``/``end_date``, but
+        the check iterates the *supplied* parameters, so omitting them entirely
+        is accepted.
+        """
+        assert market_rule.get_parameter_requirements("historical") == {
+            "start_date": [ISO_DATE],
+            "end_date": [ISO_DATE],
+        }
+        assert market_rule.validate_parameters("historical", {}) == (True, "")
+
+    def test_any_declared_pattern_may_match(self) -> None:
+        """Patterns are alternatives: matching the second one is enough."""
+        rule = MultiFormatDateRule()
+
+        assert rule.validate_parameters("historical", {"start_date": "2024-01-01"}) == (
+            True,
+            "",
+        )
+        assert rule.validate_parameters("historical", {"start_date": "01/31/2024"}) == (
+            True,
+            "",
+        )
+        assert rule.validate_parameters(
+            "historical", {"start_date": "31 Jan 2024"}
+        ) == (False, "Invalid value for parameter 'start_date': 31 Jan 2024")
+
+    def test_uncompilable_pattern_escapes_as_re_error(self) -> None:
+        """A malformed pattern crashes the caller instead of failing validation.
+
+        ``re.match`` is called without a guard, so a bad pattern surfaces as
+        ``re.error`` rather than the ``(False, "Invalid value ...")`` tuple the
+        signature promises. Callers cannot distinguish "rejected" from
+        "misconfigured" without catching this.
+        """
+        rule = UncompilableDateRule()
+
+        with pytest.raises(re.error):
+            rule.validate_parameters("historical", {"start_date": "2024-01-01"})
+
+    def test_invalid_date_is_rejected_by_name(self, market_rule: MarketRule) -> None:
+        assert market_rule.validate_parameters(
+            "historical", {"start_date": "2024/01/01"}
+        ) == (False, "Invalid value for parameter 'start_date': 2024/01/01")
+
+    def test_first_invalid_parameter_short_circuits(
+        self, market_rule: MarketRule
+    ) -> None:
+        is_valid, message = market_rule.validate_parameters(
+            "historical", {"start_date": "yesterday", "end_date": "tomorrow"}
+        )
+
+        assert not is_valid
+        assert message == "Invalid value for parameter 'start_date': yesterday"
+
+    def test_unconstrained_parameters_are_ignored(
+        self, market_rule: MarketRule
+    ) -> None:
+        assert market_rule.validate_parameters(
+            "historical", {"symbol": "AAPL", "limit": "not-a-date"}
+        ) == (True, "")
+
+    def test_values_are_stringified_before_matching(
+        self, market_rule: MarketRule
+    ) -> None:
+        assert market_rule.validate_parameters(
+            "historical", {"start_date": date(2024, 1, 1)}
+        ) == (True, "")
+        assert market_rule.validate_parameters(
+            "historical", {"start_date": 20240101}
+        ) == (False, "Invalid value for parameter 'start_date': 20240101")
+
+    def test_empty_pattern_list_rejects_every_value(self) -> None:
+        """A rule whose date patterns cannot be resolved rejects all dates."""
+        rule = NestedWithoutCommonRule()
+
+        assert rule.get_parameter_requirements("historical") == {
+            "start_date": [],
+            "end_date": [],
+        }
+        assert rule.validate_parameters("historical", {"start_date": "2024-01-01"}) == (
+            False,
+            "Invalid value for parameter 'start_date': 2024-01-01",
+        )
+
+    def test_matching_is_prefix_only(self) -> None:
+        """``re.match`` is not ``fullmatch``: trailing junk survives."""
+        rule = UnanchoredDateRule()
+
+        assert rule.validate_parameters(
+            "historical", {"start_date": "2024-01-01' OR 1=1"}
+        ) == (True, "")
+
+
+class TestHistoricalPatternShapes:
+    """_build_historical_patterns handles each PARAMETER_PATTERNS shape."""
+
+    @pytest.mark.parametrize(
+        ("rule", "expected"),
+        [
+            pytest.param(MarketRule(), [ISO_DATE], id="flat-list"),
+            pytest.param(NestedCommonRule(), [ISO_DATE], id="nested-common-list"),
+            pytest.param(NestedWithoutCommonRule(), [], id="nested-without-common"),
+            pytest.param(NestedBadCommonRule(), [], id="nested-common-not-a-list"),
+            pytest.param(NoPatternsRule(), [], id="no-date-key"),
+        ],
+    )
+    def test_start_and_end_date_patterns(
+        self, rule: CommonValidationRule, expected: list[str]
+    ) -> None:
+        assert rule.get_parameter_requirements("historical") == {
+            "start_date": expected,
+            "end_date": expected,
+        }
+
+    def test_non_historical_methods_have_no_requirements(
+        self, market_rule: MarketRule
+    ) -> None:
+        assert market_rule.get_parameter_requirements("get_quote") is None
+
+    def test_the_historical_hook_is_an_exact_name_match(
+        self, market_rule: MarketRule
+    ) -> None:
+        """Only the literal name ``historical`` gets date requirements."""
+        assert market_rule.get_parameter_requirements("historical_chart") is None
+        assert market_rule.get_parameter_requirements("Historical") is None
+
+    def test_returned_patterns_alias_the_class_level_config(self) -> None:
+        """The result is live class state, so mutating it rewrites the rule.
+
+        Both date keys hand back the *same* list object that lives on the
+        class, rather than a copy. A caller that edits the requirements it was
+        handed silently reconfigures every later validation, which is why the
+        result has to be treated as read-only.
+        """
+
+        class ScratchRule(MarketRule):
+            PARAMETER_PATTERNS: ClassVar[PatternMap] = {"date": [ISO_DATE]}
+
+        rule = ScratchRule()
+        requirements = rule.get_parameter_requirements("historical")
+
+        assert requirements is not None
+        assert requirements["start_date"] is ScratchRule.PARAMETER_PATTERNS["date"]
+        assert requirements["end_date"] is requirements["start_date"]
+
+        requirements["start_date"].clear()
+
+        assert ScratchRule.PARAMETER_PATTERNS["date"] == []
+        assert rule.get_parameter_requirements("historical") == {
+            "start_date": [],
+            "end_date": [],
+        }
+        assert rule.validate_parameters("historical", {"start_date": "2024-01-01"}) == (
+            False,
+            "Invalid value for parameter 'start_date': 2024-01-01",
+        )
+        # The damage is confined to the subclass that owns the list.
+        assert MarketRule.PARAMETER_PATTERNS["date"] == [ISO_DATE]
+
+
+class TestRegistryValidateCategory:
+    """ValidationRuleRegistry.validate_category dispatch."""
+
+    def test_register_rule_logs_the_class_name(
+        self, registry: ValidationRuleRegistry, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.DEBUG, logger="fmp_data.lc.validation"):
+            registry.register_rule(MarketRule())
+
+        # Registration is a debug-level event: it must be traceable without
+        # being promoted into the noise every consumer sees by default.
+        assert ("DEBUG", "Registered validation rule: MarketRule") in [
+            (record.levelname, record.getMessage()) for record in caplog.records
+        ]
+        # ...and the registration actually took effect.
+        assert (
+            registry.get_expected_category("get_quote") == SemanticCategory.MARKET_DATA
+        )
+
+    def test_category_with_no_rules_is_rejected(
+        self, registry: ValidationRuleRegistry
+    ) -> None:
+        registry.register_rule(EconomicRule())
+
+        assert registry.validate_category(
+            "get_quote", SemanticCategory.MARKET_DATA
+        ) == (False, "No rules found for category Market Data")
+
+    def test_unmatched_method_is_rejected(
+        self, registry: ValidationRuleRegistry
+    ) -> None:
+        registry.register_rule(MarketRule())
+
+        assert registry.validate_category(
+            "mystery_method", SemanticCategory.MARKET_DATA
+        ) == (
+            False,
+            "No matching rule found for mystery_method in category Market Data",
+        )
+
+    def test_matching_rule_is_accepted(self, registry: ValidationRuleRegistry) -> None:
+        registry.register_rule(MarketRule())
+
+        assert registry.validate_category(
+            "get_quote", SemanticCategory.MARKET_DATA
+        ) == (True, "")
+
+    def test_registry_returns_the_rules_own_verdict(
+        self, registry: ValidationRuleRegistry
+    ) -> None:
+        registry.register_rule(SnakeCaseRule())
+
+        assert registry.validate_category(
+            "get_Quote", SemanticCategory.MARKET_DATA
+        ) == (False, "get_Quote is not snake_case")
+
+    def test_mismatch_names_the_owning_category(
+        self, registry: ValidationRuleRegistry
+    ) -> None:
+        registry.register_rule(MarketRule())
+        registry.register_rule(EconomicRule())
+
+        assert registry.validate_category("get_gdp", SemanticCategory.MARKET_DATA) == (
+            False,
+            "Category mismatch: endpoint get_gdp belongs to Economic Data, "
+            "not Market Data",
+        )
+
+    def test_first_registered_prefix_wins(
+        self, registry: ValidationRuleRegistry
+    ) -> None:
+        """A broad prefix registered first claims another group's endpoint.
+
+        Current behaviour: ``get_quote`` is owned by ``MarketRule`` (exact
+        prefix) but ``BroadRule``'s ``get_`` is scanned first, so the market
+        endpoint is reported as belonging to Economic Data.
+
+        This is the #122 defect that ``fmp_data.lc.registry`` fixed by picking
+        the longest matching prefix; this module still scans first-match. If
+        it is ever fixed here too, invert this assertion rather than deleting
+        it — the point is that ownership must not depend on registration order.
+        """
+        registry.register_rule(BroadRule())
+        registry.register_rule(MarketRule())
+
+        assert registry.validate_category(
+            "get_quote", SemanticCategory.MARKET_DATA
+        ) == (
+            False,
+            "Category mismatch: endpoint get_quote belongs to Economic Data, "
+            "not Market Data",
+        )
+
+
+class TestRegistryParameterRequirements:
+    """ValidationRuleRegistry parameter lookups."""
+
+    def test_requirements_are_returned_for_the_category(
+        self, registry: ValidationRuleRegistry
+    ) -> None:
+        registry.register_rule(MarketRule())
+
+        assert registry.get_parameter_requirements(
+            "historical", SemanticCategory.MARKET_DATA
+        ) == ({"start_date": [ISO_DATE], "end_date": [ISO_DATE]}, "")
+
+    def test_rules_returning_none_are_skipped(
+        self, registry: ValidationRuleRegistry
+    ) -> None:
+        registry.register_rule(NoRequirementsRule())
+        registry.register_rule(MarketRule())
+
+        assert registry.get_parameter_requirements(
+            "historical", SemanticCategory.MARKET_DATA
+        ) == ({"start_date": [ISO_DATE], "end_date": [ISO_DATE]}, "")
+
+    def test_missing_requirements_are_reported(
+        self, registry: ValidationRuleRegistry
+    ) -> None:
+        registry.register_rule(MarketRule())
+
+        assert registry.get_parameter_requirements(
+            "get_quote", SemanticCategory.MARKET_DATA
+        ) == (None, "No parameter requirements found for get_quote")
+
+    def test_other_categories_are_not_consulted(
+        self, registry: ValidationRuleRegistry
+    ) -> None:
+        registry.register_rule(MarketRule())
+
+        assert registry.get_parameter_requirements(
+            "historical", SemanticCategory.ECONOMIC
+        ) == (None, "No parameter requirements found for historical")
+
+
+class TestRegistryValidateParameters:
+    """ValidationRuleRegistry.validate_parameters delegation."""
+
+    def test_delegates_to_the_category_rule(
+        self, registry: ValidationRuleRegistry
+    ) -> None:
+        registry.register_rule(MarketRule())
+
+        assert registry.validate_parameters(
+            "historical", SemanticCategory.MARKET_DATA, {"start_date": "2024-13-99x"}
+        ) == (False, "Invalid value for parameter 'start_date': 2024-13-99x")
+
+    def test_only_the_first_rule_of_a_category_is_used(
+        self, registry: ValidationRuleRegistry
+    ) -> None:
+        """Registration order decides the verdict, not endpoint ownership."""
+        registry.register_rule(SnakeCaseRule())  # no endpoint table
+        registry.register_rule(MarketRule())  # owns "historical"
+
+        assert registry.validate_parameters(
+            "historical", SemanticCategory.MARKET_DATA, {"start_date": "2024-01-01"}
+        ) == (False, "Invalid method name: historical")
+
+    def test_unregistered_category_passes_silently(
+        self, registry: ValidationRuleRegistry
+    ) -> None:
+        registry.register_rule(EconomicRule())
+
+        assert registry.validate_parameters(
+            "historical", SemanticCategory.MARKET_DATA, {"start_date": "nonsense"}
+        ) == (True, "")
+
+
+class TestRegistryExpectedCategory:
+    """ValidationRuleRegistry.get_expected_category."""
+
+    def test_known_prefixes_resolve(self, registry: ValidationRuleRegistry) -> None:
+        registry.register_rule(MarketRule())
+        registry.register_rule(EconomicRule())
+
+        assert (
+            registry.get_expected_category("historical") == SemanticCategory.MARKET_DATA
+        )
+        assert registry.get_expected_category("get_gdp") == SemanticCategory.ECONOMIC
+
+    def test_unknown_method_has_no_category(
+        self, registry: ValidationRuleRegistry
+    ) -> None:
+        registry.register_rule(MarketRule())
+
+        assert registry.get_expected_category("get_dividends") is None
+
+    def test_rule_without_prefixes_never_matches(
+        self, registry: ValidationRuleRegistry
+    ) -> None:
+        registry.register_rule(MinimalRule())
+
+        assert registry.get_expected_category("get_gdp") is None
+
+    def test_broad_prefix_shadows_specific_rule(
+        self, registry: ValidationRuleRegistry
+    ) -> None:
+        """Same first-match defect as ``validate_category``.
+
+        Both entry points agree today only because both are wrong in the same
+        way; see ``test_first_registered_prefix_wins``.
+        """
+        registry.register_rule(BroadRule())
+        registry.register_rule(MarketRule())
+
+        assert registry.get_expected_category("get_quote") == SemanticCategory.ECONOMIC

--- a/tests/unit/test_base_async.py
+++ b/tests/unit/test_base_async.py
@@ -1,6 +1,7 @@
 # tests/unit/test_base_async.py
 """Tests for async client functionality in BaseClient."""
 
+import inspect
 from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
@@ -108,16 +109,100 @@ class TestAsyncClientReuse:
         await client.aclose()
 
     @pytest.mark.asyncio
-    async def test_async_client_installs_cross_origin_redirect_hook(
+    async def test_async_client_installs_the_awaitable_redirect_hook(
         self, client_config
     ):
-        """Async client uses the same Location-based SEC-004 hook as sync."""
-        from fmp_data.base import BaseClient, _reject_cross_origin_redirect
+        """The async client must register the *async* SEC-004 hook.
+
+        ``httpx.AsyncClient`` does ``await hook(response)``. Registering the
+        plain sync function made httpx await ``None``, which raised
+        ``TypeError`` on every async response. Membership alone is not
+        enough — assert it is a coroutine function too.
+        """
+        from fmp_data.base import BaseClient, _areject_cross_origin_redirect
+
+        client = BaseClient(client_config)
+        try:
+            hooks = client._setup_async_client().event_hooks["response"]
+            assert _areject_cross_origin_redirect in hooks
+            assert all(inspect.iscoroutinefunction(hook) for hook in hooks), (
+                "every async response hook must be awaitable"
+            )
+        finally:
+            await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_async_hook_lets_a_normal_response_through(self, client_config):
+        """Regression: a plain 200 must not raise (#252 FMP-SEC-004).
+
+        This drives the real ``httpx.AsyncClient`` send path rather than an
+        ``AsyncMock``. Before the async wrapper existed this raised
+        ``TypeError: object NoneType can't be used in 'await' expression``
+        for *every* async request, and the mock-based tests could not see it.
+        """
+        from fmp_data.base import BaseClient
 
         client = BaseClient(client_config)
         try:
             async_client = client._setup_async_client()
-            assert _reject_cross_origin_redirect in async_client.event_hooks["response"]
+            async_client._transport = httpx.MockTransport(
+                lambda request: httpx.Response(200, json={"symbol": "AAPL"})
+            )
+            response = await async_client.get("https://financialmodelingprep.com/x")
+            assert response.status_code == 200
+            assert response.json() == {"symbol": "AAPL"}
+        finally:
+            await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_async_hook_refuses_a_real_cross_origin_redirect(self, client_config):
+        """A 302 to another origin is refused before the second hop."""
+        from fmp_data.base import BaseClient
+        from fmp_data.exceptions import FMPError
+
+        seen: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append(str(request.url))
+            if request.url.host == "financialmodelingprep.com":
+                return httpx.Response(
+                    302, headers={"Location": "https://attacker.test/steal"}
+                )
+            return httpx.Response(200, json={"leaked": True})
+
+        client = BaseClient(client_config)
+        try:
+            async_client = client._setup_async_client()
+            async_client._transport = httpx.MockTransport(handler)
+            with pytest.raises(FMPError, match="Refusing cross-origin redirect"):
+                await async_client.get("https://financialmodelingprep.com/x")
+        finally:
+            await client.aclose()
+
+        assert not any("attacker.test" in url for url in seen), (
+            f"request reached the attacker origin: {seen}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_hook_allows_a_same_origin_redirect(self, client_config):
+        """Same-origin 3xx still follows through to the final response."""
+        from fmp_data.base import BaseClient
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/x":
+                return httpx.Response(
+                    302,
+                    headers={"Location": "https://financialmodelingprep.com/y"},
+                )
+            return httpx.Response(200, json={"ok": True})
+
+        client = BaseClient(client_config)
+        try:
+            async_client = client._setup_async_client()
+            async_client._transport = httpx.MockTransport(handler)
+            response = await async_client.get("https://financialmodelingprep.com/x")
+            assert response.status_code == 200
+            assert response.json() == {"ok": True}
         finally:
             await client.aclose()
 

--- a/tests/unit/test_extras_coverage_gate.py
+++ b/tests/unit/test_extras_coverage_gate.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import configparser
 from pathlib import Path
+import re
+import subprocess
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PYPROJECT = REPO_ROOT / "pyproject.toml"
@@ -16,6 +18,10 @@ NOXFILE = REPO_ROOT / "noxfile.py"
 CI = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 GITIGNORE = REPO_ROOT / ".gitignore"
 EXTRAS_COVERAGERC = REPO_ROOT / "extras.coveragerc"
+
+# Raised from 65 once dedicated tests took the measured extras number from
+# 66.78% to 86.99% (#282). Keep the config and the nox session in step.
+EXTRAS_FAIL_UNDER = 80
 
 
 def _coverage_run_omit_block() -> str:
@@ -58,13 +64,13 @@ def test_extras_coveragerc_gates_the_omitted_trees() -> None:
     assert "fmp_data.mcp" in source
     assert "fmp_data.cache.redis_backend" in source
     assert "fmp_data/cache/redis_backend.py" not in source
-    assert parser.getint("report", "fail_under") == 65
+    assert parser.getint("report", "fail_under") == EXTRAS_FAIL_UNDER
 
 
 def test_coverage_extras_session_uses_the_dedicated_config() -> None:
     source = _coverage_extras_session_source()
     assert "--cov-config=extras.coveragerc" in source
-    assert "--cov-fail-under=65" in source
+    assert f"--cov-fail-under={EXTRAS_FAIL_UNDER}" in source
     assert "--cov=fmp_data.lc" in source
     assert "--cov=fmp_data.mcp" in source
     assert "--cov=fmp_data.cache.redis_backend" in source
@@ -95,6 +101,78 @@ def test_ci_runs_extras_coverage_separately() -> None:
     assert "needs.extras-coverage.result" in expected
 
 
+def test_exclude_lines_regexes_actually_compile_and_match() -> None:
+    """``extras.coveragerc`` is INI, so TOML double-escaping is wrong (#282).
+
+    ``class .*\\\\(Protocol\\\\):`` was copied from ``pyproject.toml``, where
+    TOML collapses ``\\\\(`` to ``\\(``. In an INI file it stays a literal
+    backslash, so the pattern compiled but could never match a real
+    ``class Foo(Protocol):`` line and the exclusion silently did nothing.
+    """
+    parser = configparser.ConfigParser()
+    parser.read(EXTRAS_COVERAGERC, encoding="utf-8")
+    patterns = [
+        line.strip()
+        for line in parser.get("report", "exclude_lines").splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+
+    for pattern in patterns:
+        re.compile(pattern)  # must not raise
+
+    protocol = [p for p in patterns if "Protocol" in p]
+    assert protocol, f"no Protocol exclusion found in {patterns}"
+    assert any(re.search(p, "class Foo(Protocol):") for p in protocol), (
+        f"Protocol exclusion never matches a real declaration: {protocol}"
+    )
+
+
+def test_ci_jobs_that_must_be_required_checks_run_unconditionally() -> None:
+    """Every job named in #282 must run on all PRs to be a safe gate.
+
+    A required check that never reports on some PRs blocks them forever, so
+    none of these may carry a ``paths:``/``paths-ignore:`` filter or a job
+    level ``if:``.
+    """
+    text = CI.read_text(encoding="utf-8")
+    assert "paths:" not in text
+    assert "paths-ignore:" not in text
+
+    for job in ("coverage:", "extras-coverage:", "secret-scan:", "actions-shell:"):
+        start = text.index(f"  {job}")
+        body = text[start : start + 400]
+        assert "\n    if:" not in body, f"{job} is conditional; unsafe to require"
+
+
 def test_uv_lock_stays_uncommitted() -> None:
-    text = GITIGNORE.read_text(encoding="utf-8")
-    assert "uv.lock" in text
+    """``uv.lock`` is ignored *and* actually absent from the index (#273).
+
+    Grepping ``.gitignore`` alone would still pass if someone force-added the
+    lock, so assert the tracked-file set too.
+    """
+    assert "uv.lock" in GITIGNORE.read_text(encoding="utf-8")
+    tracked = subprocess.run(
+        ["git", "ls-files", "--", "uv.lock", "poetry.lock"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.split()
+    assert tracked == [], f"lock files must stay untracked, found: {tracked}"
+
+
+def test_lock_file_policy_is_documented() -> None:
+    """The decision is recorded, not just enforced (#273).
+
+    The previous ``.gitignore`` rationale cited a non-existent "GitHub 500KB
+    warning" (that is pre-commit's ``check-added-large-files`` default), so
+    pin the real reasoning against silent reversion.
+    """
+    contributing = (REPO_ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+    assert "### Lock file policy" in contributing
+    assert "not committed" in contributing
+    assert "pip-audit --strict" in contributing
+
+    gitignore = GITIGNORE.read_text(encoding="utf-8")
+    assert "500KB" not in gitignore
+    assert "CONTRIBUTING.md" in gitignore

--- a/tests/unit/test_mcp_setup.py
+++ b/tests/unit/test_mcp_setup.py
@@ -1,0 +1,1151 @@
+"""Behavioural tests for the Claude Desktop setup wizard.
+
+Relative path: tests/unit/test_mcp_setup.py
+
+Every collaborator that would touch the network, a real Claude install, a
+subprocess or the terminal is replaced; the wizard itself never is. The mode
+bits of the file ``save_claude_config`` writes are pinned separately in
+``tests/unit/test_mcp_config_perms.py`` -- what is asserted here is the
+wizard's own behaviour: what it asks, what it redacts, what JSON it merges
+and what it returns.
+"""
+
+from __future__ import annotations
+
+import getpass
+import json
+import os
+from pathlib import Path
+import platform
+import subprocess
+import sys
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from fmp_data.mcp import _compat
+from fmp_data.mcp import setup as setup_mod
+from fmp_data.mcp import utils as mcp_utils
+from fmp_data.mcp.setup import SetupWizard, run_setup
+
+CONFIG_NAME = "claude_desktop_config.json"
+
+
+def feed_input(monkeypatch: pytest.MonkeyPatch, responses: list[str]) -> list[str]:
+    """Answer ``input()`` from a queue and record every prompt shown."""
+    prompts: list[str] = []
+    queue = list(responses)
+
+    def fake_input(prompt: str = "") -> str:
+        prompts.append(prompt)
+        if not queue:
+            raise AssertionError(f"wizard asked one prompt too many: {prompt!r}")
+        return queue.pop(0)
+
+    monkeypatch.setattr("builtins.input", fake_input)
+    return prompts
+
+
+def feed_secrets(monkeypatch: pytest.MonkeyPatch, responses: list[str]) -> list[str]:
+    """Answer ``getpass.getpass()`` from a queue and record its prompts."""
+    prompts: list[str] = []
+    queue = list(responses)
+
+    def fake_getpass(prompt: str = "") -> str:
+        prompts.append(prompt)
+        if not queue:
+            raise AssertionError(f"wizard asked for one secret too many: {prompt!r}")
+        return queue.pop(0)
+
+    monkeypatch.setattr(getpass, "getpass", fake_getpass)
+    return prompts
+
+
+def record_validations(
+    monkeypatch: pytest.MonkeyPatch, verdict: tuple[bool, str]
+) -> list[str]:
+    """Stand in for ``validate_api_key``, recording every key handed to it."""
+    seen: list[str] = []
+
+    def fake_validate(api_key: str) -> tuple[bool, str]:
+        seen.append(api_key)
+        return verdict
+
+    monkeypatch.setattr(setup_mod, "validate_api_key", fake_validate)
+    return seen
+
+
+def record_server_tests(
+    monkeypatch: pytest.MonkeyPatch, verdict: tuple[bool, str]
+) -> list[tuple[str, str | None]]:
+    """Stand in for ``test_mcp_server``, recording its (key, manifest) pairs."""
+    seen: list[tuple[str, str | None]] = []
+
+    def fake_test_server(api_key: str, manifest_path: str | None) -> tuple[bool, str]:
+        seen.append((api_key, manifest_path))
+        return verdict
+
+    monkeypatch.setattr(setup_mod, "test_mcp_server", fake_test_server)
+    return seen
+
+
+def break_first_error_report(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Make the *first* "Setup failed" write blow up, then behave again.
+
+    That is the only way into ``run_setup``'s fallback reporter without
+    stubbing the wizard it is supposed to be exercising.
+    """
+    real_print = print
+    failed_once: list[str] = []
+
+    def flaky_print(*args: Any, **kwargs: Any) -> None:
+        text = " ".join(str(arg) for arg in args)
+        if "Setup failed" in text and not failed_once:
+            failed_once.append(text)
+            raise OSError("stdout went away")
+        real_print(*args, **kwargs)
+
+    monkeypatch.setattr("builtins.print", flaky_print)
+    return failed_once
+
+
+@pytest.fixture
+def claude_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect the Claude Desktop config path in both namespaces."""
+    target = tmp_path / "Claude" / CONFIG_NAME
+    monkeypatch.setattr(mcp_utils, "get_claude_config_path", lambda: target)
+    monkeypatch.setattr(setup_mod, "get_claude_config_path", lambda: target)
+    return target
+
+
+@pytest.fixture
+def happy_path(claude_config: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Every collaborator wired so a whole run succeeds offline."""
+    monkeypatch.setattr(_compat, "mcp_server_available", lambda: True)
+    monkeypatch.setattr(setup_mod, "check_claude_desktop_installed", lambda: True)
+    monkeypatch.setattr(setup_mod, "get_api_key_from_env", lambda: "ENV-API-KEY")
+    monkeypatch.setattr(setup_mod, "get_manifest_choices", lambda: {"default": None})
+    monkeypatch.setattr(setup_mod, "find_python_executable", lambda: "/opt/py")
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: SimpleNamespace(returncode=0)
+    )
+    monkeypatch.setattr(
+        setup_mod,
+        "test_mcp_server",
+        lambda key, manifest: (True, "MCP server test passed"),
+    )
+    return claude_config
+
+
+class TestRedactSensitive:
+    """Nothing secret may reach the terminal, whatever shape it arrives in."""
+
+    def test_none_and_empty_pass_straight_through(self) -> None:
+        wizard = SetupWizard()
+
+        assert wizard._redact_sensitive(None) is None
+        assert wizard._redact_sensitive("") == ""
+
+    def test_the_configured_key_is_replaced_at_every_occurrence(self) -> None:
+        wizard = SetupWizard()
+        wizard.api_key = "Kk1Kk2Kk3Kk4"  # pragma: allowlist secret
+
+        redacted = wizard._redact_sensitive("tried Kk1Kk2Kk3Kk4 then Kk1Kk2Kk3Kk4")
+
+        assert redacted == "tried [REDACTED] then [REDACTED]"
+
+    def test_a_query_credential_goes_but_the_rest_of_the_url_stays(self) -> None:
+        wizard = SetupWizard()
+
+        redacted = wizard._redact_sensitive(
+            "GET https://fmp.test/api/v3/profile?apikey=hunter2xyz&symbol=AAPL"
+        )
+
+        assert redacted == (
+            "GET https://fmp.test/api/v3/profile?apikey=[REDACTED]&symbol=AAPL"
+        )
+
+    @pytest.mark.parametrize(
+        "probe",
+        [
+            "sk-abcdefgh12345678",
+            "pk_abcdefgh12345678",
+            "A1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6",  # pragma: allowlist secret
+            "deadbeef" * 5,
+        ],
+    )
+    def test_key_shaped_strings_are_redacted_without_being_configured(
+        self, probe: str
+    ) -> None:
+        """The failing-request path prints keys the wizard never held."""
+        wizard = SetupWizard()
+
+        redacted = wizard._redact_sensitive(f"request failed for {probe} at 401")
+
+        # Exact equality, not "probe not in redacted": it has to pin that the
+        # surrounding words -- including the bare ``401`` -- are left alone.
+        assert redacted == "request failed for [REDACTED] at 401"
+
+    @pytest.mark.parametrize(
+        "probe",
+        [
+            "Setup complete for AAPL",
+            "Python 3.12.1 detected",
+            "config saved to /Users/me/Library/Claude",
+        ],
+    )
+    def test_ordinary_messages_survive_untouched(self, probe: str) -> None:
+        """Over-redaction would make the wizard's output useless."""
+        assert SetupWizard()._redact_sensitive(probe) == probe
+
+
+class TestPrint:
+    """The styled writer, including the quiet switch."""
+
+    @pytest.mark.parametrize(
+        ("style", "expected"),
+        [
+            ("success", "✅ hello\n"),
+            ("error", "❌ hello\n"),
+            ("warning", "⚠️  hello\n"),
+            ("info", "\U0001f4a1 hello\n"),
+            ("", "hello\n"),
+        ],
+    )
+    def test_each_style_gets_its_own_marker(
+        self, style: str, expected: str, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        SetupWizard().print("hello", style)
+
+        assert capsys.readouterr().out == expected
+
+    def test_the_header_style_is_framed(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        SetupWizard().print("Setup", "header")
+
+        bar = "=" * 60
+        assert capsys.readouterr().out == f"\n{bar}\n\U0001f680 Setup\n{bar}\n"
+
+    def test_quiet_mode_writes_nothing_at_all(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        wizard = SetupWizard(quiet=True)
+
+        for style in ("header", "success", "error", "warning", "info", ""):
+            wizard.print("hello", style)
+
+        assert capsys.readouterr().out == ""
+
+    def test_printing_redacts_the_configured_key(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        wizard = SetupWizard()
+        wizard.api_key = "Kk1Kk2Kk3Kk4"  # pragma: allowlist secret
+
+        wizard.print("saved Kk1Kk2Kk3Kk4", "success")
+
+        out = capsys.readouterr().out
+        assert "Kk1Kk2Kk3Kk4" not in out
+        assert out == "✅ saved [REDACTED]\n"
+
+
+class TestPrompts:
+    """Input plumbing: defaults, stripping, echo, and re-asking."""
+
+    def test_a_default_is_shown_and_returned_on_an_empty_answer(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        prompts = feed_input(monkeypatch, [""])
+
+        assert SetupWizard().prompt("Continue? (y/n)", "n") == "n"
+        assert prompts == ["Continue? (y/n) [n]: "]
+
+    def test_a_typed_answer_wins_and_is_stripped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        prompts = feed_input(monkeypatch, ["  y  "])
+
+        assert SetupWizard().prompt("Continue? (y/n)", "n") == "y"
+        assert prompts == ["Continue? (y/n) [n]: "]
+
+    def test_without_a_default_an_empty_answer_is_the_empty_string(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        prompts = feed_input(monkeypatch, [""])
+
+        assert SetupWizard().prompt("Path") == ""
+        assert prompts == ["Path: "]
+
+    def test_a_secret_default_is_hidden_from_the_screen_but_still_returned(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Redaction is a display concern; the caller still needs the value."""
+        wizard = SetupWizard()
+        wizard.api_key = "Kk1Kk2Kk3Kk4"  # pragma: allowlist secret
+        prompts = feed_input(monkeypatch, [""])
+
+        answer = wizard.prompt("Use Kk1Kk2Kk3Kk4?", "Kk1Kk2Kk3Kk4")
+
+        assert answer == "Kk1Kk2Kk3Kk4"
+        assert prompts == ["Use [REDACTED]? [[REDACTED]]: "]
+
+    def test_the_key_prompt_goes_through_getpass_and_is_stripped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        wizard = SetupWizard()
+        wizard.api_key = "Kk1Kk2Kk3Kk4"  # pragma: allowlist secret
+        prompts = feed_secrets(monkeypatch, ["  typed-key  "])
+
+        assert wizard.prompt_secret("Replace Kk1Kk2Kk3Kk4") == "typed-key"
+        assert prompts == ["Replace [REDACTED]: "]
+
+    def test_an_empty_choice_takes_the_default(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        prompts = feed_input(monkeypatch, [""])
+
+        chosen = SetupWizard().prompt_choice("Pick", ["a", "b", "c"], default=1)
+
+        assert chosen == 1
+        assert prompts == ["\nSelect (1-3) [2]: "]
+        out = capsys.readouterr().out
+        assert "    1. a\n" in out
+        assert "  > 2. b\n" in out
+
+    def test_a_number_is_translated_to_a_zero_based_index(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        feed_input(monkeypatch, ["3"])
+
+        assert SetupWizard().prompt_choice("Pick", ["a", "b", "c"]) == 2
+
+    def test_an_out_of_range_number_is_rejected_and_re_asked(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        prompts = feed_input(monkeypatch, ["9", "0", "2"])
+
+        chosen = SetupWizard().prompt_choice("Pick", ["a", "b"])
+
+        assert chosen == 1
+        assert len(prompts) == 3
+        complaint = "Please enter a number between 1 and 2"
+        assert capsys.readouterr().out.count(complaint) == 2
+
+    def test_a_non_number_is_rejected_and_re_asked(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        prompts = feed_input(monkeypatch, ["two", "2"])
+
+        chosen = SetupWizard().prompt_choice("Pick", ["a", "b"])
+
+        assert chosen == 1
+        assert len(prompts) == 2
+        assert "Please enter a valid number" in capsys.readouterr().out
+
+
+class TestCheckPrerequisites:
+    """Each precondition must refuse loudly rather than fail later."""
+
+    @pytest.fixture(autouse=True)
+    def _installed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(_compat, "mcp_server_available", lambda: True)
+        monkeypatch.setattr(setup_mod, "check_claude_desktop_installed", lambda: True)
+
+    def test_everything_present_passes_without_asking_anything(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        prompts = feed_input(monkeypatch, [])
+
+        assert SetupWizard().check_prerequisites() is True
+        assert prompts == []
+        out = capsys.readouterr().out
+        assert "✅ MCP dependencies are installed" in out
+        assert "✅ Claude Desktop detected" in out
+
+    def test_an_old_interpreter_is_refused(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr(
+            setup_mod,
+            "sys",
+            SimpleNamespace(
+                version_info=SimpleNamespace(major=3, minor=9),
+                version="3.9.18 (main)",
+                executable=sys.executable,
+            ),
+        )
+
+        assert SetupWizard().check_prerequisites() is False
+        assert "Python 3.10+ required" in capsys.readouterr().out
+
+    def test_an_uninstallable_fmp_data_is_refused(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """``None`` in ``sys.modules`` makes the real import machinery fail."""
+        monkeypatch.setitem(sys.modules, "fmp_data", None)
+
+        assert SetupWizard().check_prerequisites() is False
+        out = capsys.readouterr().out
+        assert "❌ fmp-data package not installed" in out
+        assert "pip install fmp-data[mcp]" in out
+
+    def test_a_missing_mcp_extra_is_refused(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr(_compat, "mcp_server_available", lambda: False)
+
+        assert SetupWizard().check_prerequisites() is False
+        out = capsys.readouterr().out
+        assert "❌ MCP dependencies not installed" in out
+        assert "pip install fmp-data[mcp]" in out
+
+    def test_a_missing_claude_desktop_is_only_a_warning(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr(setup_mod, "check_claude_desktop_installed", lambda: False)
+        prompts = feed_input(monkeypatch, ["y"])
+
+        assert SetupWizard().check_prerequisites() is True
+        assert prompts == ["Continue anyway? (y/n) [n]: "]
+        assert "⚠️  Claude Desktop not detected" in capsys.readouterr().out
+
+    def test_declining_the_warning_stops_the_run(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Enter is enough to stop: the default answer is "n"."""
+        monkeypatch.setattr(setup_mod, "check_claude_desktop_installed", lambda: False)
+        feed_input(monkeypatch, [""])
+
+        assert SetupWizard().check_prerequisites() is False
+
+
+class TestSetupApiKey:
+    """Key acquisition, validation and the retry loop."""
+
+    def test_the_environment_key_is_adopted_without_validation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(setup_mod, "get_api_key_from_env", lambda: "ENV-API-KEY")
+        validated = record_validations(monkeypatch, (True, "ok"))
+        prompts = feed_input(monkeypatch, ["y"])
+        wizard = SetupWizard()
+
+        assert wizard.setup_api_key() is True
+        assert wizard.api_key == "ENV-API-KEY"  # pragma: allowlist secret
+        assert validated == []
+        assert prompts == ["Use API key from environment? (y/n) [y]: "]
+
+    def test_an_empty_entry_is_refused_and_asked_again(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr(setup_mod, "get_api_key_from_env", lambda: None)
+        validated = record_validations(monkeypatch, (True, "ok"))
+        secrets = feed_secrets(monkeypatch, ["   ", "  GOODKEY  "])
+        feed_input(monkeypatch, ["n"])
+        wizard = SetupWizard()
+
+        assert wizard.setup_api_key() is True
+        assert wizard.api_key == "GOODKEY"  # pragma: allowlist secret
+        assert validated == ["GOODKEY"]
+        assert len(secrets) == 2
+        assert "❌ API key is required" in capsys.readouterr().out
+
+    def test_a_rejected_key_is_reported_redacted_and_then_cleared(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The validator's message quotes the key the user just typed."""
+        monkeypatch.setattr(setup_mod, "get_api_key_from_env", lambda: None)
+        monkeypatch.setattr(
+            setup_mod,
+            "validate_api_key",
+            lambda key: (False, f"rejected {key} with 401"),
+        )
+        feed_secrets(monkeypatch, ["Kk1Kk2Kk3Kk4"])
+        prompts = feed_input(monkeypatch, ["n"])
+        wizard = SetupWizard()
+
+        assert wizard.setup_api_key() is False
+        assert wizard.api_key is None
+        out = capsys.readouterr().out
+        assert "Kk1Kk2Kk3Kk4" not in out
+        assert "❌ rejected [REDACTED] with 401" in out
+        assert prompts == ["Try another key? (y/n) [y]: "]
+
+    def test_retrying_after_a_rejection_keeps_the_second_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(setup_mod, "get_api_key_from_env", lambda: None)
+        monkeypatch.setattr(
+            setup_mod,
+            "validate_api_key",
+            lambda key: (key == "GOOD", "ok" if key == "GOOD" else "bad"),
+        )
+        feed_secrets(monkeypatch, ["BAD", "GOOD"])
+        feed_input(monkeypatch, ["y", "n"])
+        wizard = SetupWizard()
+
+        assert wizard.setup_api_key() is True
+        assert wizard.api_key == "GOOD"  # pragma: allowlist secret
+
+    def test_saying_yes_to_persistence_prints_shell_instructions(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr(setup_mod, "get_api_key_from_env", lambda: None)
+        monkeypatch.setattr(setup_mod, "validate_api_key", lambda key: (True, "ok"))
+        monkeypatch.setattr(platform, "system", lambda: "Darwin")
+        feed_secrets(monkeypatch, ["abcdWXYZabcdWXYZ"])
+        feed_input(monkeypatch, ["y"])
+
+        assert SetupWizard().setup_api_key() is True
+
+        out = capsys.readouterr().out
+        assert 'export FMP_API_KEY="abcd...WXYZ"' in out  # pragma: allowlist secret
+        assert "abcdWXYZabcdWXYZ" not in out
+
+    def test_declining_the_environment_key_falls_through_to_typing_one(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(setup_mod, "get_api_key_from_env", lambda: "ENV-API-KEY")
+        monkeypatch.setattr(setup_mod, "validate_api_key", lambda key: (True, "ok"))
+        feed_secrets(monkeypatch, ["TYPED-KEY"])
+        feed_input(monkeypatch, ["n", "n"])
+        wizard = SetupWizard()
+
+        assert wizard.setup_api_key() is True
+        assert wizard.api_key == "TYPED-KEY"  # pragma: allowlist secret
+
+
+class TestShowEnvInstructions:
+    """The persistence hint is per-platform and never quotes the whole key."""
+
+    def test_windows_gets_setx(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr(platform, "system", lambda: "Windows")
+
+        SetupWizard()._show_env_instructions("abcdWXYZabcdWXYZ")
+
+        out = capsys.readouterr().out
+        assert 'setx FMP_API_KEY "abcd...WXYZ"' in out
+        assert "abcdWXYZabcdWXYZ" not in out
+
+    @pytest.mark.parametrize(
+        ("system", "shell_file"), [("Darwin", "~/.zshrc"), ("Linux", "~/.bashrc")]
+    )
+    def test_posix_gets_the_right_rc_file(
+        self,
+        system: str,
+        shell_file: str,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setattr(platform, "system", lambda: system)
+
+        SetupWizard()._show_env_instructions("abcdWXYZabcdWXYZ")
+
+        out = capsys.readouterr().out
+        assert f"Add this line to your {shell_file}" in out
+        assert f"Then reload with: source {shell_file}" in out
+
+    def test_a_short_key_is_not_partially_revealed(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+
+        SetupWizard()._show_env_instructions("12345678")
+
+        out = capsys.readouterr().out
+        assert 'export FMP_API_KEY="[YOUR_API_KEY]"' in out
+        assert "12345678" not in out
+
+
+class TestChooseConfiguration:
+    """Profile selection, including the degenerate single-profile install."""
+
+    def test_a_lone_default_is_used_without_a_question(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr(
+            setup_mod, "get_manifest_choices", lambda: {"default": None}
+        )
+        prompts = feed_input(monkeypatch, [])
+        wizard = SetupWizard()
+
+        assert wizard.choose_configuration() is True
+        assert wizard.manifest_path is None
+        assert prompts == []
+        assert "\U0001f4a1 Using default configuration" in capsys.readouterr().out
+
+    def test_a_chosen_profile_becomes_the_manifest_path(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        choices = {
+            "default": None,
+            "minimal": "/opt/manifests/minimal_manifest.py",
+            "crypto": "/opt/manifests/crypto_manifest.py",
+        }
+        monkeypatch.setattr(setup_mod, "get_manifest_choices", lambda: choices)
+        monkeypatch.setattr(
+            setup_mod,
+            "load_manifest_tools",
+            lambda path: ["a", "b", "c"] if path else ["a"] * 40,
+        )
+        feed_input(monkeypatch, ["2"])
+        wizard = SetupWizard()
+
+        assert wizard.choose_configuration() is True
+        assert wizard.manifest_path == "/opt/manifests/minimal_manifest.py"
+        out = capsys.readouterr().out
+        assert "1. Default (40 tools) - Comprehensive toolkit" in out
+        assert "2. Minimal (3 tools) - Essential tools only" in out
+        assert "3. Crypto (3 tools) - Cryptocurrency focused" in out
+        assert "✅ Using minimal configuration" in out
+
+    def test_an_unreadable_manifest_only_costs_the_tool_count(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A broken example manifest must not abort profile selection."""
+        choices = {"default": None, "minimal": "/opt/manifests/minimal_manifest.py"}
+        monkeypatch.setattr(setup_mod, "get_manifest_choices", lambda: choices)
+
+        def explode(path: str | None) -> list[str]:
+            raise ValueError(f"cannot parse {path}")
+
+        monkeypatch.setattr(setup_mod, "load_manifest_tools", explode)
+        feed_input(monkeypatch, ["2"])
+        wizard = SetupWizard()
+
+        assert wizard.choose_configuration() is True
+        assert wizard.manifest_path == "/opt/manifests/minimal_manifest.py"
+        out = capsys.readouterr().out
+        assert "2. Minimal - Essential tools only" in out
+        assert "tools)" not in out
+
+    def test_picking_the_default_entry_leaves_the_manifest_unset(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        choices = {"default": None, "minimal": "/opt/manifests/minimal_manifest.py"}
+        monkeypatch.setattr(setup_mod, "get_manifest_choices", lambda: choices)
+        monkeypatch.setattr(setup_mod, "load_manifest_tools", lambda path: ["a"])
+        feed_input(monkeypatch, ["1"])
+        wizard = SetupWizard()
+
+        assert wizard.choose_configuration() is True
+        assert wizard.manifest_path is None
+        assert "✅ Using default configuration" in capsys.readouterr().out
+
+
+class TestFindPython:
+    """The interpreter probe -- the only subprocess the wizard spawns itself."""
+
+    @staticmethod
+    def _record(
+        monkeypatch: pytest.MonkeyPatch, result: Any
+    ) -> list[tuple[Any, dict[str, Any]]]:
+        calls: list[tuple[Any, dict[str, Any]]] = []
+
+        def fake_run(*args: Any, **kwargs: Any) -> Any:
+            calls.append((args[0], kwargs))
+            if isinstance(result, Exception):
+                raise result
+            return result
+
+        monkeypatch.setattr(setup_mod, "find_python_executable", lambda: "/opt/py")
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        return calls
+
+    def test_an_interpreter_that_imports_fmp_data_is_kept(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        calls = self._record(monkeypatch, SimpleNamespace(returncode=0))
+        wizard = SetupWizard()
+
+        assert wizard.find_python() is True
+        assert wizard.python_path == "/opt/py"
+        assert calls[0][0] == ["/opt/py", "-c", "import fmp_data"]
+        assert calls[0][1]["timeout"] == 5
+        assert "✅ Found Python: /opt/py" in capsys.readouterr().out
+
+    def test_an_interpreter_without_fmp_data_falls_back_to_the_current_one(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        self._record(monkeypatch, SimpleNamespace(returncode=1))
+        wizard = SetupWizard()
+
+        assert wizard.find_python() is True
+        assert wizard.python_path == sys.executable
+        assert "❌ Python can't import fmp_data" in capsys.readouterr().out
+
+    def test_a_probe_that_blows_up_falls_back_too(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        self._record(monkeypatch, OSError("no such executable"))
+        wizard = SetupWizard()
+
+        assert wizard.find_python() is True
+        assert wizard.python_path == sys.executable
+        assert "\U0001f4a1 Using current Python" in capsys.readouterr().out
+
+
+class TestUpdateClaudeConfig:
+    """The merge into ``claude_desktop_config.json``.
+
+    The real ``load_claude_config`` / ``save_claude_config`` run here; only
+    the *path* they resolve is redirected.
+    """
+
+    @staticmethod
+    def _ready() -> SetupWizard:
+        wizard = SetupWizard()
+        wizard.python_path = "/opt/py"
+        wizard.api_key = "FMP-API-KEY"  # pragma: allowlist secret
+        wizard.manifest_path = "/opt/manifests/minimal_manifest.py"
+        return wizard
+
+    def test_a_first_run_writes_a_complete_server_entry(
+        self,
+        claude_config: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        prompts = feed_input(monkeypatch, [])
+
+        assert self._ready().update_claude_config() is True
+
+        written = json.loads(claude_config.read_text(encoding="utf-8"))
+        assert written == {
+            "mcpServers": {
+                "fmp-data": {
+                    "command": "/opt/py",
+                    "args": ["-m", "fmp_data.mcp"],
+                    "env": {
+                        "FMP_API_KEY": "FMP-API-KEY",  # pragma: allowlist secret
+                        "FMP_MCP_MANIFEST": "/opt/manifests/minimal_manifest.py",
+                    },
+                }
+            }
+        }
+        assert prompts == []
+        out = capsys.readouterr().out
+        assert "\U0001f4a1 Creating new Claude configuration" in out
+        assert "Configuration saved to:" in out
+        assert "Backup created at:" not in out
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
+    def test_the_wizard_does_not_bypass_the_owner_only_writer(
+        self, claude_config: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The file holds an API key, so the wizard's path must be 0600 too."""
+        feed_input(monkeypatch, [])
+
+        assert self._ready().update_claude_config() is True
+        assert claude_config.stat().st_mode & 0o777 == 0o600
+
+    def test_unrelated_configuration_survives_the_merge(
+        self,
+        claude_config: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        claude_config.parent.mkdir(parents=True)
+        original = json.dumps(
+            {
+                "globalShortcut": "Alt+Space",
+                "mcpServers": {"other": {"command": "node", "args": ["x.js"]}},
+            },
+            indent=2,
+        )
+        claude_config.write_text(original, encoding="utf-8")
+        feed_input(monkeypatch, [])
+
+        assert self._ready().update_claude_config() is True
+
+        written = json.loads(claude_config.read_text(encoding="utf-8"))
+        assert written["globalShortcut"] == "Alt+Space"
+        assert written["mcpServers"]["other"] == {"command": "node", "args": ["x.js"]}
+        env = written["mcpServers"]["fmp-data"]["env"]
+        assert env["FMP_API_KEY"] == "FMP-API-KEY"  # pragma: allowlist secret
+
+        backups = list(claude_config.parent.glob("*.backup_*.json"))
+        assert len(backups) == 1
+        saved = json.loads(backups[0].read_text(encoding="utf-8"))
+        assert saved == json.loads(original)
+        assert "\U0001f4a1 Backup created at:" in capsys.readouterr().out
+
+    def test_declining_the_overwrite_leaves_the_file_byte_identical(
+        self, claude_config: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        claude_config.parent.mkdir(parents=True)
+        original = json.dumps(
+            {"mcpServers": {"fmp-data": {"command": "old", "env": {}}}}
+        )
+        claude_config.write_text(original, encoding="utf-8")
+        prompts = feed_input(monkeypatch, ["n"])
+
+        assert self._ready().update_claude_config() is False
+
+        assert claude_config.read_text(encoding="utf-8") == original
+        assert list(claude_config.parent.glob("*.backup_*.json")) == []
+        assert prompts == ["FMP Data server already configured. Overwrite? (y/n) [y]: "]
+
+    def test_accepting_the_overwrite_replaces_the_stored_key(
+        self, claude_config: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        claude_config.parent.mkdir(parents=True)
+        claude_config.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "fmp-data": {
+                            "command": "old",
+                            "env": {
+                                "FMP_API_KEY": "STALE",  # pragma: allowlist secret
+                            },
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        feed_input(monkeypatch, ["y"])
+
+        assert self._ready().update_claude_config() is True
+
+        server = json.loads(claude_config.read_text(encoding="utf-8"))["mcpServers"][
+            "fmp-data"
+        ]
+        assert server["command"] == "/opt/py"
+        assert server["env"] == {
+            "FMP_API_KEY": "FMP-API-KEY",  # pragma: allowlist secret
+            "FMP_MCP_MANIFEST": "/opt/manifests/minimal_manifest.py",
+        }
+
+    def test_no_manifest_means_no_manifest_variable(
+        self, claude_config: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        feed_input(monkeypatch, [])
+        wizard = self._ready()
+        wizard.manifest_path = None
+
+        assert wizard.update_claude_config() is True
+
+        server = json.loads(claude_config.read_text(encoding="utf-8"))["mcpServers"][
+            "fmp-data"
+        ]
+        expected_key = "FMP-API-KEY"  # pragma: allowlist secret
+        assert server["env"] == {"FMP_API_KEY": expected_key}
+
+    def test_a_missing_python_path_refuses_to_write_anything(
+        self,
+        claude_config: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        feed_input(monkeypatch, [])
+        wizard = self._ready()
+        wizard.python_path = None
+
+        assert wizard.update_claude_config() is False
+        assert not claude_config.exists()
+        assert "❌ Python path not set" in capsys.readouterr().out
+
+    def test_a_missing_api_key_refuses_to_write_anything(
+        self,
+        claude_config: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        feed_input(monkeypatch, [])
+        wizard = self._ready()
+        wizard.api_key = None
+
+        assert wizard.update_claude_config() is False
+        assert not claude_config.exists()
+        assert "❌ API key not set" in capsys.readouterr().out
+
+    def test_malformed_existing_json_is_not_swallowed(
+        self, claude_config: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Overwriting a hand-edited config on a parse error would lose it."""
+        claude_config.parent.mkdir(parents=True)
+        claude_config.write_text("{ not json", encoding="utf-8")
+        feed_input(monkeypatch, [])
+
+        with pytest.raises(json.JSONDecodeError):
+            self._ready().update_claude_config()
+
+        assert claude_config.read_text(encoding="utf-8") == "{ not json"
+
+    def test_a_json_document_that_is_not_an_object_is_rejected(
+        self, claude_config: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        claude_config.parent.mkdir(parents=True)
+        claude_config.write_text('["mcpServers"]', encoding="utf-8")
+        feed_input(monkeypatch, [])
+
+        with pytest.raises(TypeError, match="must be an object"):
+            self._ready().update_claude_config()
+
+
+class TestServerSmokeTest:
+    """``SetupWizard.test_server`` -- the pre-flight launch check."""
+
+    def test_without_a_key_the_check_is_skipped_rather_than_failed(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        calls = record_server_tests(monkeypatch, (True, "ok"))
+
+        assert SetupWizard().test_server() is True
+        assert calls == []
+        assert "⚠️  API key not set, skipping test" in capsys.readouterr().out
+
+    def test_a_passing_check_forwards_key_and_manifest(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        calls = record_server_tests(monkeypatch, (True, "MCP server test passed"))
+        wizard = SetupWizard()
+        wizard.api_key = "FMP-API-KEY"  # pragma: allowlist secret
+        wizard.manifest_path = "/opt/manifests/minimal_manifest.py"
+
+        assert wizard.test_server() is True
+        assert calls == [("FMP-API-KEY", "/opt/manifests/minimal_manifest.py")]
+        assert "✅ MCP server test passed" in capsys.readouterr().out
+
+    def test_a_failing_check_reports_redacted_and_says_it_is_not_fatal(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr(
+            setup_mod,
+            "test_mcp_server",
+            lambda key, manifest: (False, f"boot failed using {key}"),
+        )
+        wizard = SetupWizard()
+        wizard.api_key = "Kk1Kk2Kk3Kk4"  # pragma: allowlist secret
+
+        assert wizard.test_server() is False
+
+        out = capsys.readouterr().out
+        assert "Kk1Kk2Kk3Kk4" not in out
+        assert "❌ boot failed using [REDACTED]" in out
+        assert "may still work with Claude Desktop" in out
+
+
+class TestShowNextSteps:
+    def test_the_closing_screen_carries_the_platform_restart_recipe(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr(platform, "system", lambda: "Darwin")
+
+        SetupWizard().show_next_steps()
+
+        out = capsys.readouterr().out
+        # Current behaviour, warts and all: the title is passed as
+        # "\nSetup Complete!", so the header's rocket ends up alone on its
+        # own line inside the banner instead of leading the title.
+        assert "\U0001f680 \nSetup Complete!" in out
+        assert "1. Restart Claude Desktop completely" in out
+        assert "To restart Claude Desktop on macOS:" in out
+        assert "Cmd+Q" in out
+
+
+class TestRun:
+    """The whole wizard, end to end, with only the outside world faked."""
+
+    def test_a_successful_run_writes_the_config_and_returns_true(
+        self,
+        happy_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        prompts = feed_input(monkeypatch, ["y"])
+        wizard = SetupWizard()
+
+        assert wizard.run() is True
+
+        written = json.loads(happy_path.read_text(encoding="utf-8"))
+        assert written["mcpServers"]["fmp-data"] == {
+            "command": "/opt/py",
+            "args": ["-m", "fmp_data.mcp"],
+            "env": {"FMP_API_KEY": "ENV-API-KEY"},  # pragma: allowlist secret
+        }
+        assert prompts == ["Use API key from environment? (y/n) [y]: "]
+        assert "Setup Complete!" in capsys.readouterr().out
+
+    def test_failed_prerequisites_stop_before_any_question_about_keys(
+        self, happy_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(_compat, "mcp_server_available", lambda: False)
+        feed_input(monkeypatch, [])
+
+        assert SetupWizard().run() is False
+        assert not happy_path.exists()
+
+    def test_giving_up_on_the_api_key_cancels_the_run(
+        self,
+        happy_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setattr(setup_mod, "get_api_key_from_env", lambda: None)
+        monkeypatch.setattr(setup_mod, "validate_api_key", lambda key: (False, "nope"))
+        feed_secrets(monkeypatch, ["BADKEY"])
+        feed_input(monkeypatch, ["n"])
+
+        assert SetupWizard().run() is False
+        assert not happy_path.exists()
+        assert "⚠️  Setup cancelled" in capsys.readouterr().out
+
+    def test_a_failing_smoke_test_can_be_overridden(
+        self, happy_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            setup_mod, "test_mcp_server", lambda key, manifest: (False, "no server")
+        )
+        prompts = feed_input(monkeypatch, ["y", "y"])
+
+        assert SetupWizard().run() is True
+        assert happy_path.exists()
+        assert prompts[1] == "Continue with setup anyway? (y/n) [y]: "
+
+    def test_a_failing_smoke_test_can_also_end_the_run(
+        self, happy_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            setup_mod, "test_mcp_server", lambda key, manifest: (False, "no server")
+        )
+        feed_input(monkeypatch, ["y", "n"])
+
+        assert SetupWizard().run() is False
+        assert not happy_path.exists()
+
+    def test_refusing_to_overwrite_ends_the_run(
+        self, happy_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        happy_path.parent.mkdir(parents=True)
+        original = json.dumps({"mcpServers": {"fmp-data": {"command": "old"}}})
+        happy_path.write_text(original, encoding="utf-8")
+        feed_input(monkeypatch, ["y", "n"])
+
+        assert SetupWizard().run() is False
+
+        assert happy_path.read_text(encoding="utf-8") == original
+        assert list(happy_path.parent.glob("*.backup_*.json")) == []
+
+
+class TestRunSetup:
+    """The ``run_setup`` entry point: exit codes and crash handling."""
+
+    def test_success_exits_zero(
+        self, happy_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        feed_input(monkeypatch, ["y"])
+
+        assert run_setup() == 0
+
+        # The exit code alone would also be returned by a ``run_setup`` that
+        # never drove a wizard, so pin the side effect it is reporting on.
+        written = json.loads(happy_path.read_text(encoding="utf-8"))
+        assert written["mcpServers"]["fmp-data"]["env"] == {
+            "FMP_API_KEY": "ENV-API-KEY"  # pragma: allowlist secret
+        }
+
+    def test_quiet_mode_reaches_the_wizard(
+        self,
+        happy_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        feed_input(monkeypatch, ["y"])
+
+        assert run_setup(quiet=True) == 0
+        assert capsys.readouterr().out == ""
+        assert happy_path.exists()
+
+    def test_a_refused_run_exits_one(
+        self, happy_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(_compat, "mcp_server_available", lambda: False)
+        feed_input(monkeypatch, [])
+
+        assert run_setup() == 1
+        assert not happy_path.exists()
+
+    def test_ctrl_c_is_reported_as_a_cancellation(
+        self,
+        happy_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        def interrupt() -> bool:
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(setup_mod, "check_claude_desktop_installed", interrupt)
+
+        assert run_setup() == 1
+        assert "Setup cancelled by user" in capsys.readouterr().out
+        assert not happy_path.exists()
+
+    def test_an_unexpected_crash_is_reported_with_its_key_redacted(
+        self,
+        happy_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        def explode() -> bool:
+            raise RuntimeError("probe hit sk-abcdefgh12345678")
+
+        monkeypatch.setattr(setup_mod, "check_claude_desktop_installed", explode)
+
+        assert run_setup() == 1
+
+        out = capsys.readouterr().out
+        assert "❌ Setup failed: probe hit [REDACTED]" in out
+        assert "sk-abcdefgh12345678" not in out
+
+    def test_when_the_error_report_itself_fails_the_key_is_still_redacted(
+        self,
+        happy_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """The fallback wizard must inherit the key it has to hide.
+
+        ``ENV-API-KEY`` matches none of the key-shaped patterns, so only the
+        copied ``api_key`` can redact it here.
+        """
+
+        def explode() -> dict[str, str | None]:
+            raise RuntimeError("manifest scan died holding ENV-API-KEY")
+
+        monkeypatch.setattr(setup_mod, "get_manifest_choices", explode)
+        feed_input(monkeypatch, ["y"])
+        failed_once = break_first_error_report(monkeypatch)
+
+        assert run_setup() == 1
+
+        out = capsys.readouterr().out
+        assert failed_once, "the first error report never happened"
+        assert "Setup failed: manifest scan died holding [REDACTED]" in out
+        assert "ENV-API-KEY" not in out
+
+    def test_the_fallback_report_survives_a_crash_before_any_key_exists(
+        self,
+        happy_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """No key to copy is not a reason to lose the error message."""
+
+        def explode() -> bool:
+            raise RuntimeError("claude probe died")
+
+        monkeypatch.setattr(setup_mod, "check_claude_desktop_installed", explode)
+        failed_once = break_first_error_report(monkeypatch)
+
+        assert run_setup() == 1
+
+        out = capsys.readouterr().out
+        assert failed_once, "the first error report never happened"
+        assert "❌ Setup failed: claude probe died" in out

--- a/tests/unit/test_mcp_utils.py
+++ b/tests/unit/test_mcp_utils.py
@@ -1,0 +1,1350 @@
+"""Unit tests for ``fmp_data.mcp.utils``.
+
+Two things are pinned here.
+
+The first is FMP-SEC-001: a manifest is *data*. ``load_manifest_tools``
+parses a Python manifest with a restricted AST walk that accepts a
+docstring and a single module-level ``TOOLS = ["..."]`` assignment and
+nothing else. Every refusal case in ``REFUSAL_SOURCES`` is a manifest that
+would write a marker file if it were ever imported or ``exec``'d, so each
+case asserts both the refusal *and* the absence of the side effect. A
+regression that reintroduced ``exec``/``import`` would still raise for some
+of these shapes while silently running their payload -- the marker file is
+what makes that distinguishable from a genuine refusal.
+
+The second is the setup helper surface (config path, config load/save,
+interpreter discovery, subprocess-backed checks). Those functions decide
+where the tool writes and what it reports back to the user, so they are
+tested through fakes for the OS-facing collaborators only -- ``platform``,
+``os.environ``, ``subprocess.run``, ``Path.exists`` -- never by faking the
+function under test.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import platform
+import subprocess
+import sys
+from typing import Any
+
+import pytest
+
+from fmp_data.mcp import utils as mcp_utils
+
+POSIX_ONLY = pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
+#: ``os.geteuid`` is absent on Windows and skipif conditions are evaluated at
+#: import time, so a bare call would break collection there even under
+#: ``POSIX_ONLY``.
+NOT_ROOT = pytest.mark.skipif(
+    getattr(os, "geteuid", lambda: 1)() == 0,
+    reason="root ignores file permissions",
+)
+
+
+def _mode(path: Path) -> int:
+    return path.stat().st_mode & 0o777
+
+
+def _write_manifest(tmp_path: Path, name: str, source: str) -> Path:
+    path = tmp_path / name
+    path.write_text(source, encoding="utf-8")
+    return path
+
+
+class _FakeRun:
+    """Stand-in for ``subprocess.run`` that records how it was called."""
+
+    def __init__(
+        self,
+        returncode: int = 0,
+        stdout: str = "",
+        stderr: str = "",
+        raises: BaseException | None = None,
+    ) -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+        self.raises = raises
+        self.calls: list[tuple[list[str], dict[str, Any]]] = []
+
+    def __call__(
+        self, cmd: list[str], **kwargs: Any
+    ) -> subprocess.CompletedProcess[str]:
+        self.calls.append((cmd, kwargs))
+        if self.raises is not None:
+            raise self.raises
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=self.returncode,
+            stdout=self.stdout,
+            stderr=self.stderr,
+        )
+
+
+# ---------------------------------------------------------------------------
+# get_claude_config_path
+# ---------------------------------------------------------------------------
+
+
+class TestGetClaudeConfigPath:
+    def test_macos_path_is_under_application_support(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr(platform, "system", lambda: "Darwin")
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        assert mcp_utils.get_claude_config_path() == (
+            tmp_path
+            / "Library"
+            / "Application Support"
+            / "Claude"
+            / "claude_desktop_config.json"
+        )
+
+    def test_windows_path_is_under_appdata(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr(platform, "system", lambda: "Windows")
+        monkeypatch.setenv("APPDATA", str(tmp_path / "AppData"))
+
+        assert mcp_utils.get_claude_config_path() == (
+            tmp_path / "AppData" / "Claude" / "claude_desktop_config.json"
+        )
+
+    def test_windows_without_appdata_yields_a_relative_path(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Current behaviour: an unset APPDATA degrades to a CWD-relative path."""
+        monkeypatch.setattr(platform, "system", lambda: "Windows")
+        monkeypatch.delenv("APPDATA", raising=False)
+
+        result = mcp_utils.get_claude_config_path()
+
+        assert result == Path("Claude") / "claude_desktop_config.json"
+        assert not result.is_absolute()
+
+    def test_linux_path_is_under_dot_config(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        assert mcp_utils.get_claude_config_path() == (
+            tmp_path / ".config" / "Claude" / "claude_desktop_config.json"
+        )
+
+
+# ---------------------------------------------------------------------------
+# find_python_executable
+# ---------------------------------------------------------------------------
+
+
+class TestFindPythonExecutable:
+    def test_prefers_the_running_interpreter_without_probing(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        interpreter = tmp_path / "python3.13"
+        interpreter.write_text("#!/bin/sh\n", encoding="utf-8")
+        fake = _FakeRun()
+        monkeypatch.setattr(sys, "executable", str(interpreter))
+        monkeypatch.setattr(subprocess, "run", fake)
+
+        assert mcp_utils.find_python_executable() == str(interpreter)
+        assert fake.calls == []
+
+    def test_falls_back_to_first_command_which_resolves(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(sys, "executable", "")
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+        recorded: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            recorded.append(cmd)
+            if cmd[0] == "which":
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout="/usr/local/bin/python3\n/usr/bin/python3\n"
+                )
+            return subprocess.CompletedProcess(cmd, 0, stdout="Python 3.13.0\n")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        assert mcp_utils.find_python_executable() == "/usr/local/bin/python3"
+        assert recorded == [["python3", "--version"], ["which", "python3"]]
+
+    def test_skips_commands_that_are_not_installed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(sys, "executable", "")
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+        recorded: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            recorded.append(cmd)
+            if cmd[0] == "python3":
+                raise FileNotFoundError(cmd[0])
+            if cmd[0] == "which":
+                return subprocess.CompletedProcess(cmd, 0, stdout="/opt/bin/python\n")
+            return subprocess.CompletedProcess(cmd, 0, stdout="Python 3.12.0\n")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        assert mcp_utils.find_python_executable() == "/opt/bin/python"
+        assert recorded[0] == ["python3", "--version"]
+        assert ["which", "python"] in recorded
+
+    def test_skips_commands_whose_version_probe_fails(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(sys, "executable", "")
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+        recorded: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            recorded.append(cmd)
+            if cmd[0] == "python3":
+                return subprocess.CompletedProcess(cmd, 127, stdout="")
+            if cmd[0] == "which":
+                return subprocess.CompletedProcess(cmd, 0, stdout="/opt/bin/python\n")
+            return subprocess.CompletedProcess(cmd, 0, stdout="Python 3.12.0\n")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        assert mcp_utils.find_python_executable() == "/opt/bin/python"
+        assert ["which", "python3"] not in recorded
+
+    def test_uses_where_on_windows(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sys, "executable", "")
+        monkeypatch.setattr(platform, "system", lambda: "Windows")
+        recorded: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            recorded.append(cmd)
+            if cmd[0] == "where":
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout="C:\\Python\\python3.exe\n"
+                )
+            return subprocess.CompletedProcess(cmd, 0, stdout="Python 3.12.0\n")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        assert mcp_utils.find_python_executable() == "C:\\Python\\python3.exe"
+        assert ["where", "python3"] in recorded
+        assert not any(cmd[0] == "which" for cmd in recorded)
+
+    def test_defaults_to_python3_when_no_probe_resolves(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(sys, "executable", "")
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+        recorded: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            recorded.append(cmd)
+            if cmd[0] == "which":
+                return subprocess.CompletedProcess(cmd, 1, stdout="")
+            return subprocess.CompletedProcess(cmd, 0, stdout="Python 3.12.0\n")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        assert mcp_utils.find_python_executable() == "python3"
+        # The candidate list and its order are the contract: a version probe
+        # followed by a path resolution, most-preferred name first.
+        assert recorded == [
+            ["python3", "--version"],
+            ["which", "python3"],
+            ["python", "--version"],
+            ["which", "python"],
+            ["python3.10", "--version"],
+            ["which", "python3.10"],
+            ["python3.11", "--version"],
+            ["which", "python3.11"],
+            ["python3.12", "--version"],
+            ["which", "python3.12"],
+        ]
+
+    def test_defaults_to_python3_when_every_probe_errors(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(sys, "executable", "")
+        fake = _FakeRun(raises=subprocess.SubprocessError("no exec"))
+        monkeypatch.setattr(subprocess, "run", fake)
+
+        assert mcp_utils.find_python_executable() == "python3"
+        # Every candidate is still tried; a raising probe skips only itself.
+        assert [cmd for cmd, _ in fake.calls] == [
+            ["python3", "--version"],
+            ["python", "--version"],
+            ["python3.10", "--version"],
+            ["python3.11", "--version"],
+            ["python3.12", "--version"],
+        ]
+
+
+# ---------------------------------------------------------------------------
+# check_claude_desktop_installed
+# ---------------------------------------------------------------------------
+
+
+class TestCheckClaudeDesktopInstalled:
+    @staticmethod
+    def _only_these_exist(
+        monkeypatch: pytest.MonkeyPatch, existing: set[str]
+    ) -> list[str]:
+        """Make only *existing* report as present; return the probe log."""
+        probed: list[str] = []
+
+        def fake_exists(self: Path) -> bool:
+            probed.append(str(self))
+            return str(self) in existing
+
+        monkeypatch.setattr(Path, "exists", fake_exists)
+        return probed
+
+    def test_true_when_config_directory_exists(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        config = tmp_path / "Claude" / "claude_desktop_config.json"
+        monkeypatch.setattr(mcp_utils, "get_claude_config_path", lambda: config)
+        probed = self._only_these_exist(monkeypatch, {str(config.parent)})
+
+        assert mcp_utils.check_claude_desktop_installed() is True
+        # A present config dir short-circuits: no platform probe is needed.
+        assert probed == [str(config.parent)]
+
+    def test_true_on_macos_when_only_the_app_bundle_exists(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        config = tmp_path / "Claude" / "claude_desktop_config.json"
+        monkeypatch.setattr(mcp_utils, "get_claude_config_path", lambda: config)
+        monkeypatch.setattr(platform, "system", lambda: "Darwin")
+        self._only_these_exist(monkeypatch, {"/Applications/Claude.app"})
+
+        assert mcp_utils.check_claude_desktop_installed() is True
+
+    def test_false_on_macos_without_config_dir_or_app_bundle(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        config = tmp_path / "Claude" / "claude_desktop_config.json"
+        monkeypatch.setattr(mcp_utils, "get_claude_config_path", lambda: config)
+        monkeypatch.setattr(platform, "system", lambda: "Darwin")
+        self._only_these_exist(monkeypatch, set())
+
+        assert mcp_utils.check_claude_desktop_installed() is False
+
+    def test_true_on_windows_when_program_files_has_claude(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        config = tmp_path / "Claude" / "claude_desktop_config.json"
+        monkeypatch.setattr(mcp_utils, "get_claude_config_path", lambda: config)
+        monkeypatch.setattr(platform, "system", lambda: "Windows")
+        monkeypatch.setenv("ProgramFiles", str(tmp_path / "PF"))
+        self._only_these_exist(monkeypatch, {str(tmp_path / "PF" / "Claude")})
+
+        assert mcp_utils.check_claude_desktop_installed() is True
+
+    def test_windows_without_program_files_env_probes_the_documented_default(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """An unset ``ProgramFiles`` must fall back to ``C:\\Program Files``.
+
+        The bare Program Files directory existing is deliberately *not*
+        enough -- only a ``Claude`` subdirectory counts.
+        """
+        config = tmp_path / "Claude" / "claude_desktop_config.json"
+        monkeypatch.setattr(mcp_utils, "get_claude_config_path", lambda: config)
+        monkeypatch.setattr(platform, "system", lambda: "Windows")
+        monkeypatch.delenv("ProgramFiles", raising=False)
+        probed = self._only_these_exist(monkeypatch, {"C:\\Program Files"})
+
+        assert mcp_utils.check_claude_desktop_installed() is False
+        assert probed == [
+            str(config.parent),
+            str(Path("C:\\Program Files") / "Claude"),
+        ]
+
+    def test_false_on_linux_without_config_dir(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        config = tmp_path / "Claude" / "claude_desktop_config.json"
+        monkeypatch.setattr(mcp_utils, "get_claude_config_path", lambda: config)
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+        probed = self._only_these_exist(monkeypatch, {"/Applications/Claude.app"})
+
+        assert mcp_utils.check_claude_desktop_installed() is False
+        # Linux has no bundle fallback: the macOS app path is never consulted.
+        assert probed == [str(config.parent)]
+
+
+# ---------------------------------------------------------------------------
+# load_claude_config / save_claude_config
+# ---------------------------------------------------------------------------
+
+
+class TestLoadClaudeConfig:
+    def test_returns_parsed_object(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        config = tmp_path / "claude_desktop_config.json"
+        config.write_text('{"mcpServers": {"fmp": {"command": "py"}}}', "utf-8")
+        monkeypatch.setattr(mcp_utils, "get_claude_config_path", lambda: config)
+
+        assert mcp_utils.load_claude_config() == {
+            "mcpServers": {"fmp": {"command": "py"}}
+        }
+
+    def test_returns_empty_dict_when_file_is_absent(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        config = tmp_path / "missing" / "claude_desktop_config.json"
+        monkeypatch.setattr(mcp_utils, "get_claude_config_path", lambda: config)
+
+        assert mcp_utils.load_claude_config() == {}
+
+    def test_rejects_a_json_array(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        config = tmp_path / "claude_desktop_config.json"
+        config.write_text('["not", "an", "object"]', "utf-8")
+        monkeypatch.setattr(mcp_utils, "get_claude_config_path", lambda: config)
+
+        with pytest.raises(TypeError, match="must be an object"):
+            mcp_utils.load_claude_config()
+
+    def test_propagates_invalid_json(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        config = tmp_path / "claude_desktop_config.json"
+        config.write_text("{not json", "utf-8")
+        monkeypatch.setattr(mcp_utils, "get_claude_config_path", lambda: config)
+
+        with pytest.raises(json.JSONDecodeError):
+            mcp_utils.load_claude_config()
+
+
+class TestSaveClaudeConfig:
+    def test_writes_indented_json_with_trailing_newline(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        config = tmp_path / "Claude" / "claude_desktop_config.json"
+        monkeypatch.setattr(mcp_utils, "get_claude_config_path", lambda: config)
+        payload = {"mcpServers": {"fmp-data": {"args": ["-m", "fmp_data.mcp"]}}}
+
+        backup = mcp_utils.save_claude_config(payload, backup=False)
+
+        assert backup is None
+        assert (
+            config.read_text(encoding="utf-8") == json.dumps(payload, indent=2) + "\n"
+        )
+
+    def test_backup_keeps_the_previous_contents(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        config = tmp_path / "Claude" / "claude_desktop_config.json"
+        config.parent.mkdir()
+        config.write_text('{"mcpServers": {"old": {}}}\n', encoding="utf-8")
+        monkeypatch.setattr(mcp_utils, "get_claude_config_path", lambda: config)
+
+        backup = mcp_utils.save_claude_config({"mcpServers": {"new": {}}})
+
+        assert backup is not None
+        assert json.loads(backup.read_text()) == {"mcpServers": {"old": {}}}
+        assert json.loads(config.read_text()) == {"mcpServers": {"new": {}}}
+        assert backup.name.startswith("claude_desktop_config.backup_")
+
+    def test_backup_is_skipped_when_no_config_exists_yet(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        config = tmp_path / "Claude" / "claude_desktop_config.json"
+        monkeypatch.setattr(mcp_utils, "get_claude_config_path", lambda: config)
+
+        backup = mcp_utils.save_claude_config({"a": 1}, backup=True)
+
+        assert backup is None
+        assert [p.name for p in config.parent.iterdir()] == [config.name]
+
+    def test_unserialisable_payload_leaves_no_partial_file(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        config = tmp_path / "Claude" / "claude_desktop_config.json"
+        monkeypatch.setattr(mcp_utils, "get_claude_config_path", lambda: config)
+
+        with pytest.raises(TypeError):
+            mcp_utils.save_claude_config({"handle": object()}, backup=False)
+
+        assert not config.exists()
+        assert list(config.parent.iterdir()) == []
+
+    def test_a_failed_write_does_not_truncate_the_previous_config(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The temp-file-then-``os.replace`` path, stated as behaviour.
+
+        A direct ``open(path, "w")`` implementation would empty the file
+        before ``json.dump`` raised, so this is what makes the write atomic
+        rather than merely tidy.
+        """
+        config = tmp_path / "Claude" / "claude_desktop_config.json"
+        config.parent.mkdir()
+        config.write_text('{"mcpServers": {"old": {}}}\n', encoding="utf-8")
+        monkeypatch.setattr(mcp_utils, "get_claude_config_path", lambda: config)
+
+        with pytest.raises(TypeError):
+            mcp_utils.save_claude_config({"handle": object()}, backup=False)
+
+        assert json.loads(config.read_text()) == {"mcpServers": {"old": {}}}
+        assert [p.name for p in config.parent.iterdir()] == [config.name]
+
+
+class TestChmodUserOnly:
+    @POSIX_ONLY
+    def test_narrows_mode_to_owner_only(self, tmp_path: Path) -> None:
+        target = tmp_path / "cfg.json"
+        target.write_text("{}", encoding="utf-8")
+        os.chmod(target, 0o644)
+
+        mcp_utils._chmod_user_only(target, 0o600)
+
+        assert _mode(target) == 0o600
+
+    @POSIX_ONLY
+    def test_is_a_no_op_on_windows(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        target = tmp_path / "cfg.json"
+        target.write_text("{}", encoding="utf-8")
+        os.chmod(target, 0o644)
+        monkeypatch.setattr(os, "name", "nt")
+
+        mcp_utils._chmod_user_only(target, 0o600)
+
+        assert _mode(target) == 0o644
+
+    @POSIX_ONLY
+    def test_swallows_oserror_from_chmod(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        target = tmp_path / "cfg.json"
+        target.write_text("{}", encoding="utf-8")
+        os.chmod(target, 0o644)
+        attempts: list[tuple[Any, int]] = []
+
+        def boom(path: Any, mode: int, *args: Any, **kwargs: Any) -> None:
+            attempts.append((path, mode))
+            raise OSError("read-only filesystem")
+
+        monkeypatch.setattr(os, "chmod", boom)
+
+        mcp_utils._chmod_user_only(target, 0o600)  # must not propagate
+
+        # Without this the test would also pass for an implementation that
+        # never attempted the chmod at all.
+        assert attempts == [(target, 0o600)]
+        assert _mode(target) == 0o644
+
+
+# ---------------------------------------------------------------------------
+# add_mcp_server_to_config
+# ---------------------------------------------------------------------------
+
+
+class TestAddMcpServerToConfig:
+    def test_creates_the_servers_section(self) -> None:
+        config: dict[str, Any] = {}
+
+        result = mcp_utils.add_mcp_server_to_config(
+            config, "fmp-data", "/usr/bin/python3", "KEY123"
+        )
+
+        assert result is config
+        assert result["mcpServers"]["fmp-data"] == {
+            "command": "/usr/bin/python3",
+            "args": ["-m", "fmp_data.mcp"],
+            "env": {"FMP_API_KEY": "KEY123"},  # pragma: allowlist secret
+        }
+
+    def test_manifest_path_is_passed_through_the_environment(self) -> None:
+        result = mcp_utils.add_mcp_server_to_config(
+            {}, "fmp-data", "python3", "KEY123", manifest_path="/etc/tools.json"
+        )
+
+        assert result["mcpServers"]["fmp-data"]["env"] == {
+            "FMP_API_KEY": "KEY123",  # pragma: allowlist secret
+            "FMP_MCP_MANIFEST": "/etc/tools.json",
+        }
+
+    def test_omits_the_manifest_variable_when_not_given(self) -> None:
+        result = mcp_utils.add_mcp_server_to_config({}, "fmp", "python3", "K")
+
+        assert "FMP_MCP_MANIFEST" not in result["mcpServers"]["fmp"]["env"]
+
+    def test_preserves_other_servers_and_replaces_its_own(self) -> None:
+        config = {
+            "mcpServers": {
+                "other": {"command": "node"},
+                "fmp-data": {
+                    "command": "stale",
+                    "env": {"FMP_API_KEY": "OLD"},  # pragma: allowlist secret
+                },
+            },
+            "unrelated": True,
+        }
+
+        result = mcp_utils.add_mcp_server_to_config(
+            config, "fmp-data", "python3", "NEW"
+        )
+
+        assert result["mcpServers"]["other"] == {"command": "node"}
+        assert result["unrelated"] is True
+        assert result["mcpServers"]["fmp-data"] == {
+            "command": "python3",
+            "args": ["-m", "fmp_data.mcp"],
+            "env": {"FMP_API_KEY": "NEW"},  # pragma: allowlist secret
+        }
+
+
+# ---------------------------------------------------------------------------
+# test_mcp_server (aliased: the source name would be collected by pytest)
+# ---------------------------------------------------------------------------
+
+run_mcp_server_check = mcp_utils.test_mcp_server
+
+
+class TestRunMcpServerCheck:
+    def test_reports_success_and_passes_the_key_by_environment(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FMP_API_KEY", raising=False)
+        monkeypatch.delenv("FMP_MCP_MANIFEST", raising=False)
+        fake = _FakeRun(returncode=0, stdout="Server initialized successfully\n")
+        monkeypatch.setattr(subprocess, "run", fake)
+
+        assert run_mcp_server_check("KEY123") == (True, "MCP server test passed")
+
+        cmd, kwargs = fake.calls[0]
+        assert cmd[0] == sys.executable
+        # The probe has to actually build the app; a bare `print()` would
+        # satisfy a test that only looked at the interpreter and the env.
+        assert cmd[1] == "-c"
+        assert "from fmp_data.mcp.server import create_app" in cmd[2]
+        assert "create_app()" in cmd[2]
+        assert kwargs["env"]["FMP_API_KEY"] == "KEY123"  # pragma: allowlist secret
+        assert "FMP_MCP_MANIFEST" not in kwargs["env"]
+        assert kwargs["timeout"] == 5
+        # stderr is reported verbatim on failure, so decoded output is part
+        # of the contract, not an incidental kwarg.
+        assert kwargs["capture_output"] is True
+        assert kwargs["text"] is True
+        assert "FMP_API_KEY" not in os.environ
+
+    def test_forwards_the_manifest_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.delenv("FMP_MCP_MANIFEST", raising=False)
+        fake = _FakeRun(returncode=0)
+        monkeypatch.setattr(subprocess, "run", fake)
+        manifest = str(tmp_path / "tools.yaml")
+
+        assert run_mcp_server_check("KEY123", manifest_path=manifest) == (
+            True,
+            "MCP server test passed",
+        )
+
+        env = fake.calls[0][1]["env"]
+        assert env["FMP_MCP_MANIFEST"] == manifest
+        assert env["FMP_API_KEY"] == "KEY123"  # pragma: allowlist secret
+        assert "FMP_MCP_MANIFEST" not in os.environ
+
+    def test_reports_stderr_on_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            subprocess, "run", _FakeRun(returncode=1, stderr="  ImportError: mcp  ")
+        )
+
+        assert run_mcp_server_check("KEY123") == (
+            False,
+            "MCP server test failed: ImportError: mcp",
+        )
+
+    def test_reports_unknown_error_when_stderr_is_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(subprocess, "run", _FakeRun(returncode=2, stderr=""))
+
+        assert run_mcp_server_check("KEY123") == (
+            False,
+            "MCP server test failed: Unknown error",
+        )
+
+    def test_timeout_counts_as_a_started_server(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            _FakeRun(raises=subprocess.TimeoutExpired(cmd="py", timeout=5)),
+        )
+
+        assert run_mcp_server_check("KEY123") == (
+            True,
+            "MCP server test passed (server started)",
+        )
+
+    def test_unexpected_exception_is_reported_not_raised(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            subprocess, "run", _FakeRun(raises=OSError("no such executable"))
+        )
+
+        assert run_mcp_server_check("KEY123") == (
+            False,
+            "MCP server test failed: no such executable",
+        )
+
+
+# ---------------------------------------------------------------------------
+# get_api_key_from_env / validate_api_key
+# ---------------------------------------------------------------------------
+
+
+class TestGetApiKeyFromEnv:
+    def test_returns_the_environment_value(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("FMP_API_KEY", "KEY123")
+
+        assert mcp_utils.get_api_key_from_env() == "KEY123"
+
+    def test_returns_none_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("FMP_API_KEY", raising=False)
+
+        assert mcp_utils.get_api_key_from_env() is None
+
+
+class TestValidateApiKey:
+    def test_valid_key_reports_success_and_never_leaks_into_os_environ(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FMP_API_KEY", raising=False)
+        fake = _FakeRun(returncode=0, stdout="API key is valid\n")
+        monkeypatch.setattr(subprocess, "run", fake)
+
+        assert mcp_utils.validate_api_key("KEY123") == (True, "API key is valid")
+
+        cmd, kwargs = fake.calls[0]
+        assert cmd[0] == sys.executable
+        # The probe must build a client from the environment -- otherwise a
+        # key that never reaches FMP would still be reported "valid".
+        assert cmd[1] == "-c"
+        assert "from fmp_data import FMPDataClient" in cmd[2]
+        assert "FMPDataClient.from_env()" in cmd[2]
+        assert kwargs["env"]["FMP_API_KEY"] == "KEY123"  # pragma: allowlist secret
+        assert kwargs["timeout"] == 10
+        assert kwargs["capture_output"] is True
+        assert kwargs["text"] is True
+        assert "FMP_API_KEY" not in os.environ
+
+    @pytest.mark.parametrize("status", ["401", "403"])
+    def test_auth_status_codes_map_to_an_invalid_key_message(
+        self, monkeypatch: pytest.MonkeyPatch, status: str
+    ) -> None:
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            _FakeRun(returncode=1, stderr=f"AuthenticationError: {status} for url"),
+        )
+
+        assert mcp_utils.validate_api_key("BAD") == (
+            False,
+            "API key is invalid or expired",
+        )
+
+    def test_other_failures_surface_stderr(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            subprocess, "run", _FakeRun(returncode=1, stderr="ConnectionError: dns\n")
+        )
+
+        assert mcp_utils.validate_api_key("KEY123") == (
+            False,
+            "API key validation failed: ConnectionError: dns",
+        )
+
+    def test_empty_stderr_falls_back_to_invalid_key_text(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(subprocess, "run", _FakeRun(returncode=1, stderr=""))
+
+        assert mcp_utils.validate_api_key("KEY123") == (
+            False,
+            "API key validation failed: Invalid API key",
+        )
+
+    def test_timeout_is_reported_as_a_timeout(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            _FakeRun(raises=subprocess.TimeoutExpired(cmd="py", timeout=10)),
+        )
+
+        assert mcp_utils.validate_api_key("KEY123") == (
+            False,
+            "API key validation timed out",
+        )
+
+    def test_unexpected_exception_is_reported_not_raised(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            subprocess, "run", _FakeRun(raises=OSError("exec format error"))
+        )
+
+        assert mcp_utils.validate_api_key("KEY123") == (
+            False,
+            "API key validation failed: exec format error",
+        )
+
+
+# ---------------------------------------------------------------------------
+# get_manifest_choices
+# ---------------------------------------------------------------------------
+
+
+#: Every advertised manifest choice and the file it must come from. Pinning
+#: the whole table matters: a test that seeded only two names would keep
+#: passing if the other two were dropped from the mapping.
+EXAMPLE_MANIFESTS: dict[str, str] = {
+    "minimal": "minimal_manifest.py",
+    "trading": "trading_manifest.py",
+    "research": "research_manifest.py",
+    "crypto": "crypto_manifest.py",
+}
+
+
+class TestGetManifestChoices:
+    @staticmethod
+    def _redirect_examples_root(
+        monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> Path:
+        monkeypatch.setattr(
+            mcp_utils, "__file__", str(tmp_path / "fmp_data" / "mcp" / "utils.py")
+        )
+        return tmp_path / "examples" / "mcp_configurations"
+
+    @pytest.mark.parametrize("name", sorted(EXAMPLE_MANIFESTS))
+    def test_each_choice_maps_to_its_own_file_and_only_when_present(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, name: str
+    ) -> None:
+        examples = self._redirect_examples_root(monkeypatch, tmp_path)
+        examples.mkdir(parents=True)
+        target = examples / EXAMPLE_MANIFESTS[name]
+        target.write_text("TOOLS = []\n", encoding="utf-8")
+
+        assert mcp_utils.get_manifest_choices() == {
+            "default": None,
+            name: str(target),
+        }
+
+    def test_all_choices_are_offered_when_every_example_exists(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        examples = self._redirect_examples_root(monkeypatch, tmp_path)
+        examples.mkdir(parents=True)
+        for filename in EXAMPLE_MANIFESTS.values():
+            (examples / filename).write_text("TOOLS = []\n", encoding="utf-8")
+
+        assert mcp_utils.get_manifest_choices() == {
+            "default": None,
+            **{
+                name: str(examples / filename)
+                for name, filename in EXAMPLE_MANIFESTS.items()
+            },
+        }
+
+    def test_only_default_when_the_examples_tree_is_absent(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        self._redirect_examples_root(monkeypatch, tmp_path)
+
+        assert mcp_utils.get_manifest_choices() == {"default": None}
+
+
+# ---------------------------------------------------------------------------
+# FMP-SEC-001: a Python manifest is parsed as data, never executed
+# ---------------------------------------------------------------------------
+
+#: Manifest shapes the restricted parser must refuse. Each one writes
+#: ``MARKER`` if it is ever executed, so the absence of that file is the
+#: actual security assertion; the raise alone would not distinguish a
+#: refusal from a refusal-after-payload.
+#:
+#: ``subscript`` and ``dunder_attribute`` look redundant but are not: CPython
+#: exposes ``__builtins__`` as a dict in some execution contexts and as the
+#: module in others, and only one reach-the-``open`` spelling works in each.
+REFUSAL_SOURCES: dict[str, str] = {
+    "lambda": "TOOLS = [(lambda p: open(p, 'w').write('RAN'))(MARKER)]\n",
+    "list_comprehension": "TOOLS = [open(p, 'w').write('RAN') for p in [MARKER]]\n",
+    "generator_expression": (
+        "TOOLS = list(open(p, 'w').write('RAN') for p in [MARKER])\n"
+    ),
+    "starred_expression": "TOOLS = [*[open(MARKER, 'w').write('RAN')]]\n",
+    "subscript": "TOOLS = [__builtins__['open'](MARKER, 'w').write('RAN')]\n",
+    "dunder_attribute": (
+        "TOOLS = [__builtins__.__dict__['open'](MARKER, 'w').write('RAN')]\n"
+    ),
+    "walrus": "TOOLS = [(_p := open(MARKER, 'w').write('RAN'))]\n",
+    "ternary": (
+        "TOOLS = ['company.profile'] if open(MARKER, 'w').write('RAN') else []\n"
+    ),
+    "decorated_function": (
+        "def _deco(fn):\n"
+        "    open(MARKER, 'w').write('RAN')\n"
+        "    return fn\n"
+        "\n"
+        "@_deco\n"
+        "def hook():\n"
+        "    return None\n"
+        "\n"
+        "TOOLS = ['company.profile']\n"
+    ),
+    "class_body": (
+        "class Boom:\n"
+        "    open(MARKER, 'w').write('RAN')\n"
+        "\n"
+        "TOOLS = ['company.profile']\n"
+    ),
+    "augmented_assignment": (
+        "TOOLS = ['company.profile']\nTOOLS += [open(MARKER, 'w').write('RAN')]\n"
+    ),
+    "multiple_targets": "TOOLS = OTHER = [open(MARKER, 'w').write('RAN')]\n",
+    "if_statement": (
+        "if True:\n    open(MARKER, 'w').write('RAN')\n\nTOOLS = ['company.profile']\n"
+    ),
+    "for_loop": (
+        "for _ in [1]:\n"
+        "    open(MARKER, 'w').write('RAN')\n"
+        "\n"
+        "TOOLS = ['company.profile']\n"
+    ),
+    "with_statement": (
+        "with open(MARKER, 'w') as fh:\n"
+        "    fh.write('RAN')\n"
+        "\n"
+        "TOOLS = ['company.profile']\n"
+    ),
+    "try_except": (
+        "try:\n"
+        "    open(MARKER, 'w').write('RAN')\n"
+        "except OSError:\n"
+        "    pass\n"
+        "\n"
+        "TOOLS = ['company.profile']\n"
+    ),
+}
+
+
+class TestPythonManifestIsParsedAsData:
+    @pytest.mark.parametrize("shape", sorted(REFUSAL_SOURCES))
+    def test_refuses_the_shape_without_running_its_payload(
+        self, tmp_path: Path, shape: str
+    ) -> None:
+        marker = tmp_path / f"{shape}.ran"
+        source = REFUSAL_SOURCES[shape].replace("MARKER", repr(str(marker)))
+        manifest = _write_manifest(tmp_path, f"{shape}.py", source)
+
+        with pytest.raises(ValueError) as excinfo:
+            mcp_utils.load_manifest_tools(manifest)
+
+        assert "does not execute" in str(excinfo.value)
+        assert str(manifest) in str(excinfo.value)
+        assert not marker.exists()
+
+    def test_refuses_a_second_tools_assignment(self, tmp_path: Path) -> None:
+        manifest = _write_manifest(
+            tmp_path,
+            "twice.py",
+            "TOOLS = ['company.profile']\nTOOLS = ['market.gainers']\n",
+        )
+
+        with pytest.raises(ValueError) as excinfo:
+            mcp_utils.load_manifest_tools(manifest)
+
+        assert "assigned more than once" in str(excinfo.value)
+
+    def test_refuses_an_annotated_tools_assignment(self, tmp_path: Path) -> None:
+        """Current behaviour: ``TOOLS: list[str] = [...]`` is not accepted."""
+        manifest = _write_manifest(
+            tmp_path, "annotated.py", "TOOLS: list[str] = ['company.profile']\n"
+        )
+
+        with pytest.raises(ValueError) as excinfo:
+            mcp_utils.load_manifest_tools(manifest)
+
+        assert "only a docstring and TOOLS" in str(excinfo.value)
+
+    @pytest.mark.parametrize(
+        ("shape", "source"),
+        [
+            ("string", "TOOLS = 'company.profile'\n"),
+            ("tuple", "TOOLS = ('company.profile',)\n"),
+            ("concatenation", "TOOLS = ['company.profile'] + ['market.gainers']\n"),
+            ("name_reference", "TOOLS = OTHER_TOOLS\n"),
+            ("attribute", "TOOLS = catalog.tools\n"),
+            ("dict", "TOOLS = {'company': 'profile'}\n"),
+        ],
+    )
+    def test_tools_must_be_a_list_literal(
+        self, tmp_path: Path, shape: str, source: str
+    ) -> None:
+        manifest = _write_manifest(tmp_path, f"{shape}.py", source)
+
+        with pytest.raises(ValueError) as excinfo:
+            mcp_utils.load_manifest_tools(manifest)
+
+        assert "TOOLS must be a list of string literals" in str(excinfo.value)
+
+    @pytest.mark.parametrize(
+        ("shape", "source"),
+        [
+            ("integer", "TOOLS = [1]\n"),
+            ("none", "TOOLS = [None]\n"),
+            ("bytes", "TOOLS = [b'company.profile']\n"),
+            ("empty_string", "TOOLS = ['']\n"),
+            ("nested_list", "TOOLS = [['company.profile']]\n"),
+            ("name", "TOOLS = [company_profile]\n"),
+        ],
+    )
+    def test_elements_must_be_non_empty_string_literals(
+        self, tmp_path: Path, shape: str, source: str
+    ) -> None:
+        manifest = _write_manifest(tmp_path, f"element_{shape}.py", source)
+
+        with pytest.raises(ValueError) as excinfo:
+            mcp_utils.load_manifest_tools(manifest)
+
+        assert "TOOLS must contain only non-empty string literals" in str(excinfo.value)
+
+    def test_syntax_error_is_reported_as_an_invalid_manifest(
+        self, tmp_path: Path
+    ) -> None:
+        manifest = _write_manifest(tmp_path, "broken.py", "TOOLS = [\n")
+
+        with pytest.raises(ValueError) as excinfo:
+            mcp_utils.load_manifest_tools(manifest)
+
+        assert str(excinfo.value).startswith(f"Invalid Python manifest {manifest}")
+        assert isinstance(excinfo.value.__cause__, SyntaxError)
+
+    def test_docstring_is_allowed_and_empty_tools_is_accepted(
+        self, tmp_path: Path
+    ) -> None:
+        manifest = _write_manifest(
+            tmp_path, "empty.py", '"""Nothing enabled."""\n\nTOOLS = []\n'
+        )
+
+        assert mcp_utils.load_manifest_tools(manifest) == []
+
+    def test_duplicate_entries_are_returned_verbatim(self, tmp_path: Path) -> None:
+        manifest = _write_manifest(
+            tmp_path,
+            "dupes.py",
+            "TOOLS = ['company.profile', 'company.profile', 'market.gainers']\n",
+        )
+
+        assert mcp_utils.load_manifest_tools(manifest) == [
+            "company.profile",
+            "company.profile",
+            "market.gainers",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# JSON / YAML / TOML manifests
+# ---------------------------------------------------------------------------
+
+
+class TestDataManifestFormats:
+    def test_json_suffix_match_is_case_insensitive(self, tmp_path: Path) -> None:
+        manifest = _write_manifest(tmp_path, "tools.JSON", '["company.profile"]\n')
+
+        assert mcp_utils.load_manifest_tools(manifest) == ["company.profile"]
+
+    def test_malformed_json_is_wrapped(self, tmp_path: Path) -> None:
+        manifest = _write_manifest(tmp_path, "tools.json", "{not json\n")
+
+        with pytest.raises(ValueError) as excinfo:
+            mcp_utils.load_manifest_tools(manifest)
+
+        assert str(excinfo.value).startswith(f"Invalid JSON manifest {manifest}")
+        assert isinstance(excinfo.value.__cause__, json.JSONDecodeError)
+
+    def test_json_object_without_tools_key_is_rejected(self, tmp_path: Path) -> None:
+        manifest = _write_manifest(tmp_path, "tools.json", '{"enabled": ["a"]}\n')
+
+        with pytest.raises(ValueError) as excinfo:
+            mcp_utils.load_manifest_tools(manifest)
+
+        assert "must be a list of tool specs or an object with a 'tools' list" in str(
+            excinfo.value
+        )
+
+    def test_tools_key_must_hold_a_list(self, tmp_path: Path) -> None:
+        manifest = _write_manifest(
+            tmp_path, "tools.json", '{"tools": "company.profile"}\n'
+        )
+
+        with pytest.raises(ValueError) as excinfo:
+            mcp_utils.load_manifest_tools(manifest)
+
+        assert "'tools' must be a list of strings" in str(excinfo.value)
+
+    @pytest.mark.parametrize(
+        ("shape", "payload"),
+        [
+            ("integer", '["company.profile", 7]'),
+            ("null", '["company.profile", null]'),
+            ("empty_string", '["company.profile", ""]'),
+            ("nested", '[["company.profile"]]'),
+        ],
+    )
+    def test_json_entries_must_be_non_empty_strings(
+        self, tmp_path: Path, shape: str, payload: str
+    ) -> None:
+        manifest = _write_manifest(tmp_path, f"{shape}.json", payload)
+
+        with pytest.raises(ValueError) as excinfo:
+            mcp_utils.load_manifest_tools(manifest)
+
+        assert "every tool spec must be a non-empty string" in str(excinfo.value)
+
+    def test_duplicate_entries_are_returned_verbatim(self, tmp_path: Path) -> None:
+        """Symmetry with the Python path: the parser must not dedupe.
+
+        Listing one tool twice is an error the *loader* reports (#162). A
+        parser that quietly collapsed duplicates would swallow it, and no
+        other assertion here would notice.
+        """
+        manifest = _write_manifest(
+            tmp_path,
+            "dupes.json",
+            '["company.profile", "company.profile", "market.gainers"]',
+        )
+
+        assert mcp_utils.load_manifest_tools(manifest) == [
+            "company.profile",
+            "company.profile",
+            "market.gainers",
+        ]
+
+    def test_yaml_top_level_list(self, tmp_path: Path) -> None:
+        """The ``.yaml`` suffix really routes to the YAML parser.
+
+        The comment and unquoted scalars are YAML-only, so a routing bug
+        that fell through to JSON (or to the Python parser) would raise
+        instead of returning these entries.
+        """
+        manifest = _write_manifest(
+            tmp_path,
+            "tools.yaml",
+            "# enabled tools\n- company.profile\n- market.gainers\n",
+        )
+
+        assert mcp_utils.load_manifest_tools(manifest) == [
+            "company.profile",
+            "market.gainers",
+        ]
+
+    def test_malformed_yaml_is_wrapped(self, tmp_path: Path) -> None:
+        yaml = pytest.importorskip("yaml")
+        manifest = _write_manifest(tmp_path, "tools.yaml", "tools: [unclosed\n")
+
+        with pytest.raises(ValueError) as excinfo:
+            mcp_utils.load_manifest_tools(manifest)
+
+        assert str(excinfo.value).startswith(f"Invalid YAML manifest {manifest}")
+        assert isinstance(excinfo.value.__cause__, yaml.YAMLError)
+
+    def test_empty_yaml_document_is_rejected(self, tmp_path: Path) -> None:
+        manifest = _write_manifest(tmp_path, "tools.yaml", "\n")
+
+        with pytest.raises(ValueError) as excinfo:
+            mcp_utils.load_manifest_tools(manifest)
+
+        assert "must be a list of tool specs" in str(excinfo.value)
+
+    def test_yaml_does_not_construct_arbitrary_objects(self, tmp_path: Path) -> None:
+        """``safe_load`` refuses python/object tags (no ``yaml.load``)."""
+        marker = tmp_path / "pwned"
+        manifest = _write_manifest(
+            tmp_path,
+            "unsafe.yaml",
+            f"tools: !!python/object/apply:os.system ['touch {marker}']\n",
+        )
+
+        with pytest.raises(ValueError) as excinfo:
+            mcp_utils.load_manifest_tools(manifest)
+
+        assert "Invalid YAML manifest" in str(excinfo.value)
+        assert not marker.exists()
+
+    def test_malformed_toml_is_wrapped(self, tmp_path: Path) -> None:
+        manifest = _write_manifest(tmp_path, "tools.toml", "tools = [\n")
+
+        with pytest.raises(ValueError) as excinfo:
+            mcp_utils.load_manifest_tools(manifest)
+
+        assert str(excinfo.value).startswith(f"Invalid TOML manifest {manifest}")
+
+    def test_toml_entries_must_be_strings(self, tmp_path: Path) -> None:
+        manifest = _write_manifest(tmp_path, "tools.toml", "tools = [1, 2]\n")
+
+        with pytest.raises(ValueError) as excinfo:
+            mcp_utils.load_manifest_tools(manifest)
+
+        assert "every tool spec must be a non-empty string" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# path handling
+# ---------------------------------------------------------------------------
+
+
+class TestManifestPathHandling:
+    def test_missing_file_raises_with_the_resolved_path(self, tmp_path: Path) -> None:
+        missing = tmp_path / "nope.json"
+
+        with pytest.raises(FileNotFoundError) as excinfo:
+            mcp_utils.load_manifest_tools(missing)
+
+        assert str(excinfo.value) == f"Manifest file not found: {missing.resolve()}"
+
+    def test_a_directory_is_not_a_manifest(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError, match="Manifest file not found"):
+            mcp_utils.load_manifest_tools(tmp_path)
+
+    def test_tilde_is_expanded_before_the_lookup(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        (tmp_path / "tools.json").write_text('["company.profile"]', encoding="utf-8")
+
+        assert mcp_utils.load_manifest_tools("~/tools.json") == ["company.profile"]
+
+    @POSIX_ONLY
+    @NOT_ROOT
+    def test_unreadable_manifest_raises_permission_error(self, tmp_path: Path) -> None:
+        manifest = _write_manifest(tmp_path, "secret.json", '["company.profile"]')
+        manifest.chmod(0o000)
+
+        try:
+            with pytest.raises(PermissionError):
+                mcp_utils.load_manifest_tools(manifest)
+        finally:
+            manifest.chmod(0o600)
+
+    def test_non_utf8_bytes_raise_a_decode_error(self, tmp_path: Path) -> None:
+        manifest = tmp_path / "tools.json"
+        manifest.write_bytes(b"\xff\xfe[]")
+
+        with pytest.raises(UnicodeDecodeError):
+            mcp_utils.load_manifest_tools(manifest)
+
+    def test_unknown_extension_is_parsed_as_a_python_manifest(
+        self, tmp_path: Path
+    ) -> None:
+        manifest = _write_manifest(
+            tmp_path, "tools.txt", "TOOLS = ['company.profile']\n"
+        )
+
+        assert mcp_utils.load_manifest_tools(manifest) == ["company.profile"]
+
+    def test_none_returns_a_mutable_copy_of_the_defaults(self) -> None:
+        """``DEFAULT_TOOLS`` is a module-level *list*, so this is real.
+
+        The snapshot has to be taken before anything is appended: comparing
+        a mutated return value against a freshly read ``DEFAULT_TOOLS``
+        compares the aliased list with itself and can never fail. The
+        identity check runs first so a regression is caught before it
+        corrupts the module global for the rest of the session.
+        """
+        from fmp_data.mcp.tools_manifest import DEFAULT_TOOLS
+
+        expected = list(DEFAULT_TOOLS)
+        assert expected, "floor: an empty default manifest would prove nothing"
+
+        tools = mcp_utils.load_manifest_tools(None)
+
+        assert tools == expected
+        assert tools is not DEFAULT_TOOLS
+
+        tools.append("sentinel.not-a-real-tool")
+
+        assert list(DEFAULT_TOOLS) == expected
+        assert mcp_utils.load_manifest_tools(None) == expected
+
+    def test_python_manifest_without_tools_names_the_missing_global(
+        self, tmp_path: Path
+    ) -> None:
+        manifest = _write_manifest(
+            tmp_path, "docstring_only.py", '"""Just a docstring."""\n'
+        )
+
+        with pytest.raises(AttributeError) as excinfo:
+            mcp_utils.load_manifest_tools(manifest)
+
+        assert str(excinfo.value) == (
+            f"{manifest} does not define a global variable 'TOOLS'"
+        )
+
+    def test_json_content_under_an_unknown_extension_is_refused(
+        self, tmp_path: Path
+    ) -> None:
+        manifest = _write_manifest(tmp_path, "tools.conf", '["company.profile"]\n')
+
+        with pytest.raises(ValueError) as excinfo:
+            mcp_utils.load_manifest_tools(manifest)
+
+        assert "only a docstring and TOOLS" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# restart_claude_desktop_instructions
+# ---------------------------------------------------------------------------
+
+
+class TestRestartInstructions:
+    @pytest.mark.parametrize(
+        ("system", "expected"),
+        [
+            ("Darwin", "Cmd+Q"),
+            ("Windows", "system tray"),
+            ("Linux", "application menu"),
+        ],
+    )
+    def test_instructions_are_platform_specific(
+        self, monkeypatch: pytest.MonkeyPatch, system: str, expected: str
+    ) -> None:
+        monkeypatch.setattr(platform, "system", lambda: system)
+
+        text = mcp_utils.restart_claude_desktop_instructions()
+
+        assert expected in text
+        assert text.startswith("To restart Claude Desktop")
+        steps = text.splitlines()[1:]
+        assert [step.strip()[:2] for step in steps] == ["1.", "2.", "3."]
+
+    def test_each_platform_gets_a_distinct_message(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        messages = []
+        for system in ("Darwin", "Windows", "Linux"):
+            monkeypatch.setattr(platform, "system", lambda s=system: s)
+            messages.append(mcp_utils.restart_claude_desktop_instructions())
+
+        assert len(set(messages)) == 3

--- a/tests/unit/test_redis_backend.py
+++ b/tests/unit/test_redis_backend.py
@@ -1,0 +1,461 @@
+"""Unit tests for the Redis cache backend.
+
+The ``redis`` package is an optional extra, so these tests install a stub
+``redis`` module into ``sys.modules`` instead of importing the real client.
+That keeps the suite runnable with or without ``fmp-data[cache-redis]`` and
+guarantees no socket is ever opened.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+import json
+import logging
+import sys
+import threading
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+from fmp_data.cache.redis_backend import RedisCache
+
+LOGGER_NAME = "fmp_data.cache.redis_backend"
+
+
+class FakeRedis:
+    """In-process stand-in for ``redis.Redis`` that records every call.
+
+    Set ``fail_on`` to make an operation raise, and ``scan_pages`` to script
+    the SCAN cursor loop as a list of ``(next_cursor, keys)`` pages.
+    """
+
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+        self.get_calls: list[str] = []
+        self.setex_calls: list[tuple[str, int, str]] = []
+        self.delete_calls: list[tuple[str, ...]] = []
+        self.scan_calls: list[tuple[int, str | None, int | None]] = []
+        self.call_threads: list[int] = []
+        self.fail_on: set[str] = set()
+        self.scan_pages: list[tuple[int, list[str]]] = [(0, [])]
+
+    def _guard(self, operation: str) -> None:
+        self.call_threads.append(threading.get_ident())
+        if operation in self.fail_on:
+            raise RuntimeError(f"redis {operation} unavailable")
+
+    def get(self, key: str) -> str | None:
+        self.get_calls.append(key)
+        self._guard("get")
+        return self.store.get(key)
+
+    def setex(self, key: str, ttl: int, value: str) -> None:
+        self.setex_calls.append((key, ttl, value))
+        self._guard("setex")
+        self.store[key] = value
+
+    def delete(self, *keys: str) -> int:
+        self.delete_calls.append(keys)
+        self._guard("delete")
+        return sum(self.store.pop(key, None) is not None for key in keys)
+
+    def scan(
+        self,
+        cursor: int,
+        match: str | None = None,
+        count: int | None = None,
+    ) -> tuple[int, list[str]]:
+        self.scan_calls.append((cursor, match, count))
+        self._guard("scan")
+        if not self.scan_pages:
+            return 0, []
+        return self.scan_pages.pop(0)
+
+
+class FakeRedisModule(ModuleType):
+    """Stub ``redis`` module whose ``from_url`` hands back a `FakeRedis`."""
+
+    def __init__(self) -> None:
+        super().__init__("redis")
+        self.from_url_calls: list[tuple[str, dict[str, Any]]] = []
+        self.client = FakeRedis()
+
+    def from_url(self, url: str, **kwargs: Any) -> FakeRedis:
+        self.from_url_calls.append((url, kwargs))
+        return self.client
+
+
+@pytest.fixture
+def redis_stub(monkeypatch: pytest.MonkeyPatch) -> FakeRedisModule:
+    """Install the stub ``redis`` module for the duration of one test."""
+    stub = FakeRedisModule()
+    monkeypatch.setitem(sys.modules, "redis", stub)
+    return stub
+
+
+class TestRedisCacheInit:
+    """Construction, dependency check and constructor defaults."""
+
+    def test_missing_redis_package_raises_import_error_with_extra_hint(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # ``None`` in sys.modules makes ``import redis`` raise ImportError.
+        monkeypatch.setitem(sys.modules, "redis", None)
+
+        with pytest.raises(ImportError) as exc_info:
+            RedisCache()
+
+        message = str(exc_info.value)
+        assert "'redis' package" in message
+        assert "pip install 'fmp-data[cache-redis]'" in message
+        assert isinstance(exc_info.value.__cause__, ImportError)
+
+    def test_from_url_receives_url_and_decode_responses(
+        self, redis_stub: FakeRedisModule
+    ) -> None:
+        RedisCache(redis_url="redis://cache.internal:6380/2")
+
+        assert redis_stub.from_url_calls == [
+            ("redis://cache.internal:6380/2", {"decode_responses": True})
+        ]
+
+    def test_default_url(self, redis_stub: FakeRedisModule) -> None:
+        RedisCache()
+
+        assert redis_stub.from_url_calls[0][0] == "redis://localhost:6379/0"
+
+    def test_default_ttl_is_300_seconds(self, redis_stub: FakeRedisModule) -> None:
+        cache = RedisCache()
+
+        cache.set("quote", {"symbol": "AAPL"})
+
+        assert redis_stub.client.setex_calls[0][1] == 300
+
+    def test_default_key_prefix_is_fmp(self, redis_stub: FakeRedisModule) -> None:
+        cache = RedisCache()
+
+        cache.get("quote")
+
+        assert redis_stub.client.get_calls == ["fmp:quote"]
+
+    def test_custom_prefix_applies_to_every_operation(
+        self, redis_stub: FakeRedisModule
+    ) -> None:
+        cache = RedisCache(key_prefix="tenant7:", default_ttl=42)
+        client = redis_stub.client
+        client.scan_pages = [(0, [])]
+
+        cache.get("quote")
+        cache.set("quote", 1)
+        cache.delete("quote")
+        cache.clear()
+
+        assert client.get_calls == ["tenant7:quote"]
+        assert client.setex_calls == [("tenant7:quote", 42, "1")]
+        assert client.delete_calls == [("tenant7:quote",)]
+        assert client.scan_calls == [(0, "tenant7:*", 100)]
+
+
+class TestRedisCacheGet:
+    """Reads: hits, misses, corrupt payloads and client failures."""
+
+    def test_hit_returns_parsed_json(self, redis_stub: FakeRedisModule) -> None:
+        cache = RedisCache()
+        redis_stub.client.store["fmp:quotes"] = json.dumps(
+            [{"symbol": "AAPL", "price": 150.0}]
+        )
+
+        assert cache.get("quotes") == [{"symbol": "AAPL", "price": 150.0}]
+
+    def test_round_trip_through_the_client(self, redis_stub: FakeRedisModule) -> None:
+        cache = RedisCache()
+
+        cache.set("profile", {"symbol": "MSFT", "employees": 221000})
+
+        assert cache.get("profile") == {"symbol": "MSFT", "employees": 221000}
+
+    def test_miss_returns_none(self, redis_stub: FakeRedisModule) -> None:
+        cache = RedisCache()
+
+        assert cache.get("absent") is None
+        assert redis_stub.client.get_calls == ["fmp:absent"]
+
+    def test_malformed_json_returns_none(self, redis_stub: FakeRedisModule) -> None:
+        cache = RedisCache()
+        redis_stub.client.store["fmp:corrupt"] = "{not valid json"
+
+        assert cache.get("corrupt") is None
+
+    def test_json_null_is_indistinguishable_from_a_miss(
+        self, redis_stub: FakeRedisModule
+    ) -> None:
+        """Current behaviour: a cached ``None`` reads back as a miss."""
+        cache = RedisCache()
+        cache.set("empty", None)
+
+        assert redis_stub.client.store["fmp:empty"] == "null"
+        assert cache.get("empty") is None
+
+    def test_client_error_returns_none_and_logs_key_only(
+        self, redis_stub: FakeRedisModule, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        cache = RedisCache()
+        redis_stub.client.store["fmp:user:42:portfolio"] = json.dumps("classified")
+        redis_stub.client.fail_on.add("get")
+
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            result = cache.get("user:42:portfolio")
+
+        assert result is None
+        records = [r for r in caplog.records if r.name == LOGGER_NAME]
+        assert len(records) == 1
+        assert records[0].levelno == logging.WARNING
+        assert records[0].getMessage() == "Redis get error for key user:42:portfolio"
+        assert records[0].exc_info is not None
+        assert records[0].exc_info[0] is RuntimeError
+        assert "classified" not in caplog.text
+
+
+class TestRedisCacheSet:
+    """Writes: TTL selection, serialization and swallowed failures."""
+
+    def test_default_ttl_used_when_ttl_omitted(
+        self, redis_stub: FakeRedisModule
+    ) -> None:
+        cache = RedisCache(default_ttl=600)
+
+        cache.set("quote", {"symbol": "AAPL"})
+
+        assert redis_stub.client.setex_calls == [
+            ("fmp:quote", 600, '{"symbol": "AAPL"}')
+        ]
+
+    def test_explicit_ttl_overrides_default(self, redis_stub: FakeRedisModule) -> None:
+        cache = RedisCache(default_ttl=600)
+
+        cache.set("quote", "v", ttl=15)
+
+        assert redis_stub.client.setex_calls == [("fmp:quote", 15, '"v"')]
+
+    def test_zero_ttl_is_forwarded_verbatim(self, redis_stub: FakeRedisModule) -> None:
+        """``ttl=0`` is not treated as "unset" -- it reaches SETEX as 0."""
+        cache = RedisCache(default_ttl=600)
+
+        cache.set("quote", "v", ttl=0)
+
+        assert redis_stub.client.setex_calls == [("fmp:quote", 0, '"v"')]
+
+    def test_non_serializable_value_falls_back_to_str(
+        self, redis_stub: FakeRedisModule
+    ) -> None:
+        cache = RedisCache()
+        moment = datetime(2026, 8, 13, 9, 30)
+
+        cache.set("asof", {"timestamp": moment})
+
+        stored = redis_stub.client.setex_calls[0][2]
+        assert json.loads(stored) == {"timestamp": "2026-08-13 09:30:00"}
+
+    def test_client_error_is_swallowed_and_logged_without_value(
+        self, redis_stub: FakeRedisModule, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        cache = RedisCache()
+        client = redis_stub.client
+        client.fail_on.add("setex")
+
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            cache.set("user:42:portfolio", "top-holding-plaintext")
+
+        # The write was attempted, and its failure left no entry behind.
+        assert client.setex_calls == [
+            ("fmp:user:42:portfolio", 300, '"top-holding-plaintext"')
+        ]
+        assert client.store == {}
+        records = [r for r in caplog.records if r.name == LOGGER_NAME]
+        assert len(records) == 1
+        assert records[0].levelno == logging.WARNING
+        assert records[0].getMessage() == "Redis set error for key user:42:portfolio"
+        # exc_info keeps the traceback; without it the log line is undebuggable.
+        assert records[0].exc_info is not None
+        assert records[0].exc_info[0] is RuntimeError
+        assert "top-holding-plaintext" not in caplog.text
+
+
+class TestRedisCacheDelete:
+    """Deletes: key prefixing and swallowed failures."""
+
+    def test_deletes_prefixed_key(self, redis_stub: FakeRedisModule) -> None:
+        cache = RedisCache()
+        cache.set("quote", "v")
+
+        cache.delete("quote")
+
+        assert redis_stub.client.delete_calls == [("fmp:quote",)]
+        assert cache.get("quote") is None
+
+    def test_client_error_is_swallowed_and_logged(
+        self, redis_stub: FakeRedisModule, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        cache = RedisCache()
+        client = redis_stub.client
+        cache.set("quote", "v")
+        client.fail_on.add("delete")
+
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            cache.delete("quote")
+
+        # The delete was attempted and the entry survives the failure.
+        assert client.delete_calls == [("fmp:quote",)]
+        assert client.store == {"fmp:quote": '"v"'}
+        records = [r for r in caplog.records if r.name == LOGGER_NAME]
+        assert len(records) == 1
+        assert records[0].levelno == logging.WARNING
+        assert records[0].getMessage() == "Redis delete error for key quote"
+        assert records[0].exc_info is not None
+        assert records[0].exc_info[0] is RuntimeError
+
+
+class TestRedisCacheClear:
+    """The SCAN cursor loop."""
+
+    def test_iterates_every_scan_page_and_deletes_each_batch(
+        self, redis_stub: FakeRedisModule
+    ) -> None:
+        cache = RedisCache()
+        client = redis_stub.client
+        client.scan_pages = [
+            (17, ["fmp:a", "fmp:b"]),
+            (0, ["fmp:c"]),
+        ]
+
+        cache.clear()
+
+        assert client.scan_calls == [(0, "fmp:*", 100), (17, "fmp:*", 100)]
+        assert client.delete_calls == [("fmp:a", "fmp:b"), ("fmp:c",)]
+
+    def test_glob_metacharacters_in_prefix_are_not_escaped(
+        self, redis_stub: FakeRedisModule
+    ) -> None:
+        """Current behaviour: the prefix is concatenated into the SCAN
+        pattern verbatim, so glob metacharacters change what is matched.
+        """
+        cache = RedisCache(key_prefix="fmp[1]:")
+        client = redis_stub.client
+        client.scan_pages = [(0, [])]
+
+        cache.set("quote", "v")
+        cache.clear()
+
+        assert client.setex_calls[0][0] == "fmp[1]:quote"
+        assert client.scan_calls == [(0, "fmp[1]:*", 100)]
+
+    def test_empty_page_does_not_call_delete(self, redis_stub: FakeRedisModule) -> None:
+        cache = RedisCache()
+        client = redis_stub.client
+        client.scan_pages = [(9, []), (0, ["fmp:only"])]
+
+        cache.clear()
+
+        assert client.scan_calls == [(0, "fmp:*", 100), (9, "fmp:*", 100)]
+        assert client.delete_calls == [("fmp:only",)]
+
+    def test_single_empty_page_ends_the_loop_after_one_scan(
+        self, redis_stub: FakeRedisModule
+    ) -> None:
+        """A cursor of 0 on the first page terminates -- no re-SCAN, no DELETE."""
+        cache = RedisCache()
+        client = redis_stub.client
+        client.scan_pages = [(0, [])]
+
+        cache.clear()
+
+        assert client.scan_calls == [(0, "fmp:*", 100)]
+        assert client.delete_calls == []
+
+    def test_clear_removes_entries_from_the_backing_store(
+        self, redis_stub: FakeRedisModule
+    ) -> None:
+        cache = RedisCache()
+        client = redis_stub.client
+        cache.set("a", 1)
+        cache.set("b", 2)
+        client.scan_pages = [(0, list(client.store))]
+
+        cache.clear()
+
+        assert client.store == {}
+        assert cache.get("a") is None
+
+    def test_scan_error_is_swallowed_and_logged(
+        self, redis_stub: FakeRedisModule, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        cache = RedisCache()
+        client = redis_stub.client
+        cache.set("survivor", "v")
+        client.fail_on.add("scan")
+
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            cache.clear()
+
+        # A failed SCAN aborts before deleting anything.
+        assert client.delete_calls == []
+        assert client.store == {"fmp:survivor": '"v"'}
+        records = [r for r in caplog.records if r.name == LOGGER_NAME]
+        assert len(records) == 1
+        assert records[0].levelno == logging.WARNING
+        assert records[0].getMessage() == "Redis clear error"
+        assert records[0].exc_info is not None
+        assert records[0].exc_info[0] is RuntimeError
+
+    def test_delete_error_mid_loop_aborts_without_raising(
+        self, redis_stub: FakeRedisModule, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        cache = RedisCache()
+        client = redis_stub.client
+        client.scan_pages = [(5, ["fmp:a"]), (0, ["fmp:b"])]
+        client.fail_on.add("delete")
+
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            cache.clear()
+
+        assert client.delete_calls == [("fmp:a",)]
+        assert client.scan_calls == [(0, "fmp:*", 100)]
+        records = [r for r in caplog.records if r.name == LOGGER_NAME]
+        assert [r.getMessage() for r in records] == ["Redis clear error"]
+
+
+class TestRedisCacheAsync:
+    """The inherited async wrappers drive the same client."""
+
+    @pytest.mark.asyncio
+    async def test_aset_then_aget_round_trip(self, redis_stub: FakeRedisModule) -> None:
+        cache = RedisCache(default_ttl=30)
+
+        await cache.aset("quote", {"symbol": "AAPL"})
+
+        assert redis_stub.client.setex_calls == [
+            ("fmp:quote", 30, '{"symbol": "AAPL"}')
+        ]
+        assert await cache.aget("quote") == {"symbol": "AAPL"}
+
+    @pytest.mark.asyncio
+    async def test_blocking_client_calls_run_off_the_event_loop_thread(
+        self, redis_stub: FakeRedisModule
+    ) -> None:
+        """``redis-py`` is synchronous, so the wrappers must offload it.
+
+        Without this the coroutines would block the loop on every network
+        round trip -- and a plain ``await`` on a direct call still satisfies a
+        round-trip assertion, so pin the thread hand-off explicitly.
+        """
+        cache = RedisCache()
+
+        await cache.aset("quote", "v")
+        await cache.aget("quote")
+        await cache.adelete("quote")
+        await cache.aclear()
+
+        loop_thread = threading.get_ident()
+        assert redis_stub.client.call_threads, "no client call was recorded"
+        assert loop_thread not in redis_stub.client.call_threads

--- a/tests/unit/test_tag_ancestry_guard.py
+++ b/tests/unit/test_tag_ancestry_guard.py
@@ -1,0 +1,71 @@
+"""The TestPyPI tag guard must compare against fully-qualified refs (#252).
+
+``git rev-parse`` resolves an unqualified name in this order (gitrevisions):
+``refs/<name>``, ``refs/tags/<name>``, ``refs/heads/<name>``,
+``refs/remotes/<name>``. ``actions/checkout`` with ``fetch-depth: 0`` mirrors
+every tag verbatim via ``+refs/tags/*:refs/tags/*``, so a tag literally named
+``origin/main`` lands at ``refs/tags/origin/main`` and outranks
+``refs/remotes/origin/main``.
+
+The #268 guard compared against the bare name ``origin/main``, so that shadow
+tag made ``git merge-base --is-ancestor`` test HEAD against an attacker-chosen
+commit. Git only warns ("refname is ambiguous"), which ``set -euo pipefail``
+does not trap, so the job went green and published an arbitrary tree.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+WORKFLOW = (
+    Path(__file__).resolve().parents[2]
+    / ".github"
+    / "workflows"
+    / "publish-testpypi.yml"
+)
+
+
+def _guard_step() -> str:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    start = text.index("- name: Require tag commit reachable from main or dev")
+    rest = text[start + 1 :]
+    end = rest.find("\n      - name:")
+    return rest if end == -1 else rest[:end]
+
+
+def test_guard_step_still_exists() -> None:
+    assert "Require tag commit reachable from main or dev" in WORKFLOW.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_ancestry_compares_fully_qualified_remote_refs() -> None:
+    """Both ``--is-ancestor`` targets must be under ``refs/remotes/``."""
+    step = _guard_step()
+    # Trailing `;` / `\` belong to the shell, not the refname.
+    targets = [
+        ref.rstrip(";\\")
+        for ref in re.findall(r"--is-ancestor\s+\"\$HEAD\"\s+(\S+)", step)
+    ]
+    assert targets, f"no --is-ancestor comparisons found in:\n{step}"
+    assert set(targets) == {
+        "refs/remotes/origin/main",
+        "refs/remotes/origin/dev",
+    }, f"unqualified rev name is shadowable by a tag: {targets}"
+
+
+def test_fetch_does_not_import_tags_into_the_comparison() -> None:
+    """The guard's own fetch must not repopulate ``refs/tags/*``."""
+    step = _guard_step()
+    assert "--no-tags" in step
+    assert "+refs/heads/main:refs/remotes/origin/main" in step
+    assert "+refs/heads/dev:refs/remotes/origin/dev" in step
+
+
+def test_guard_fails_closed() -> None:
+    step = _guard_step()
+    assert "set -euo pipefail" in step
+    assert "exit 1" in step
+    assert "continue-on-error" not in step
+    assert "|| true" not in step


### PR DESCRIPTION
Closes the remaining items on #273 and #282. While re-auditing #252's
acceptance checklist against `dev` I also found four real defects; they are
fixed here rather than left for a later pass.

## Defects found and fixed

### 1. Async requests were broken outright (high)

`httpx.AsyncClient` **awaits** every response hook (`await hook(response)`,
`httpx/_client.py:1697`) while `httpx.Client` calls it plainly (`:982`).
#277's cross-origin redirect guard is a plain `def` and was registered on
both clients, so httpx awaited `None`:

```
TypeError: object NoneType can't be used in 'await' expression
```

That fired on **every successful async response**, not just redirects — so
`AsyncFMPDataClient` was unusable. Unreleased: `v2.6.0` is the last tag and
this never shipped.

Why nothing caught it: every async test replaced the client with `AsyncMock`
and asserted only that the hook was *in* `event_hooks["response"]`. The new
tests drive a real `httpx.MockTransport`; 3 of the 4 fail without the fix.

### 2. TestPyPI tag-ancestry guard was bypassable (medium)

The #268 guard compared against the **unqualified** rev `origin/main`. Git
resolves `refs/tags/<name>` before `refs/remotes/<name>`, and
`actions/checkout` with `fetch-depth: 0` mirrors every tag verbatim
(`+refs/tags/*:refs/tags/*`). A tag literally named `origin/main` therefore
shadowed the remote-tracking branch, and the guard compared HEAD against an
attacker-chosen commit — passing with only a `refname is ambiguous` warning,
which `set -euo pipefail` does not trap.

Reproduced against a scratch remote:

```
=== BASELINE: evil tag, no shadow tag ===
  old guard: BLOCKED (correct)
=== ATTACK: push a tag named 'origin/main' at the evil commit ===
  old guard: PASS  <-- BYPASSED
  new guard: BLOCKED (fix works)
```

Now uses `refs/remotes/origin/{main,dev}` and fetches with `--no-tags` and an
explicit refspec.

### 3. Bandit ran nowhere in CI (medium)

#278 replaced the blanket `B404`/`B603`/`B607`/`B608` skips with narrow
file-local `# nosec` notes — but bandit existed only in
`.pre-commit-config.yaml`, and this repo has **no pre-commit CI job**. So the
narrowing was unenforced on CI and a new `subprocess` call could land
unreviewed. It now runs in `nox -s security` (0 findings).

Same root cause: #278 dropped the global skips without annotating
`examples/mcp/claude_desktop/setup_claude_desktop.py`, leaving
`pre-commit run --all-files` **already red on `dev`**. It gets the same notes.

### 4. Nested secrets survived `repr` (low)

`_redact_kwargs` matched key names at the top level only and copied nested
containers by reference. `OpenAIEmbeddings` genuinely accepts
`default_headers={"Authorization": ...}` and `model_kwargs={"api_key": ...}`,
and this config splats them straight through, so a credential one level down
was printed verbatim. Redaction is now recursive (depth-bounded) and leaves
the live kwargs unmutated.

## #273 — remaining items

**Coverage omit → separate gate with real headroom.** Rather than lower the
bar, this adds behavioural tests to the weakest and most security-relevant
files:

| File | Before | After |
|---|---|---|
| `cache/redis_backend.py` | ~25% | **100%** |
| `lc/validation.py` | ~30% | **100%** |
| `lc/__init__.py` | ~59% | **100%** |
| `mcp/utils.py` | ~52% | **100%** |
| `mcp/setup.py` | ~24% | **98.9%** |
| **extras total** | **66.96%** | **86.98%** |

`fail_under` 65 → **80**, leaving ~7 points of headroom now that the job is a
required check. Also fixes the `Protocol` exclusion in `extras.coveragerc`,
copied from TOML with a doubled backslash — in an INI file that is a literal
backslash, so it compiled but never matched anything.

Tests were checked for theater, not just line count: all 257 have real
assertions (AST-verified), and mutation testing kills the mutants
(restricted-AST guard, `yaml.safe_load` → `unsafe_load`, `getpass` → `input`,
config/backup modes, and the three the authoring pass injected into
`lc/__init__.py`).

**Bandit skips** — see defect 3.

**`uv.lock` policy** — stays uncommitted, now recorded as a decision in
`CONTRIBUTING.md`: this is a library, so the contract users install against is
the floors in `pyproject.toml`; drift is caught by `nox -s security` auditing
a live `uv export` with `pip-audit --strict` rather than frozen behind stale
pins. The old `.gitignore` rationale cited a non-existent "GitHub 500KB
warning" — that threshold is pre-commit's `check-added-large-files` default,
and GitHub's is 50MB. Guard test now asserts the lock is genuinely untracked,
not just that the ignore line exists.

**Residual `additional_kwargs`** — see defect 4.

## #282 — required status checks (applied)

`Extras Coverage`, `coverage`, `Secret Scan`, `Actions shell checks` and
`Test-MatrixExpected` are now required on **Protect Dev** *and* **Protect
Main** (Main keeps CodeRabbit). Previously only `tests (3.10–3.14)` were
required, so a red extras or secret scan could not block a merge.

Safe to require: all five jobs run unconditionally on `pull_request` with no
path filters — pinned by a new test so a later `paths:` filter or job-level
`if:` cannot silently turn a required check into a deadlock.

## Also

`warn_unused_ignores` is disabled **for tests only**. Tests are type-checked in
two dependency environments — the `typecheck` nox session installs core+dev,
while a local `--all-extras` run resolves langchain types — so an ignore that
is required in one is necessarily redundant in the other, making the two envs
mutually unsatisfiable. The library keeps the strict global setting.

## Verification

- `2258 passed, 7 skipped` in **both** the no-extras env (what CI installs) and
  the all-extras env
- `nox -s coverage_extras`: 86.98% vs the new 80 floor
- `nox -s security`: bandit 0 findings, `pip-audit --strict` no known vulns
- ruff, mypy (229 files), and the full `pre-commit run --all-files` clean
- Async fix and tag-guard bypass both verified by reproduction, not inspection

## Not included

Left on #252 deliberately, since each is its own change:

- `pypi` / `testpypi` GitHub environments still have no protection rules or
  deployment-branch policy (repo settings, and `release.yml` deploys from
  `refs/pull/N/merge`, so a naive `main`-only restriction would break it)
- No tag ruleset restricting who may push `v*`
- `release.yml`'s build job holds `contents: write` (it tags and creates the
  release; it holds no `id-token`)
- `model_dump()` / `model_dump_json()` still emit secrets in cleartext for the
  config models — `repr`/`str` are covered, serialization is not

🤖 Generated with [Claude Code](https://claude.com/claude-code)
