### PR TITLE
ci(dependabot): group CodeQL and artifact action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,14 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "dev"
+    # These actions share runtime state. A split major bump leaves CI or
+    # release jobs mixed across incompatible majors (CodeQL init/analyze,
+    # upload/download-artifact). Group so Dependabot opens one PR per pair.
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
+      artifact-actions:
+        patterns:
+          - "actions/upload-artifact"
+          - "actions/download-artifact"

--- a/tests/unit/test_dependabot_action_groups.py
+++ b/tests/unit/test_dependabot_action_groups.py
@@ -1,0 +1,17 @@
+"""GitHub Actions Dependabot groups keep lockstep pairs together."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+CONFIG = Path(__file__).resolve().parents[2] / ".github" / "dependabot.yml"
+
+
+def test_github_actions_groups_cover_codeql_and_artifacts() -> None:
+    text = CONFIG.read_text(encoding="utf-8")
+    assert 'package-ecosystem: "github-actions"' in text
+    assert "codeql-action:" in text
+    assert "github/codeql-action*" in text
+    assert "artifact-actions:" in text
+    assert "actions/upload-artifact" in text
+    assert "actions/download-artifact" in text


### PR DESCRIPTION
Isolated follow-up from the review of #284–#287.

Dependabot opened one PR per GitHub Action id, so lockstep pairs landed as incompatible split majors:

- #284 / #286 mixed `codeql-action` v3 and v4. Analyze Python failed with `Loaded a configuration file for version '4.37.6', but running version '3.37.7'`.
- #285 / #287 split `upload-artifact` v7 from `download-artifact` v4. PR CI stayed green because release workflows are not exercised on pull requests.

This groups each pair so the next weekly run opens a single PR.

The actual version bumps stay on #286 (CodeQL init+analyze) and #287 (upload+download). #284 and #285 will be closed as superseded once those are green.