### PR TITLE
fix(sec): redact API keys in non-JSON and scalar error bodies (#252)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -303,7 +303,7 @@
         "filename": "tests/unit/test_base.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 103
+        "line_number": 105
       }
     ],
     "tests/unit/test_base_async.py": [
@@ -525,5 +525,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-14T04:30:11Z"
+  "generated_at": "2026-08-14T14:04:18Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,17 @@ None. No FMP path we ship was newly retired by this changelog window.
   handlers unredacted. The filter now renders and masks the traceback
   itself, and ``JsonFormatter`` masks the exception message and
   traceback it derives from ``record.exc_info``.
+- **Non-JSON and scalar error bodies redact the API key (#252 FMP-SEC-005).**
+  ``handle_response``'s ``json.JSONDecodeError`` branch built
+  ``FMPError.response`` from the raw bytes with no redaction, while the
+  5xx sibling ran the same bytes through ``_redact_api_keys`` — so a 2xx
+  carrying a non-JSON body leaked the live key into the exception. This
+  is routine, not exotic: WAF and CDN block pages echo the full request
+  URL, and ours carries ``apikey=``. A bare JSON *string* body took the
+  same unredacted route through ``_parse_json_response``. Both now
+  redact, and the body is decoded with ``errors="replace"`` so a
+  non-UTF-8 payload cannot raise ``UnicodeDecodeError`` from inside the
+  JSON error handler and mask the real failure.
 - **``pip-audit --strict`` audits a live extras export (#252 FMP-SEC-008).**
   ``nox -s security`` runs ``uv export`` for the published extras
   (langchain, mcp, cache-redis) and audits that pin set. There is no

--- a/fmp_data/base.py
+++ b/fmp_data/base.py
@@ -681,9 +681,18 @@ class BaseClient:
         except httpx.HTTPStatusError as exc:
             return self._handle_http_status_error(endpoint_for_error, exc)
         except json.JSONDecodeError as exc:
+            # Redact, exactly as the sibling error path does. A 2xx carrying a
+            # non-JSON body is routine -- WAF and CDN block pages echo the full
+            # request URL, and ours carries `apikey=` -- so this branch put the
+            # live key straight into `FMPError.response` while the same body on
+            # a 5xx came back redacted (#252 FMP-SEC-005).
+            # `errors="replace"` matches `_get_error_details`: without it a
+            # non-UTF-8 body raises UnicodeDecodeError *while handling* the
+            # JSON error, losing the original failure.
+            raw = response.content.decode("utf-8", errors="replace")
             raise FMPError(
                 f"Invalid JSON response from API: {exc!s}",
-                response={"raw_content": response.content.decode()},
+                response={"raw_content": _redact_api_keys(raw)},
             ) from exc
 
     @staticmethod
@@ -692,9 +701,15 @@ class BaseClient:
     ) -> dict[str, Any] | list[Any]:
         data = response.json()
         if not isinstance(data, dict | list):
+            # Scalar bodies land here -- including a bare JSON *string*, which
+            # is how upstream proxies return short error text. That string can
+            # reflect the request URL, so it needs the same redaction the
+            # dict/list paths get via `_sanitize_error_details` (#252).
             raise FMPError(
                 f"Unexpected response type: {type(data)}. Expected dict or list.",
-                response={"data": data},
+                response={"data": _sanitize_error_details(data)}
+                if isinstance(data, str)
+                else {"data": data},
             )
         return cast(dict[str, Any] | list[Any], data)
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -199,6 +199,11 @@ def mock_response():
         payload = {} if json_data is None else json_data
         response.json.return_value = payload
         response.text = json.dumps(payload) if payload is not None else ""
+        # Real responses carry bytes here. Leaving it a bare Mock let
+        # `response.content.decode()` return another Mock that flowed into
+        # error payloads unnoticed, so any code that actually *inspected* the
+        # body (redaction, decoding) was never exercised by these tests.
+        response.content = response.text.encode()
 
         if raise_error:
             response.raise_for_status.side_effect = httpx.HTTPStatusError(

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -44,6 +44,8 @@ def mock_response():
         payload = json_data or {}
         mock.json.return_value = payload
         mock.text = json.dumps(payload)
+        # Real responses carry bytes here; see the note in tests/unit/conftest.py.
+        mock.content = mock.text.encode()
         mock.raise_for_status = Mock()
         if status_code >= 400:
             mock.raise_for_status.side_effect = httpx.HTTPStatusError(
@@ -291,6 +293,82 @@ def test_get_error_details_redacts_api_keys_in_scalar_json():
     assert isinstance(details, dict)
     assert fake_key_value not in repr(details)
     assert "[REDACTED]" in details["raw_content"]
+
+
+def _handle_body(client_config, status, content):
+    """Drive the real ``handle_response`` and return the raised FMPError."""
+    client = BaseClient(client_config)
+    response = httpx.Response(
+        status, request=httpx.Request("GET", "https://example.com"), content=content
+    )
+    with pytest.raises(FMPError) as excinfo:
+        client.handle_response(response)
+    return excinfo.value
+
+
+def test_handle_response_redacts_key_in_non_json_success_body(client_config):
+    """A 2xx with a non-JSON body must redact like every other error path.
+
+    The ``JSONDecodeError`` branch built ``FMPError.response`` from the raw
+    bytes with no redaction, while the 5xx sibling ran them through
+    ``_redact_api_keys``. Every existing test drove the *helper*, never this
+    branch -- which is how the asymmetry survived (#252 FMP-SEC-005).
+
+    Reachable in normal operation: WAF and CDN block pages echo the full
+    request URL, and ours carries ``apikey=``.
+    """
+    fake_key_value = "SECRET_FMP_KEY"
+    body = f"<html>blocked for apikey={fake_key_value}</html>".encode()
+
+    error = _handle_body(client_config, 200, body)
+
+    rendered = repr(error.response)
+    assert fake_key_value not in rendered
+    assert "[REDACTED]" in rendered
+
+
+def test_handle_response_redacts_scalar_json_body(client_config):
+    """A bare JSON *string* body is how proxies return short error text."""
+    fake_key_value = "SECRET_FMP_KEY"
+    body = json.dumps(f"denied for apikey={fake_key_value}").encode()
+
+    error = _handle_body(client_config, 200, body)
+
+    rendered = repr(error.response)
+    assert fake_key_value not in rendered
+    assert "[REDACTED]" in rendered
+
+
+def test_handle_response_non_json_redaction_matches_the_error_path(client_config):
+    """Pin the parity, not just the fix.
+
+    The defect was that two branches handling the same bytes disagreed.
+    Asserting only "200 redacts" would still pass if the paths drifted apart
+    again in the other direction.
+    """
+    fake_key_value = "SECRET_FMP_KEY"
+    body = f"<html>blocked for apikey={fake_key_value}</html>".encode()
+
+    assert (
+        _handle_body(client_config, 200, body).response
+        == _handle_body(client_config, 500, body).response
+    )
+
+
+def test_handle_response_non_utf8_body_does_not_mask_the_json_error(client_config):
+    """A non-UTF-8 body must not raise *while handling* the JSON failure.
+
+    Bare ``.decode()`` raises ``UnicodeDecodeError`` from inside the
+    ``except json.JSONDecodeError`` block, replacing the real error with a
+    decoding one. ``errors="replace"`` matches ``_get_error_details``.
+    """
+    fake_key_value = "SECRET_FMP_KEY"
+    body = b"\xff\xfe blocked for apikey=" + fake_key_value.encode()
+
+    error = _handle_body(client_config, 200, body)
+
+    assert "Invalid JSON response" in str(error)
+    assert fake_key_value not in repr(error.response)
 
 
 def test_get_error_details_handles_non_utf8_body():


### PR DESCRIPTION
## The defect

`handle_response`'s `json.JSONDecodeError` branch built `FMPError.response` straight from the raw bytes, while the 5xx sibling (`_get_error_details`) ran the same bytes through `_redact_api_keys`. Two branches, same payload, opposite behaviour:

```
200 non-JSON  -> {'raw_content': '<html>blocked for apikey=SECRETKEY_1234...'}   LEAK
500 non-JSON  -> {'raw_content': '<html>blocked for apikey=[REDACTED]</html>'}   ok
```

This is routine rather than exotic. A 2xx carrying a non-JSON body is exactly what WAF and CDN block pages return, and they habitually echo the full request URL — which for this client always carries `apikey=`.

`_parse_json_response` had the same gap for a bare JSON **string** body (how proxies return short error text); only dict/list bodies were sanitized.

## The fix

Both paths now redact. The body is also decoded with `errors="replace"`, matching what `_get_error_details` already did — a bare `.decode()` raises `UnicodeDecodeError` from *inside* the `except json.JSONDecodeError` block, replacing the real failure with a decoding one.

After:

```
200 non-JSON (JSONDecodeError)     -> FMPError  LEAK=False
500 non-JSON (sibling, control)    -> FMPError  LEAK=False
200 scalar JSON string             -> FMPError  LEAK=False
200 non-UTF8 body                  -> FMPError  LEAK=False
```

## Why it survived

Every existing test drove the *helper* (`_get_error_details`), never the branch — so the asymmetry was never exercised. There are five tests named `test_get_error_details_*` and none of them touch `handle_response`.

The new tests call `handle_response` itself through a real `httpx.Response`. One asserts the two paths produce **identical** output, pinning the parity rather than just the fix, so the branches cannot drift apart again in either direction.

## Fixture repair

Both `mock_response` fixtures — there are two, and the one in `test_base.py` shadows conftest's — left `.content` an unset `Mock`. So `response.content.decode()` returned another `Mock` that flowed into error payloads unnoticed, meaning any code that actually *inspected* the body was never exercised. They now carry real bytes.

That is what surfaced `test_invalid_json_response` failing once redaction started reading the body for real: the mock was under-specified, not the fix wrong.

## Verification

Mutation-tested:

| Reverted | Result |
|---|---|
| JSONDecodeError redaction | 3 failed |
| scalar-body redaction | 1 failed |
| neither (as landed) | 6 passed |

`2267 passed, 7 skipped`; `nox -s lint` and `nox -s typecheck` green (rebased onto #290).

Refs #252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)