### PR TITLE
fix(sec)!: type credential config fields as SecretStr (#252)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -269,14 +269,14 @@
         "filename": "tests/unit/lc/test_config.py",
         "hashed_secret": "46e9122567abad042837c395bc98095a6cd417b3",
         "is_verified": false,
-        "line_number": 70
+        "line_number": 71
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/lc/test_config.py",
         "hashed_secret": "e242ca24e021d3f3906758434300a2241bd5554f",
         "is_verified": false,
-        "line_number": 71
+        "line_number": 72
       }
     ],
     "tests/unit/lc/test_embedding.py": [
@@ -360,13 +360,6 @@
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/test_client.py",
-        "hashed_secret": "767ef7376d44bb6e52b390ddcd12c1cb1b3902a4",
-        "is_verified": false,
-        "line_number": 26
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/unit/test_client.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
         "line_number": 34
@@ -386,13 +379,6 @@
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
         "line_number": 369
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/unit/test_config.py",
-        "hashed_secret": "172ce43af039f34e03db145738088d0addc715d9",
-        "is_verified": false,
-        "line_number": 432
       },
       {
         "type": "Secret Keyword",
@@ -525,5 +511,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-14T14:04:18Z"
+  "generated_at": "2026-08-14T15:03:29Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,39 @@ None. No FMP path we ship was newly retired by this changelog window.
 
 ### Changed
 
+- **BREAKING: credential config fields are `pydantic.SecretStr` (#252
+  FMP-SEC-007).** `ClientConfig.api_key`, `LangChainConfig.embedding_api_key`,
+  `EmbeddingConfig.api_key` and `CacheConfig.redis_url` changed type.
+
+  `repr()` and `str()` were already redacted, but `model_dump()` and
+  `model_dump_json()` returned every one of them in cleartext — so anything
+  serializing a config (a structured log, a JSON dump, an error report) leaked
+  the key. `SecretStr` closes that at the type level, including for
+  third-party callers who invoke `model_dump()` themselves.
+
+  **Migration:** read the value with `.get_secret_value()`.
+
+  ```python
+  # before
+  client = FMPDataClient(api_key=config.api_key)
+  # after
+  client = FMPDataClient(api_key=config.api_key.get_secret_value())
+  ```
+
+  Construction is unchanged — passing a plain `str` still works, pydantic
+  coerces it. Truthiness checks (`if not config.api_key`) still work. What
+  breaks is code that *reads* the field expecting a `str`: comparisons
+  against a string, slicing, or passing it into a `str`-typed parameter.
+
+  Note that passing a `SecretStr` where a string is expected often fails
+  *silently* rather than loudly — `httpx` accepts it and sends
+  `apikey=**********`, producing 401s with no local error. If you see
+  unexplained auth failures after upgrading, look for a missed
+  `.get_secret_value()`.
+
+  `ClientConfig.validate_api_key` now also rejects a key consisting only of
+  asterisks, which is what rebuilding a config from a masked dump produces.
+
 - **List-returning requests are `list[T]` without collapsing `request()` (#235).**
   `BaseClient.request` stays `Endpoint[T] -> T | list[T]`. Company list
   methods stay on `request()` (so existing mocks still work) and normalize

--- a/README.md
+++ b/README.md
@@ -298,8 +298,10 @@ client = FMPDataClient(config=config)
 
 # Create vector store using the config
 vector_store = create_vector_store(
-    fmp_api_key=config.api_key,  # pragma: allowlist secret
-    openai_api_key=config.embedding_api_key,  # pragma: allowlist secret
+    # Credential fields are `SecretStr`, so `model_dump()` cannot leak them.
+    # Unwrap with `.get_secret_value()` wherever a plain string is required.
+    fmp_api_key=config.api_key.get_secret_value(),  # pragma: allowlist secret
+    openai_api_key=config.embedding_api_key.get_secret_value(),  # pragma: allowlist secret
     cache_dir=config.vector_store_path,
     embedding_provider=config.embedding_provider,
     embedding_model=config.embedding_model,

--- a/fmp_data/base.py
+++ b/fmp_data/base.py
@@ -537,9 +537,12 @@ class BaseClient:
             # Build URL
             url = endpoint.build_url(self.config.base_url, validated_params)
 
-            # Extract query parameters and add API key
+            # Extract query parameters and add API key.
+            # `.get_secret_value()` is mandatory here: httpx accepts a
+            # SecretStr and stringifies it, so a missed unwrap silently sends
+            # `apikey=**********` and every request 401s (#252).
             query_params = endpoint.get_query_params(validated_params)
-            query_params["apikey"] = self.config.api_key
+            query_params["apikey"] = self.config.api_key.get_secret_value()
 
             # Check cache before rate limiting — cache hits are free
             cache_key: str | None = None
@@ -1128,9 +1131,12 @@ class BaseClient:
             # Build URL
             url = endpoint.build_url(self.config.base_url, validated_params)
 
-            # Extract query parameters and add API key
+            # Extract query parameters and add API key.
+            # `.get_secret_value()` is mandatory here: httpx accepts a
+            # SecretStr and stringifies it, so a missed unwrap silently sends
+            # `apikey=**********` and every request 401s (#252).
             query_params = endpoint.get_query_params(validated_params)
-            query_params["apikey"] = self.config.api_key
+            query_params["apikey"] = self.config.api_key.get_secret_value()
 
             # Check cache before rate limiting — cache hits are free
             cache_key: str | None = None

--- a/fmp_data/cache/__init__.py
+++ b/fmp_data/cache/__init__.py
@@ -43,6 +43,12 @@ def create_backend(config: CacheConfig) -> CacheBackend:
     if config.backend == "redis":
         from fmp_data.cache.redis_backend import RedisCache
 
-        redis_url = config.redis_url or "redis://localhost:6379/0"
+        # `redis.from_url` needs the real string; a SecretStr raises
+        # AttributeError on `.startswith` (#252).
+        redis_url = (
+            config.redis_url.get_secret_value()
+            if config.redis_url
+            else "redis://localhost:6379/0"
+        )
         return RedisCache(redis_url=redis_url, default_ttl=config.default_ttl)
     raise ValueError(f"Unknown cache backend: {config.backend!r}")

--- a/fmp_data/cache/config.py
+++ b/fmp_data/cache/config.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Literal
 import warnings
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, SecretStr, model_validator
 
 
 @functools.lru_cache(maxsize=1)
@@ -61,22 +61,32 @@ class CacheConfig(BaseModel):
     cache_dir: Path | None = Field(
         default=None, description="Directory for file-based cache"
     )
-    redis_url: str | None = Field(
-        default=None, description="Redis connection URL", repr=False
+    redis_url: SecretStr | None = Field(
+        default=None,
+        description=(
+            "Redis connection URL. May carry userinfo credentials, so it is "
+            "a SecretStr: read it with `config.redis_url.get_secret_value()`."
+        ),
+        repr=False,
     )
 
     def __str__(self) -> str:
         from urllib.parse import urlsplit, urlunsplit
 
         data = self.model_dump()
-        url = data.get("redis_url")
+        # Compute from the field: the dump now holds `SecretStr('**********')`,
+        # which has no parseable netloc left to redact (#252). Assign back
+        # unconditionally so a credential-free URL still shows its host --
+        # only the userinfo is secret, and the host is what makes this string
+        # worth printing.
+        url = self.redis_url.get_secret_value() if self.redis_url else None
         if isinstance(url, str) and url:
             parts = urlsplit(url)
             if parts.username or parts.password:
                 host = parts.hostname or ""
                 if parts.port:
                     host = f"{host}:{parts.port}"
-                data["redis_url"] = urlunsplit(
+                url = urlunsplit(
                     (
                         parts.scheme,
                         f"***@{host}",
@@ -85,6 +95,7 @@ class CacheConfig(BaseModel):
                         parts.fragment,
                     )
                 )
+            data["redis_url"] = url
         return f"CacheConfig({data})"
 
     def __repr__(self) -> str:

--- a/fmp_data/config.py
+++ b/fmp_data/config.py
@@ -15,10 +15,22 @@ from pathlib import Path
 from typing import Any, Literal
 from urllib.parse import urlparse, urlsplit, urlunsplit
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator
 
 from fmp_data.cache.config import CacheConfig
 from fmp_data.exceptions import ConfigError
+
+
+def _reveal(value: SecretStr | str | None) -> str | None:
+    """Unwrap a possibly-``SecretStr`` credential for use at the wire.
+
+    Credential fields are ``SecretStr`` so ``model_dump`` and
+    ``model_dump_json`` cannot emit them (#252); every point that actually
+    *uses* the value goes through here.
+    """
+    if value is None:
+        return None
+    return value.get_secret_value() if isinstance(value, SecretStr) else value
 
 
 def _is_loopback_host(hostname: str | None) -> bool:
@@ -29,17 +41,19 @@ def _is_loopback_host(hostname: str | None) -> bool:
     return host in {"localhost", "127.0.0.1", "::1"} or host.startswith("127.")
 
 
-def _mask_secret(value: str) -> str:
-    if len(value) > 4:
-        return f"{value[:4]}***"
+def _mask_secret(value: SecretStr | str) -> str:
+    revealed = _reveal(value) or ""
+    if len(revealed) > 4:
+        return f"{revealed[:4]}***"
     return "***"
 
 
-def _redact_url_userinfo(url: str) -> str:
+def _redact_url_userinfo(url: SecretStr | str) -> str:
     """Drop userinfo from a URL so ``redis://:hunter2@host`` cannot leak."""
-    parts = urlsplit(url)
+    revealed = _reveal(url) or ""
+    parts = urlsplit(revealed)
     if not (parts.username or parts.password):
-        return url
+        return revealed
     host = parts.hostname or ""
     if parts.port:
         host = f"{host}:{parts.port}"
@@ -210,8 +224,11 @@ class ClientConfig(BaseModel):
         str_strip_whitespace=True,
     )
 
-    api_key: str = Field(
-        description="FMP API key. Can be set via FMP_API_KEY environment variable",
+    api_key: SecretStr = Field(
+        description=(
+            "FMP API key. Can be set via FMP_API_KEY environment variable. "
+            "Read the value with `config.api_key.get_secret_value()`."
+        ),
         repr=False,  # Exclude API key from repr
     )
     timeout: int = Field(default=30, gt=0, description="Request timeout in seconds")
@@ -268,11 +285,29 @@ class ClientConfig(BaseModel):
 
     @field_validator("api_key")
     @classmethod
-    def validate_api_key(cls, v: str) -> str:
-        """Validate API key is not empty"""
-        if not v or not v.strip():
+    def validate_api_key(cls, v: SecretStr) -> SecretStr:
+        """Validate API key is not empty.
+
+        Unwraps first: ``model_config``'s ``str_strip_whitespace`` does not
+        reach inside a ``SecretStr``, and ``SecretStr`` has no ``.strip()``,
+        so the stripping this validator has always done has to be explicit
+        now (#252).
+        """
+        revealed = (_reveal(v) or "").strip()
+        if not revealed:
             raise ValueError("API key cannot be empty")
-        return v.strip()
+        if set(revealed) == {"*"}:
+            # A value of nothing but asterisks is a redaction marker that has
+            # been round-tripped back in as if it were real -- e.g. rebuilding
+            # a config from `model_dump(mode="json")`. Accepting it produces a
+            # client that 401s on every call with no local error, so fail here
+            # where the cause is still visible (#252).
+            raise ValueError(
+                "API key looks like a redaction mask, not a key. It was "
+                "probably read back from a masked dump; use "
+                "`config.api_key.get_secret_value()` to obtain the real value."
+            )
+        return SecretStr(revealed)
 
     @field_validator("base_url")
     @classmethod
@@ -305,16 +340,23 @@ class ClientConfig(BaseModel):
         return v
 
     def __str__(self) -> str:
-        """String representation with masked API key"""
-        # Create a copy of the model dict with masked API key
+        """String representation with masked API key.
+
+        The masks are computed from the *fields*, not from ``model_dump()``.
+        Now that the credential fields are ``SecretStr`` the dump already
+        yields ``SecretStr('**********')``, and re-masking that would print
+        a mask of a mask -- losing the leading-4-character affordance that
+        makes this string useful for telling two keys apart.
+        """
         data = self.model_dump()
         if data.get("api_key"):
-            data["api_key"] = _mask_secret(str(data["api_key"]))
-        if data.get("embedding_api_key"):
-            data["embedding_api_key"] = _mask_secret(str(data["embedding_api_key"]))
+            data["api_key"] = _mask_secret(self.api_key)
+        embedding_api_key = getattr(self, "embedding_api_key", None)
+        if data.get("embedding_api_key") and embedding_api_key:
+            data["embedding_api_key"] = _mask_secret(embedding_api_key)
         cache = data.get("cache")
-        if isinstance(cache, dict) and cache.get("redis_url"):
-            cache["redis_url"] = _redact_url_userinfo(str(cache["redis_url"]))
+        if isinstance(cache, dict) and cache.get("redis_url") and self.cache:
+            cache["redis_url"] = _redact_url_userinfo(self.cache.redis_url or "")
 
         # Create a string representation from the masked data
         fields = []

--- a/fmp_data/lc/config.py
+++ b/fmp_data/lc/config.py
@@ -1,7 +1,7 @@
 # fmp_data/lc/config.py
 import os
 
-from pydantic import ConfigDict, Field
+from pydantic import ConfigDict, Field, SecretStr
 
 from fmp_data.config import ClientConfig
 from fmp_data.lc.embedding import EmbeddingConfig, EmbeddingProvider
@@ -23,9 +23,12 @@ class LangChainConfig(ClientConfig):
     embedding_model: str | None = Field(
         default=None, description="Model name for embeddings"
     )
-    embedding_api_key: str | None = Field(
+    embedding_api_key: SecretStr | None = Field(
         default=None,
-        description="API key for embedding provider",
+        description=(
+            "API key for embedding provider. Read the value with "
+            "`config.embedding_api_key.get_secret_value()`."
+        ),
         repr=False,
     )
 
@@ -58,7 +61,14 @@ class LangChainConfig(ClientConfig):
     @classmethod
     def from_env(cls) -> "LangChainConfig":
         """Create LangChain config from environment variables."""
-        # Get base config first
+        # Get base config first.
+        # Python-mode `model_dump()` on purpose: it yields the SecretStr
+        # *objects*, which re-validate into this model unchanged. Switching to
+        # `mode="json"` or `model_dump_json()` -- the reflex, since SecretStr
+        # is not JSON-serialisable -- substitutes the literal mask, and
+        # `validate_api_key` accepts `'**********'` as a perfectly good key.
+        # The result is a client that 401s on every request with no local
+        # error (#252).
         base_config = super().from_env()
         config_dict = base_config.model_dump()
 

--- a/fmp_data/lc/embedding.py
+++ b/fmp_data/lc/embedding.py
@@ -5,7 +5,7 @@ import os
 from typing import Any
 
 from langchain_core.embeddings import Embeddings
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, SecretStr
 
 from fmp_data.exceptions import ConfigError
 from fmp_data.lc.utils import check_package_dependency
@@ -78,9 +78,12 @@ class EmbeddingConfig(BaseModel):
     model_name: str | None = Field(
         default=None, description="Model name for the embedding provider"
     )
-    api_key: str | None = Field(
+    api_key: SecretStr | None = Field(
         default=None,
-        description="API key for the embedding provider",
+        description=(
+            "API key for the embedding provider. Read the value with "
+            "`config.api_key.get_secret_value()`."
+        ),
         repr=False,
     )
     additional_kwargs: dict[str, Any] = Field(
@@ -126,7 +129,9 @@ class EmbeddingConfig(BaseModel):
                 from langchain_openai import OpenAIEmbeddings
 
                 return OpenAIEmbeddings(
-                    openai_api_key=self.api_key,
+                    # Providers take a plain string; a SecretStr would be
+                    # stringified to its mask and authenticate as nobody (#252).
+                    openai_api_key=self.api_key.get_secret_value(),
                     model=self.model_name or "text-embedding-ada-002",
                     **self.additional_kwargs,
                 )
@@ -155,7 +160,7 @@ class EmbeddingConfig(BaseModel):
                 from langchain_community.embeddings import CohereEmbeddings
 
                 return CohereEmbeddings(
-                    cohere_api_key=self.api_key,
+                    cohere_api_key=self.api_key.get_secret_value(),
                     model=self.model_name or "embed-english-v2.0",
                     **self.additional_kwargs,
                 )

--- a/tests/integration/test_lc.py
+++ b/tests/integration/test_lc.py
@@ -48,7 +48,7 @@ def vector_store(
     # sentinel the fixture has to interpret.
     try:
         store = create_vector_store(
-            fmp_api_key=fmp_client.config.api_key,
+            fmp_api_key=fmp_client.config.api_key.get_secret_value(),
             openai_api_key=openai_api_key,
             cache_dir=str(cache_dir),
             store_name="test_store",
@@ -82,7 +82,7 @@ class TestLangChainIntegration:
     ):
         """Test vector store creation and basic functionality"""
         store = create_vector_store(
-            fmp_api_key=fmp_client.config.api_key,
+            fmp_api_key=fmp_client.config.api_key.get_secret_value(),
             openai_api_key=openai_api_key,
             cache_dir=str(tmp_path),
             store_name="test_store",

--- a/tests/unit/lc/test_config.py
+++ b/tests/unit/lc/test_config.py
@@ -36,7 +36,7 @@ def test_langchain_config_validation():
         similarity_threshold=0.5,
         max_tools=5,
     )
-    assert config.api_key == "test-key"
+    assert config.api_key.get_secret_value() == "test-key"
     assert config.embedding_provider == EmbeddingProvider.OPENAI
     assert config.similarity_threshold == 0.5
 
@@ -56,10 +56,11 @@ def test_langchain_config_from_env(lc_env_vars, tmp_path):
     """Test LangChain configuration from environment variables"""
     config = LangChainConfig.from_env()
 
-    assert config.api_key == "test-fmp-key"
+    assert config.api_key.get_secret_value() == "test-fmp-key"
     assert config.embedding_provider == EmbeddingProvider.OPENAI
     assert config.embedding_model == "text-embedding-ada-002"
-    assert config.embedding_api_key == "test-openai-key"
+    assert config.embedding_api_key is not None
+    assert config.embedding_api_key.get_secret_value() == "test-openai-key"
     assert config.vector_store_path == str(tmp_path / "vector_store")
     assert config.similarity_threshold == 0.5
     assert config.max_tools == 10
@@ -72,4 +73,5 @@ def test_embedding_api_key_not_in_repr() -> None:
     )
     assert "openai-secret-key" not in repr(config)
     assert "openai-secret-key" not in str(config)
-    assert config.embedding_api_key == "openai-secret-key"
+    assert config.embedding_api_key is not None
+    assert config.embedding_api_key.get_secret_value() == "openai-secret-key"

--- a/tests/unit/lc/test_embedding.py
+++ b/tests/unit/lc/test_embedding.py
@@ -100,7 +100,8 @@ def test_embedding_config_validation():
         model_name="text-embedding-ada-002",
     )
     assert config.provider == EmbeddingProvider.OPENAI
-    assert config.api_key == "test-key"
+    assert config.api_key is not None
+    assert config.api_key.get_secret_value() == "test-key"
 
     # Test valid HuggingFace config without API key
     config = EmbeddingConfig(

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -163,9 +163,16 @@ def test_base_client_query_params(client_config):
         mock_request.return_value.json.return_value = {}
         client.request(endpoint)
 
-        # Verify API key was added to params
+        # Verify API key was added to params.
+        # Assert the literal value, not `== client_config.api_key`: with
+        # SecretStr fields that comparison passes vacuously the moment both
+        # sides are masked, so it would go green on a client sending
+        # `apikey=**********`. httpx accepts a SecretStr and stringifies it,
+        # so that failure is silent (#252).
         called_params = mock_request.call_args[1]["params"]
-        assert called_params["apikey"] == client_config.api_key
+        assert called_params["apikey"] == client_config.api_key.get_secret_value()
+        assert isinstance(called_params["apikey"], str)
+        assert set(called_params["apikey"]) != {"*"}
         assert called_params["param1"] == "value1"
 
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -23,7 +23,7 @@ class TestFMPDataClientInitialization:
     def test_client_initialization_with_config(self, client_config):
         """Test client initialization with config object"""
         client = FMPDataClient(config=client_config)
-        assert client.config.api_key == "test_api_key"
+        assert client.config.api_key.get_secret_value() == "test_api_key"
         assert client.config.base_url == "https://test.financialmodelingprep.com/api"
         assert client._initialized is True
         client.close()
@@ -37,7 +37,7 @@ class TestFMPDataClientInitialization:
             base_url="https://custom.api.com",
             debug=True,
         )
-        assert client.config.api_key == "test_key"
+        assert client.config.api_key.get_secret_value() == "test_key"
         assert client.config.timeout == 60
         assert client.config.max_retries == 5
         assert client.config.base_url == "https://custom.api.com"
@@ -121,7 +121,7 @@ class TestFMPDataClientFromEnv:
     def test_from_env_basic(self):
         """Test basic from_env functionality"""
         client = FMPDataClient.from_env()
-        assert client.config.api_key == "env_test_key"
+        assert client.config.api_key.get_secret_value() == "env_test_key"
         assert client._initialized is True
         client.close()
 
@@ -129,7 +129,7 @@ class TestFMPDataClientFromEnv:
     def test_from_env_with_debug(self):
         """Test from_env with debug mode"""
         client = FMPDataClient.from_env(debug=True)
-        assert client.config.api_key == "env_test_key"
+        assert client.config.api_key.get_secret_value() == "env_test_key"
         assert client.config.logging.level == "DEBUG"
         assert client.config.logging.handlers["console"].level == "DEBUG"
         client.close()
@@ -138,7 +138,7 @@ class TestFMPDataClientFromEnv:
     def test_from_env_debug_false(self):
         """Test from_env with debug explicitly False"""
         client = FMPDataClient.from_env(debug=False)
-        assert client.config.api_key == "env_test_key"
+        assert client.config.api_key.get_secret_value() == "env_test_key"
         # Should use default config logging levels
         client.close()
 
@@ -180,7 +180,7 @@ class TestFMPDataClientContextManager:
     def test_context_manager_basic_usage(self):
         """Test basic context manager functionality"""
         with FMPDataClient(api_key="test_key") as client:
-            assert client.config.api_key == "test_key"
+            assert client.config.api_key.get_secret_value() == "test_key"
             assert client._initialized is True
             assert client.client is not None
             assert not client.client.is_closed

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -368,7 +368,7 @@ class TestClientConfig:
         config = ClientConfig(
             api_key="test_key", base_url="https://api.test.com", timeout=60
         )
-        assert config.api_key == "test_key"
+        assert config.api_key.get_secret_value() == "test_key"
         assert config.base_url == "https://api.test.com"
         assert config.timeout == 60
 
@@ -429,7 +429,7 @@ class TestClientConfig:
         """Test API key validation"""
         # Valid API key
         config = ClientConfig(api_key="valid_key")
-        assert config.api_key == "valid_key"
+        assert config.api_key.get_secret_value() == "valid_key"
 
         # Empty API key should fail
         with pytest.raises(ValidationError):
@@ -485,7 +485,7 @@ class TestClientConfig:
             )
 
             config = ClientConfig.from_env()
-            assert config.api_key == "env_test_key"
+            assert config.api_key.get_secret_value() == "env_test_key"
             assert config.base_url == "https://env.api.com"
             assert config.timeout == 45
             assert config.max_retries == 4
@@ -513,7 +513,7 @@ class TestClientConfig:
             # Don't set other variables
 
             config = ClientConfig.from_env()
-            assert config.api_key == "test_key"
+            assert config.api_key.get_secret_value() == "test_key"
             # Should use defaults for other values
             assert config.timeout == 30
             assert config.max_retries == 3
@@ -649,7 +649,7 @@ class TestConfigEdgeCases:
             )
 
             config = ClientConfig.from_env()
-            assert config.api_key == "test_key"
+            assert config.api_key.get_secret_value() == "test_key"
             # Should use defaults and not be affected by unknown vars
 
     def test_path_handling_edge_cases(self, tmp_path):
@@ -689,7 +689,7 @@ class TestConfigEdgeCases:
             base_url="https://api-test.example.com",  # Using simple ASCII URL
         )
 
-        assert config.api_key == "test_key_with_特殊字符"
+        assert config.api_key.get_secret_value() == "test_key_with_特殊字符"
 
     def test_nested_config_modification(self):
         """Test modifying nested configuration objects"""

--- a/tests/unit/test_config_secret_serialization.py
+++ b/tests/unit/test_config_secret_serialization.py
@@ -1,0 +1,152 @@
+"""Credential config fields survive serialization without leaking (#252).
+
+``repr`` and ``str`` were redacted by hand long before this, but
+``model_dump()`` and ``model_dump_json()`` returned every credential in
+cleartext — so anything that serialized a config (structured logging, a JSON
+error report, a config endpoint) leaked the key while the eyeball-level checks
+all looked clean.
+
+Hand-written ``__repr__``/``__str__`` cannot close that: a third party calling
+``model_dump()`` never goes through them. Typing the fields ``SecretStr`` moves
+the guarantee into pydantic, where every serialization path inherits it.
+
+These tests drive all four models over every escape route, and pin the two
+properties that make the migration safe rather than merely quiet:
+
+* the real value still reaches the wire (a missed ``.get_secret_value()``
+  fails *silently* — httpx stringifies a ``SecretStr`` to its mask);
+* a python-mode dump still round-trips, because ``LangChainConfig.from_env``
+  rebuilds itself through one.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from fmp_data.cache.config import CacheConfig
+from fmp_data.config import ClientConfig
+
+API_KEY = "SUPERSECRETKEY123456"  # pragma: allowlist secret
+REDIS_PASSWORD = "hunter2"  # noqa: S105  # pragma: allowlist secret
+REDIS_URL = f"redis://:{REDIS_PASSWORD}@localhost:6379/0"
+
+
+@pytest.fixture
+def config() -> ClientConfig:
+    return ClientConfig(
+        api_key=API_KEY,
+        cache=CacheConfig(backend="redis", redis_url=REDIS_URL),
+    )
+
+
+def _renderings(model: object) -> dict[str, str]:
+    """Every way a caller can turn a model into text."""
+    return {
+        "repr": repr(model),
+        "str": str(model),
+        "model_dump": str(model.model_dump()),  # type: ignore[attr-defined]
+        "model_dump(mode=json)": str(model.model_dump(mode="json")),  # type: ignore[attr-defined]
+        "model_dump_json": model.model_dump_json(),  # type: ignore[attr-defined]
+    }
+
+
+def test_client_config_never_renders_the_api_key(config: ClientConfig) -> None:
+    for label, text in _renderings(config).items():
+        assert API_KEY not in text, f"api_key leaked via {label}: {text[:200]}"
+
+
+def test_client_config_never_renders_nested_redis_credentials(
+    config: ClientConfig,
+) -> None:
+    for label, text in _renderings(config).items():
+        assert REDIS_PASSWORD not in text, f"redis userinfo leaked via {label}"
+
+
+def test_cache_config_never_renders_redis_credentials() -> None:
+    cache = CacheConfig(backend="redis", redis_url=REDIS_URL)
+    for label, text in _renderings(cache).items():
+        assert REDIS_PASSWORD not in text, f"redis userinfo leaked via {label}"
+
+
+def test_str_keeps_the_leading_characters_of_the_key(config: ClientConfig) -> None:
+    """The mask is still useful for telling two keys apart.
+
+    ``__str__`` derives it from the *field*, not from ``model_dump()`` — the
+    dump is already masked, and masking a mask would print ``'*******'`` for
+    every key alike.
+    """
+    assert f"api_key='{API_KEY[:4]}***'" in str(config)
+
+
+def test_cache_str_still_shows_the_host() -> None:
+    """Only the userinfo is secret; the host is why this string is printed."""
+    text = str(CacheConfig(backend="redis", redis_url=REDIS_URL))
+    assert REDIS_PASSWORD not in text
+    assert "localhost:6379" in text
+
+
+def test_the_real_key_reaches_the_wire(config: ClientConfig) -> None:
+    """The silent-failure guard.
+
+    ``httpx`` accepts a ``SecretStr`` query param and stringifies it, so a
+    missed ``.get_secret_value()`` sends ``apikey=**********`` and 401s with
+    no local error. Assert the literal value rather than comparing against
+    the config field, which would match vacuously once both sides are masked.
+    """
+    request = httpx.Request(
+        "GET",
+        "https://financialmodelingprep.com/stable/profile",
+        params={"apikey": config.api_key.get_secret_value(), "symbol": "AAPL"},
+    )
+    assert f"apikey={API_KEY}" in str(request.url)
+    assert "%2A" not in str(request.url)
+
+
+def test_python_mode_dump_round_trips(config: ClientConfig) -> None:
+    """``LangChainConfig.from_env`` rebuilds itself through this exact path."""
+    rebuilt = ClientConfig(**config.model_dump())
+    assert rebuilt.api_key.get_secret_value() == API_KEY
+    assert rebuilt.cache is not None
+    assert rebuilt.cache.redis_url is not None
+    assert rebuilt.cache.redis_url.get_secret_value() == REDIS_URL
+
+
+def test_json_mode_round_trip_is_refused_rather_than_silently_wrong(
+    config: ClientConfig,
+) -> None:
+    """A masked dump must not validate back into a working-looking config.
+
+    ``mode="json"`` is the natural reflex, since ``SecretStr`` is not
+    JSON-serialisable — and it substitutes the literal mask. Accepting
+    ``'**********'`` as a key yields a client that 401s on every call with
+    nothing to point at locally, so it is rejected at construction.
+    """
+    with pytest.raises(ValueError, match="redaction mask"):
+        ClientConfig(**json.loads(config.model_dump_json()))
+
+
+def test_plain_strings_are_still_accepted_at_construction() -> None:
+    """Callers passing a `str` keep working; only *reads* changed."""
+    assert ClientConfig(api_key=API_KEY).api_key.get_secret_value() == API_KEY
+
+
+def test_whitespace_is_still_stripped() -> None:
+    """`str_strip_whitespace` does not reach inside a SecretStr."""
+    assert ClientConfig(api_key=f"  {API_KEY}  ").api_key.get_secret_value() == API_KEY
+
+
+@pytest.mark.parametrize("value", ["", "   "])
+def test_empty_keys_are_still_rejected(value: str) -> None:
+    with pytest.raises(ValueError, match="cannot be empty"):
+        ClientConfig(api_key=value)
+
+
+def test_truthiness_still_works_for_the_client_guards() -> None:
+    """`fmp_data/client.py` and `async_client.py` test `not config.api_key`."""
+    from pydantic import SecretStr
+
+    assert not SecretStr("")
+    assert SecretStr("x")


### PR DESCRIPTION
Closes the last code item on #252: `model_dump()` / `model_dump_json()` emitted every credential in cleartext.

## The hole

`repr` and `str` were hand-redacted long ago. The dumps were not:

| | api_key | redis userinfo |
|---|---|---|
| `repr` / `str` | masked | masked |
| `model_dump()` | **LEAK** | **LEAK** |
| `model_dump_json()` | **LEAK** | **LEAK** |

All four models — `ClientConfig`, `LangChainConfig`, `EmbeddingConfig`, `CacheConfig` — including `redis_url` both directly and nested under `ClientConfig.cache`. Anything that serializes a config (structured logging, a JSON error report, a config endpoint) emitted the key while every eyeball-level check looked clean.

A hand-written `__repr__` **cannot** close this — a third party calling `model_dump()` never goes through it. Typing the fields moves the guarantee into pydantic, where every serialization path inherits it.

## Breaking change

Read the values with `.get_secret_value()`:

```python
- client = FMPDataClient(api_key=config.api_key)
+ client = FMPDataClient(api_key=config.api_key.get_secret_value())
```

**Unchanged:** construction (a plain `str` still coerces) and truthiness, so the `not config.api_key` guards in `client.py` / `async_client.py` are untouched. What changes is *reading* the field.

## Four traps, each verified rather than assumed

*(against pydantic 2.13.4 / httpx 0.28.1)*

1. **The wire fails silently.** httpx accepts a `SecretStr` and stringifies it:

   ```
   https://.../profile?apikey=%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A&symbol=AAPL
   ```

   No exception — just 401s with nothing to point at locally. Both `base.py` sites unwrap explicitly. Critically, the existing guard asserted `called_params["apikey"] == client_config.api_key`, which passes **vacuously** once both sides are masked; it now asserts the literal value and that the value isn't all-asterisks.

2. **`str_strip_whitespace` does not reach inside a `SecretStr`**, and `SecretStr` has no `.strip()` (`AttributeError`). The validator strips explicitly.

3. **`lc/config.py:63` must stay on python-mode `model_dump()`.** It round-trips `SecretStr` objects unchanged. `mode="json"` — the reflex, since `SecretStr` isn't JSON-serialisable — substitutes the literal mask, and the old validator accepted `'**********'` as a perfectly good key. `validate_api_key` now rejects an all-asterisk value, so that mistake fails at construction instead of as a mystery 401.

4. **`__str__` must mask from the field, not the dump.** The dump is already `SecretStr('**********')`; re-masking prints a mask of a mask and loses the leading-4-character affordance (`api_key='SUPE***'`) that lets you tell two keys apart. Preserved deliberately — `test_config.py:724` pins it.

## Verification

All eight escape routes closed, wire still correct:

```
repr / str / model_dump / mode=json / model_dump_json   key=False redis=False
cache repr / cache dump / cache dump_json               redis=False
api_key revealed  : True
real key on wire  : True     mask on wire : False
python round-trip : True     json round-trip: rejected
```

Mutation-verified — reverting `api_key` to `str` reds 6 tests including the primary leak assertion; reverting `redis_url` reds 3.

The restored mypy gate from #290 immediately caught two integration call sites in `tests/integration/test_lc.py` that the unit suite never exercises — worth noting as the gate paying for itself.

`2284 passed, 7 skipped`; lint and mypy green.

Refs #252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)