### PR TITLE
fix(ci): run the quality gates that were silently skipped (#252)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,13 @@ jobs:
         env:
           NOX_USE_UV: "1"
         run: |
-          uv tool run nox -s lint -s typecheck -s security
+          # One session per invocation. `nox -s` is store-not-append, so the
+          # earlier `-s lint -s typecheck -s security` form silently selected
+          # only `security` -- ruff and mypy never ran in CI at all (#252).
+          # Separate lines also keep each gate's failure unambiguous in the log.
+          uv tool run nox -s lint
+          uv tool run nox -s typecheck
+          uv tool run nox -s security
 
   # Coverage job - run all tests in one job for simplicity
   coverage:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,6 +192,11 @@ extend-exclude = [
     "build",
     "dist",
     "extras.coveragerc",
+    # Dated, archival process documents. `ruff format` reflows Python inside
+    # Markdown fences, and these record *excerpts* -- partial bodies lifted out
+    # of their enclosing function. Reformatting re-indents them as if they were
+    # standalone modules, which corrupts the record rather than tidying it.
+    "docs/superpowers",
 ]
 
 [tool.ruff.lint]

--- a/tests/unit/test_ci_quality_gates.py
+++ b/tests/unit/test_ci_quality_gates.py
@@ -1,0 +1,125 @@
+"""CI actually runs ruff, mypy and bandit/pip-audit (#252).
+
+``ci.yml`` used to invoke the gates as::
+
+    uv tool run nox -s lint -s typecheck -s security
+
+``nox``'s ``-s`` is an ordinary *store* argument taking ``nargs="*"``, not an
+``append``. Repeating the flag therefore does not accumulate -- the last
+occurrence wins outright, so that line selected ``security`` and nothing else.
+``ruff`` and ``mypy`` had no CI enforcement at all, and ``bandit``/``pip-audit``
+survived only by being last in the list.
+
+That is the #283 finding one layer up: there, ``bandit`` was configured but
+never wired to a CI job; here the job exists and *looks* right, so grepping
+``ci.yml`` for ``"lint"`` passes while the session never runs. These tests
+reproduce nox's own flag semantics instead of matching substrings, and
+``test_repeated_s_flag_form_is_detected_as_broken`` pins that reproduction
+against the real known-bad line so the check cannot rot into a tautology.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import shlex
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CI = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+REQUIRED_GATES = {"lint", "typecheck", "security"}
+
+
+def _ci() -> dict[str, Any]:
+    loaded = yaml.safe_load(CI.read_text(encoding="utf-8"))
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def _quality_gate_step() -> dict[str, Any]:
+    steps = _ci()["jobs"]["tests"]["steps"]
+    matches = [s for s in steps if "Quality Gates" in str(s.get("name", ""))]
+    assert len(matches) == 1, f"expected exactly one Quality Gates step, got {matches}"
+    step = matches[0]
+    assert isinstance(step, dict)
+    return step
+
+
+def _sessions_nox_would_select(run_block: str) -> set[str]:
+    """Sessions nox actually selects, per nox's own argument semantics.
+
+    Mirrors ``nox``'s parser: ``-s``/``--sessions``/``--session``/``-e`` take
+    ``nargs="*"`` and *store* (not append), so a repeated flag discards every
+    earlier occurrence. Anything relying on repetition silently narrows.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-s", "--sessions", "--session", "-e", nargs="*", default=[])
+
+    selected: set[str] = set()
+    for line in run_block.splitlines():
+        line = line.strip()
+        if line.startswith("#") or "nox" not in line:
+            continue
+        tokens = shlex.split(line, comments=True)
+        if "nox" not in tokens:
+            continue
+        known, _ = parser.parse_known_args(tokens[tokens.index("nox") + 1 :])
+        selected.update(known.sessions or [])
+    return selected
+
+
+def test_ci_selects_every_quality_gate() -> None:
+    selected = _sessions_nox_would_select(_quality_gate_step()["run"])
+    missing = REQUIRED_GATES - selected
+    assert not missing, (
+        f"ci.yml Quality Gates selects {sorted(selected)}; "
+        f"nox would never run {sorted(missing)}"
+    )
+
+
+def test_repeated_s_flag_form_is_detected_as_broken() -> None:
+    """The parser above must actually catch the historical regression.
+
+    Without this, a mimic that quietly accumulated flags would report the
+    broken line as healthy and ``test_ci_selects_every_quality_gate`` would
+    pass on exactly the config it exists to reject.
+    """
+    broken = _sessions_nox_would_select(
+        "uv tool run nox -s lint -s typecheck -s security"
+    )
+    assert broken == {"security"}, (
+        f"expected the repeated -s form to collapse to just security, got {broken}"
+    )
+
+    healthy = _sessions_nox_would_select("uv tool run nox -s lint typecheck security")
+    assert healthy == REQUIRED_GATES
+
+
+def test_quality_gate_condition_matches_a_real_matrix_entry() -> None:
+    """A gate pinned to a Python version absent from the matrix never runs.
+
+    ``if: matrix.python == '3.14'`` is silent when 3.14 is dropped from the
+    matrix: the step is skipped, the job still reports success, and the gate
+    disappears without anything going red.
+    """
+    step = _quality_gate_step()
+    condition = str(step.get("if", ""))
+    assert condition, "Quality Gates step has no `if:`; expected a matrix pin"
+
+    matrix = _ci()["jobs"]["tests"]["strategy"]["matrix"]["python"]
+    versions = {str(v) for v in matrix}
+    assert any(f"'{v}'" in condition or f'"{v}"' in condition for v in versions), (
+        f"Quality Gates `if:` ({condition!r}) names no version in the matrix "
+        f"{sorted(versions)}; the step would silently never run"
+    )
+
+
+def test_gates_are_not_soft_failed() -> None:
+    """``continue-on-error`` / trailing ``|| true`` would make the gate cosmetic."""
+    step = _quality_gate_step()
+    assert step.get("continue-on-error") in (None, False)
+    assert "|| true" not in step["run"]
+    assert "|| :" not in step["run"]


### PR DESCRIPTION
## What

`ci.yml:67` invoked the gates as `nox -s lint -s typecheck -s security`. nox's `-s` is a *store* argument with `nargs="*"`, not an `append` — repeating the flag discards every earlier occurrence, so **only `security` was ever selected**. `ruff` and `mypy` had no CI enforcement at all; bandit/pip-audit survived purely by being last in the list.

Reproduced:

```
$ nox -l -s lint -s typecheck -s security
- lint ...        (skipped)
- typecheck ...   (skipped)
* security ...    (selected)
```

And in the last green run on `dev` (31417673277) — every `nox > Running session` line in the job:

```
tests-3.10..3.14(core|langchain|mcp-server)
coverage_local
security
```

No `lint`. No `typecheck`.

This is the #283 bandit finding one layer up: there the tool was configured but never wired to a job; here the job exists and *reads* correctly, so grepping `ci.yml` for `"lint"` passes while the session never runs.

## Changes

1. **One session per nox invocation** — the selection cannot collapse again, and each gate's failure stays unambiguous in the log.

2. **`docs/superpowers` excluded from ruff.** Turning the gate back on surfaced a pre-existing red on `dev`: `ruff format` reflows Python inside Markdown fences, and those dated plan/spec docs record partial *excerpts* — bodies lifted out of their enclosing function. Ruff re-indents them as standalone modules, corrupting the record rather than tidying it. Without this, the required `Test-Matrix` check goes red on every PR.

3. **A meta-test that reproduces nox's flag semantics** instead of matching substrings. A membership assertion would pass on exactly the line it exists to reject — the silent-defeat shape #283 called out. `test_repeated_s_flag_form_is_detected_as_broken` pins the reproduction against the real known-bad string.

   It also asserts the gate's `if:` names a Python version present in the matrix; otherwise dropping 3.14 would skip the step and still report success.

## Verification

Mutation-tested — reverting `ci.yml` to the broken form goes red on the right assertion:

```
E   AssertionError: ci.yml Quality Gates selects ['security'];
E   nox would never run ['lint', 'typecheck']
```

green again on restore.

The restored mypy gate immediately caught two `no-any-return` errors in the new test file itself — fixed here, which is the gate working.

`2267 passed, 7 skipped`; `nox -s lint` and `nox -s typecheck` both green.

Refs #252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)