### PR TITLE
fix(ci): split the TestPyPI PR comment off the OIDC job (#252)

### DIFF
--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -162,10 +162,12 @@ jobs:
     environment:
       name: testpypi
       url: https://test.pypi.org/project/fmp-data/${{ needs.test-release-build.outputs.version }}/
+    # Publishing credential only. `pull-requests: write` / `issues: write`
+    # existed solely to post the PR comment, which now runs in its own job:
+    # nothing that holds the TestPyPI OIDC token should also be able to write
+    # to the repository (#252 FMP-SEC-002).
     permissions:
       id-token: write
-      pull-requests: write
-      issues: write
       contents: read
 
     steps:
@@ -191,6 +193,17 @@ jobs:
           verbose: true
           print-hash: true
 
+  test-release-comment:
+    # Repo-write scopes live here, isolated from the publishing credential.
+    # This job never sees an OIDC token and never touches the artifact.
+    needs: [test-release-build, test-release-publish]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+      contents: read
+
+    steps:
       - name: 📝  Comment on PR
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,18 @@ None. No FMP path we ship was newly retired by this changelog window.
 
 ### Security
 
+- **The TestPyPI publish job no longer holds repo-write (#252 FMP-SEC-002).**
+  ``test-release-publish`` carried ``pull-requests: write`` and
+  ``issues: write`` alongside ``id-token: write`` purely so it could post
+  the "test release published" PR comment. Anything running in that job —
+  a compromised action, a malicious build dependency — could reach both
+  the TestPyPI OIDC token and the repository. The comment now runs in a
+  separate ``test-release-comment`` job with no OIDC token and no access
+  to the artifact; the publishing job is down to ``id-token: write`` plus
+  ``contents: read``. A new test walks every workflow and fails on any
+  job combining ``id-token: write`` with another write scope (the
+  ``actions/deploy-pages`` job is exempted narrowly, scoped to the
+  ``github-pages`` environment, since that pairing is mandatory there).
 - **``Authorization: Bearer`` no longer crashes the log filter, and
   tracebacks are actually redacted (#252 FMP-SEC-005).**
   ``SensitiveDataFilter`` read capture group 3 for every pattern, but

--- a/tests/unit/test_workflow_permission_isolation.py
+++ b/tests/unit/test_workflow_permission_isolation.py
@@ -1,0 +1,110 @@
+"""No job holds a publishing credential and repo-write at the same time (#252).
+
+``id-token: write`` mints the OIDC token PyPI/TestPyPI trust to accept an
+upload. Any other write scope in the *same* job is reachable by anything that
+runs there -- a compromised action, a malicious build dependency, an injected
+script step. Keeping the two apart is what makes the publish job's blast
+radius "can upload the artifact it was handed" rather than "can upload *and*
+rewrite the repository".
+
+``publish-testpypi.yml`` carried ``pull-requests: write`` + ``issues: write``
+on the job holding ``id-token: write`` purely to post a PR comment. The
+comment now runs in its own job with no OIDC token.
+
+These assertions walk every workflow rather than the one that was wrong, so a
+new job cannot quietly reintroduce the combination.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = sorted((REPO_ROOT / ".github" / "workflows").glob("*.yml"))
+
+# `actions/deploy-pages` mandates `pages: write` + `id-token: write` together;
+# the token it mints is a Pages deployment token, not a package-index one, and
+# the job is already artifact-only with no checkout. Scoped to the
+# `github-pages` environment so the exemption cannot be borrowed by a job that
+# publishes somewhere else.
+PAGES_DEPLOY_ENVIRONMENT = "github-pages"
+
+
+def _jobs(path: Path) -> dict[str, Any]:
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(loaded, dict), f"{path.name} is not a mapping"
+    jobs = loaded.get("jobs") or {}
+    assert isinstance(jobs, dict)
+    return jobs
+
+
+def _write_scopes(permissions: Any) -> set[str]:
+    """Scopes granted at ``write`` level, ignoring ``contents: read`` etc."""
+    if not isinstance(permissions, dict):
+        # `permissions: write-all` (or any scalar) is never acceptable on a
+        # job we are reasoning about; surface it as every scope at once.
+        return {str(permissions)}
+    return {scope for scope, level in permissions.items() if level == "write"}
+
+
+def test_workflows_are_parseable() -> None:
+    assert WORKFLOWS, "no workflows found; the glob or path is wrong"
+    for path in WORKFLOWS:
+        _jobs(path)
+
+
+def _environment_name(job: dict[str, Any]) -> str | None:
+    env = job.get("environment")
+    if isinstance(env, dict):
+        return str(env.get("name")) if env.get("name") else None
+    return str(env) if env else None
+
+
+@pytest.mark.parametrize("path", WORKFLOWS, ids=lambda p: p.name)
+def test_no_job_mixes_oidc_with_repo_write(path: Path) -> None:
+    offenders = []
+    for name, job in _jobs(path).items():
+        scopes = _write_scopes(job.get("permissions"))
+        if "id-token" not in scopes:
+            continue
+        allowed = {"id-token"}
+        if _environment_name(job) == PAGES_DEPLOY_ENVIRONMENT:
+            allowed.add("pages")
+        extra = scopes - allowed
+        if extra:
+            offenders.append(f"{name}: id-token + {sorted(extra)}")
+
+    assert not offenders, (
+        f"{path.name} grants repo-write alongside the publishing credential: "
+        f"{offenders}. Move the write-scoped steps into their own job."
+    )
+
+
+def test_the_testpypi_comment_is_a_separate_job() -> None:
+    """Pin the specific split, so it cannot be merged back in.
+
+    The generic check above passes if the comment step is simply deleted;
+    this asserts the capability still exists, just somewhere safe.
+    """
+    jobs = _jobs(REPO_ROOT / ".github" / "workflows" / "publish-testpypi.yml")
+
+    publish = jobs["test-release-publish"]
+    comment = jobs["test-release-comment"]
+
+    assert _write_scopes(publish.get("permissions")) == {"id-token"}
+    assert "id-token" not in _write_scopes(comment.get("permissions"))
+    assert _write_scopes(comment.get("permissions")) == {"pull-requests", "issues"}
+
+    # The comment must still run, and only after a successful publish --
+    # otherwise it advertises a version that was never uploaded.
+    assert set(comment["needs"]) == {"test-release-build", "test-release-publish"}
+    assert any("Comment on PR" in str(s.get("name", "")) for s in comment["steps"])
+
+    # And it must not have quietly kept a copy of the artifact or the token.
+    assert "environment" not in comment
+    step_uses = " ".join(str(s.get("uses", "")) for s in comment["steps"])
+    assert "download-artifact" not in step_uses


### PR DESCRIPTION
## What

`test-release-publish` held `pull-requests: write` and `issues: write` alongside `id-token: write` for exactly one reason — to post the "test release published" PR comment:

```yaml
permissions:
  id-token: write
  pull-requests: write   # <- only for the comment step
  issues: write          # <- only for the comment step
  contents: read
```

That put the TestPyPI publishing credential and repo-write capability in the same job, reachable by anything running there: a compromised action, a malicious build dependency, an injected script step.

## Change

| Job | Before | After |
|---|---|---|
| `test-release-publish` | `id-token`, `pull-requests`, `issues` | `id-token` only (+ `contents: read`) |
| `test-release-comment` | — (new) | `pull-requests`, `issues`; **no** OIDC token, no environment, no artifact |

`test-release-comment` declares both upstream jobs in `needs`, so it still resolves `needs.test-release-build.outputs.*` and only runs after a **successful** publish — it must not advertise a version that was never uploaded.

## Test

The new test walks **every** workflow, not the one that was wrong, and fails any job combining `id-token: write` with another write scope. It also pins this specific split, because the generic check would pass equally well if the comment step were simply deleted — so it asserts the capability still exists, just somewhere safe.

The sweep immediately surfaced one **legitimate** pairing worth recording: `document.yml`'s `deploy-docs` needs `pages: write` + `id-token: write` together, which `actions/deploy-pages` mandates. That token is a Pages deployment token, not a package-index one, and the job is already artifact-only with no checkout. Exempted narrowly — keyed to the `github-pages` environment, so a job publishing anywhere else cannot borrow the exemption.

## Verification

Mutation-tested — restoring the combined permissions reds both tests:

```
FAILED test_no_job_mixes_oidc_with_repo_write[publish-testpypi.yml]
FAILED test_the_testpypi_comment_is_a_separate_job
```

`24 passed` across the workflow meta-tests; `nox -s lint` and `nox -s typecheck` green.

> Not in this PR: `release.yml`'s build job (the other half of the issue's L3 item). Its `contents: write` is genuinely required — it pushes the tag and creates the Release — so it needs a different treatment, and there is a `hatch-vcs` ordering trap in it. Separate PR.

Refs #252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)