### PR TITLE
fix(sec): stop the log filter crashing on Bearer and leaking tracebacks (#252)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,20 @@ None. No FMP path we ship was newly retired by this changelog window.
 
 ### Security
 
+- **``Authorization: Bearer`` no longer crashes the log filter, and
+  tracebacks are actually redacted (#252 FMP-SEC-005).**
+  ``SensitiveDataFilter`` read capture group 3 for every pattern, but
+  ``authorization`` defines only two groups. Any log line containing
+  ``Authorization: Bearer <token>`` raised ``IndexError: no such group``
+  from inside ``logging``, so the Bearer rule never redacted *and* the
+  filter's own exception replaced the caller's — reachable through
+  ``FMPDataClient.__exit__``, which logs with ``exc_info=True``.
+  Separately, filters run before formatting, so ``record.exc_text`` was
+  still ``None`` when the filter looked at it: the ``exc_text`` branch
+  never fired on a live ``exc_info=True`` call and tracebacks reached
+  handlers unredacted. The filter now renders and masks the traceback
+  itself, and ``JsonFormatter`` masks the exception message and
+  traceback it derives from ``record.exc_info``.
 - **``pip-audit --strict`` audits a live extras export (#252 FMP-SEC-008).**
   ``nox -s security`` runs ``uv export`` for the published extras
   (langchain, mcp, cache-redis) and audits that pin set. There is no

--- a/fmp_data/logger.py
+++ b/fmp_data/logger.py
@@ -10,6 +10,7 @@ from logging.handlers import RotatingFileHandler
 import os
 from pathlib import Path
 import re
+import traceback
 from typing import Any, ClassVar, Optional, ParamSpec, TypeVar
 
 from fmp_data.config import LoggingConfig, LogHandlerConfig
@@ -85,10 +86,18 @@ class SensitiveDataFilter(logging.Filter):
         masked_text = text
         for pattern in self.patterns.values():
 
-            def mask_replacement(match: Any) -> Any:
-                prefix = match.group(1) if match.group(1) else ""
+            def mask_replacement(match: re.Match[str]) -> str:
+                # Group count varies by pattern. The quoted-value patterns
+                # capture a trailing quote as group 3, but `authorization`
+                # is (prefix)(token) with no delimiter to restore, so
+                # reading group 3 unconditionally raised
+                # `IndexError: no such group` -- which meant the Bearer rule
+                # never redacted *and* the exception escaped through
+                # `logger.error(..., exc_info=True)` to replace the caller's
+                # own error (#252).
+                prefix = match.group(1) or ""
                 sensitive_value = match.group(2)
-                suffix = match.group(3) if match.group(3) else ""
+                suffix = (match.group(3) or "") if match.re.groups >= 3 else ""
                 masked_value = self._mask_value(sensitive_value)
                 return f"{prefix}{masked_value}{suffix}"
 
@@ -124,7 +133,27 @@ class SensitiveDataFilter(logging.Filter):
             elif key in {"exc_text", "stack_info"} and isinstance(value, str):
                 record.__dict__[key] = self._mask_patterns_in_string(value)
 
+        self._redact_traceback(record)
         return True
+
+    def _redact_traceback(self, record: logging.LogRecord) -> None:
+        """Render and mask the traceback before any formatter can emit it.
+
+        Filters run *before* formatting, so ``record.exc_text`` is still
+        ``None`` here and the ``exc_text`` branch above never fires on a live
+        ``exc_info=True`` call -- the traceback reached the handler
+        unredacted, carrying whatever credential the raised exception's
+        message held (#252 FMP-SEC-005 called for exception text and
+        tracebacks, not just extras).
+
+        ``logging.Formatter.format`` reuses a non-empty ``record.exc_text``
+        instead of re-deriving it, so populating it with a masked rendering
+        is enough for the stdlib path.
+        """
+        if not record.exc_info or not record.exc_info[0] or record.exc_text:
+            return
+        rendered = "".join(traceback.format_exception(*record.exc_info))
+        record.exc_text = self._mask_patterns_in_string(rendered.rstrip("\n"))
 
     def _mask_dict_recursive(self, d: Any, parent_key: str = "") -> Any:
         """Recursively mask sensitive values in dictionaries and lists"""
@@ -170,10 +199,19 @@ class JsonFormatter(logging.Formatter):
         if record.exc_info and record.exc_info[0]:
             exc_type = record.exc_info[0]
             exc_value = record.exc_info[1]
+            # Mask here too: this formatter renders the exception from
+            # ``record.exc_info`` directly rather than reading the masked
+            # ``record.exc_text``, so it would otherwise re-derive the raw
+            # traceback the filter just sanitized (#252 FMP-SEC-005).
+            masker = SensitiveDataFilter()
             log_data["exception"] = {
                 "type": exc_type.__name__ if exc_type else "Unknown",
-                "message": str(exc_value) if exc_value else "",
-                "traceback": self.formatException(record.exc_info),
+                "message": masker._mask_patterns_in_string(
+                    str(exc_value) if exc_value else ""
+                ),
+                "traceback": masker._mask_patterns_in_string(
+                    record.exc_text or self.formatException(record.exc_info)
+                ),
             }
 
         # Add any extra fields from the record

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -188,6 +188,76 @@ class TestSensitiveDataFilter:
         assert secret not in caplog.text
         assert "api_key=" in caplog.text
 
+    def test_every_pattern_masks_without_raising(self) -> None:
+        """No pattern may read a capture group it does not define (#252).
+
+        ``mask_replacement`` read ``match.group(3)`` unconditionally while
+        ``authorization`` is a two-group pattern, so the Bearer rule raised
+        ``IndexError`` instead of redacting. Drive every configured pattern
+        rather than only the three-group ones, so adding another two-group
+        rule cannot reintroduce this.
+        """
+        filter_instance = SensitiveDataFilter()
+        planted = "PLANTEDCREDENTIALVALUE"
+        samples = {
+            "api_key": f"api_key={planted}",
+            "authorization": f"Authorization: Bearer {planted}",
+            "password": f"password: {planted}",
+            "token": f"token={planted}",
+            "secret": f"client_secret={planted}",
+            "key": f"key={planted}",
+        }
+        assert set(samples) == set(filter_instance.patterns), (
+            "a pattern was added or renamed without a sample here"
+        )
+
+        for name, text in samples.items():
+            masked = filter_instance._mask_patterns_in_string(text)
+            assert planted not in masked, f"{name} pattern did not redact: {masked}"
+
+    def test_bearer_token_is_redacted_not_crashed(self) -> None:
+        """The two-group ``authorization`` pattern actually masks."""
+        filter_instance = SensitiveDataFilter()
+        planted = "PLANTEDCREDENTIALVALUE"
+        record = logging.LogRecord(
+            name="test_logger",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg=f"sending Authorization: Bearer {planted}",
+            args=(),
+            exc_info=None,
+        )
+        assert filter_instance.filter(record) is True
+        text = record.getMessage()
+        assert planted not in text
+        assert "Authorization: Bearer " in text
+
+    def test_bearer_in_traceback_does_not_replace_callers_exception(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The filter must never become the error the caller sees (#252).
+
+        ``FMPDataClient.__exit__`` logs with ``exc_info=True``. The filter
+        walks ``exc_text``, so an exception whose message carried a Bearer
+        token raised ``IndexError: no such group`` *from inside logging* and
+        the caller's real ``RuntimeError`` was lost behind it.
+        """
+        from fmp_data.logger import FMPLogger
+
+        planted = "PLANTEDCREDENTIALVALUE"
+        log = FMPLogger().get_logger("fmp_data.base")
+        caplog.set_level(logging.ERROR, logger="fmp_data.base")
+
+        try:
+            raise RuntimeError(f"upstream rejected Authorization: Bearer {planted}")
+        except RuntimeError:
+            log.error("Error in context manager", exc_info=True)
+
+        assert planted not in caplog.text
+        assert "upstream rejected" in caplog.text
+        assert "no such group" not in caplog.text
+
 
 class TestJsonFormatter:
     """Test JsonFormatter functionality"""
@@ -263,6 +333,40 @@ class TestJsonFormatter:
 
         assert "exception" in json_data
         assert "ValueError" in json_data["exception"]["type"]
+
+    def test_format_masks_credentials_in_exception_and_traceback(self):
+        """The JSON exception block must not re-derive the raw traceback.
+
+        ``JsonFormatter`` renders from ``record.exc_info`` directly, so it
+        bypassed the mask the filter had applied and emitted the credential
+        verbatim under ``exception.message`` / ``exception.traceback``
+        (#252 FMP-SEC-005).
+        """
+        formatter = JsonFormatter()
+        secret = "supersecretkey99"  # noqa: S105
+
+        try:
+            raise ValueError(f"upstream said api_key={secret}")
+        except ValueError:
+            exc_info = sys.exc_info()
+
+        record = logging.LogRecord(
+            name="test_logger",
+            level=logging.ERROR,
+            pathname="/path/to/file.py",
+            lineno=42,
+            msg="Exception occurred",
+            args=(),
+            exc_info=exc_info,
+        )
+
+        formatted = formatter.format(record)
+        assert secret not in formatted
+
+        json_data = json.loads(formatted)
+        assert "api_key=" in json_data["exception"]["message"]
+        assert secret not in json_data["exception"]["message"]
+        assert secret not in json_data["exception"]["traceback"]
 
     def test_format_excludes_private_attributes(self):
         """Test that private attributes are excluded from JSON"""


### PR DESCRIPTION
Two defects in `SensitiveDataFilter`, both inside the FMP-SEC-005 remit — *"sanitize extras, exception text, **and tracebacks**"* — that the original pass only half delivered.

## 1. `Authorization: Bearer` crashed the filter

`mask_replacement` read `match.group(3)` unconditionally, but `authorization` is `(Authorization:\s*Bearer\s+)(\S+)` — **two** groups:

```
  pattern 'api_key'        groups=3
  pattern 'authorization'  groups=2   <-- only two
  ...
  'api_key=abc123'                             -> 'api_key=******'
  'password: hunter2'                          -> 'password: *******'
  'Authorization: Bearer <token>'              -> IndexError: no such group
```

Two bugs for the price of one: the Bearer rule **never redacted**, *and* the filter's own exception **replaced the caller's**. That is reachable without contrivance — `FMPDataClient.__exit__` logs with `exc_info=True`, so a `RuntimeError` whose message carried a Bearer token surfaced to the user as the filter's `IndexError` instead of their actual error.

The replacement is now group-count aware.

## 2. Tracebacks were never redacted at all

Found while writing the regression test for (1): the crash was gone, but the token was still in the captured output.

Filters run *before* formatting, so `record.exc_text` is still `None` when the filter inspects it. The existing `exc_text` branch could therefore never fire on a live `exc_info=True` call, and the traceback reached the handler carrying whatever credential the raised exception's message held.

The filter now renders and masks the traceback itself — `logging.Formatter.format` reuses a non-empty `exc_text` rather than re-deriving it.

`JsonFormatter` needed the same treatment independently: it builds its exception block from `record.exc_info` directly, so it re-derived the raw traceback no matter what the filter had done.

## Tests

Drive **every** configured pattern rather than only the three-group ones, and assert the sample set matches `filter.patterns` — so adding another two-group rule cannot silently reintroduce this.

Mutation-verified, each fix reverted independently:

| Reverted | Result |
|---|---|
| group-count guard | 3 failed, 57 passed |
| `_redact_traceback` call | 1 failed, 59 passed |
| neither (as landed) | 60 passed |

`2267 passed, 7 skipped`; mypy clean.

> Note: `nox -s lint` is red on this branch only because of the pre-existing `docs/superpowers` formatting issue on `dev`, which #290 fixes. My changed files are clean under both `ruff check` and `ruff format`.

Refs #252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)