### PR TITLE
fix(ci): drop the persisted git credential from the release build (#252)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,12 @@ jobs:
           # Prefer the merge/squash commit on main so the tag points at what
           # was actually merged, not a transient pull/merge ref.
           ref: ${{ github.event.pull_request.merge_commit_sha }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # No persisted credentials. This job installs a PEP 517 frontend and
+          # backend and then runs a build, so anything in that dependency tree
+          # would otherwise be able to read a repo-write token out of
+          # .git/config. The one step that needs write access pushes its tag
+          # through the API with an explicitly scoped GH_TOKEN instead (#252).
+          persist-credentials: false
 
       - name: 🐍 Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
@@ -122,6 +127,9 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: 🏷️ Create and push tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           git config user.name github-actions
@@ -143,8 +151,32 @@ jobs:
             exit 1
           fi
 
+          # Create the tag locally FIRST and keep it. hatch-vcs derives the
+          # version from the local tag, and the build step below runs after
+          # this one -- a remote-only tag would silently produce a .devN
+          # version instead of the release version.
           git tag -a "$RELEASE_TAG" -m "Release $RELEASE_TAG"
-          git push origin "$RELEASE_TAG"
+
+          # Publish it through the API rather than `git push`: the checkout no
+          # longer persists credentials, so there is no git remote auth. Two
+          # calls keep the remote tag *annotated*, matching the local one --
+          # creating the ref alone would leave a lightweight tag.
+          COMMIT_SHA="$(git rev-parse "${RELEASE_TAG}^{commit}")"
+          TAG_SHA="$(gh api "repos/${REPO}/git/tags" \
+            -f tag="$RELEASE_TAG" \
+            -f message="Release $RELEASE_TAG" \
+            -f object="$COMMIT_SHA" \
+            -f type=commit \
+            --jq .sha)"
+          gh api "repos/${REPO}/git/refs" \
+            -f ref="refs/tags/${RELEASE_TAG}" \
+            -f sha="$TAG_SHA" > /dev/null
+
+          # Confirm the remote actually has it before anything downstream
+          # relies on it (`gh release create --verify-tag` would fail later
+          # and less legibly).
+          gh api "repos/${REPO}/git/ref/tags/${RELEASE_TAG}" > /dev/null
+          echo "Pushed tag ${RELEASE_TAG} -> ${COMMIT_SHA}"
 
       - name: 📦 Build distribution
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,18 @@ None. No FMP path we ship was newly retired by this changelog window.
 
 ### Security
 
+- **The release build job no longer carries a persisted git credential
+  (#252 FMP-SEC-002).** `release.yml`'s build job legitimately needs
+  `contents: write` — it pushes the release tag and creates the GitHub
+  Release — but it checked out with `token: ${{ secrets.GITHUB_TOKEN }}`,
+  leaving repo-write credentials in `.git/config` for the whole job,
+  including while it installs a PEP 517 frontend and backend and runs a
+  build. Exactly one step needed remote write; it now creates the tag
+  through the API with an explicitly scoped `GH_TOKEN`, so the checkout
+  uses `persist-credentials: false`. The tag is still created locally
+  first (hatch-vcs derives the version from the local tag, and the build
+  runs after) and the remote tag is created as an annotated tag object
+  rather than a bare ref, so it matches.
 - **The TestPyPI publish job no longer holds repo-write (#252 FMP-SEC-002).**
   ``test-release-publish`` carried ``pull-requests: write`` and
   ``issues: write`` alongside ``id-token: write`` purely so it could post

--- a/tests/unit/test_release_tag_push.py
+++ b/tests/unit/test_release_tag_push.py
@@ -1,0 +1,114 @@
+"""The release build job holds no persisted git credentials (#252).
+
+``release.yml``'s build job legitimately needs ``contents: write`` -- it
+pushes the release tag and creates the GitHub Release. What it did *not* need
+was a repo-write token sitting in ``.git/config`` for the whole job, including
+while it installs a PEP 517 frontend and backend and runs a build. Anything in
+that dependency tree could read it.
+
+Only one step ever needed remote write: the ``git push origin <tag>``. It now
+goes through the API with an explicitly scoped ``GH_TOKEN``, so the checkout
+can drop credentials entirely.
+
+Two orderings make that safe, and both are easy to break by tidying:
+
+* the tag is created **locally** before the build, because ``hatch-vcs``
+  derives the version from the local tag -- a remote-only tag silently yields
+  a ``.devN`` version instead of the release version;
+* the remote tag is created as an **annotated** tag object, not just a ref,
+  so it matches the local one.
+
+This path cannot be exercised without performing a real release, so these
+assertions stand in for that.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RELEASE = REPO_ROOT / ".github" / "workflows" / "release.yml"
+
+
+def _build_steps() -> list[dict[str, Any]]:
+    loaded = yaml.safe_load(RELEASE.read_text(encoding="utf-8"))
+    assert isinstance(loaded, dict)
+    steps = loaded["jobs"]["build"]["steps"]
+    assert isinstance(steps, list)
+    return steps
+
+
+def _step(fragment: str) -> dict[str, Any]:
+    matches = [s for s in _build_steps() if fragment in str(s.get("name", ""))]
+    assert len(matches) == 1, f"expected one step matching {fragment!r}, got {matches}"
+    return matches[0]
+
+
+def _index(fragment: str) -> int:
+    for i, step in enumerate(_build_steps()):
+        if fragment in str(step.get("name", "")):
+            return i
+    raise AssertionError(f"no step matching {fragment!r}")
+
+
+def test_checkout_does_not_persist_credentials() -> None:
+    checkout = _step("Checkout repository")
+    with_ = checkout.get("with") or {}
+    assert with_.get("persist-credentials") is False
+    assert "token" not in with_, (
+        "passing `token:` re-persists the credential for the whole job"
+    )
+
+
+def test_only_the_steps_that_need_it_receive_a_token() -> None:
+    """A job-level `env: GH_TOKEN` would hand it to the build step too."""
+    holders = {
+        str(s.get("name")) for s in _build_steps() if "GH_TOKEN" in (s.get("env") or {})
+    }
+    assert len(holders) == 2, f"unexpected GH_TOKEN holders: {holders}"
+    assert any("tag" in h for h in holders)
+    assert any("Release" in h for h in holders)
+
+    build = _step("Build distribution")
+    assert "GH_TOKEN" not in (build.get("env") or {})
+
+
+def test_tag_is_created_locally_before_the_build() -> None:
+    """hatch-vcs reads the *local* tag; a remote-only tag yields `.devN`."""
+    assert _index("Create and push tag") < _index("Build distribution")
+    assert "git tag -a" in _step("Create and push tag")["run"]
+
+
+def _code_lines(run: str) -> str:
+    """Executable lines only -- comments legitimately mention `git push`."""
+    return "\n".join(
+        line for line in run.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+def test_tag_is_pushed_through_the_api_as_an_annotated_tag() -> None:
+    run = _step("Create and push tag")["run"]
+
+    # No git remote auth exists any more, so this must not come back.
+    assert "git push" not in _code_lines(run)
+
+    # Two calls: the tag *object* then the ref. Creating only the ref would
+    # leave a lightweight tag where the local one is annotated.
+    assert "git/tags" in run
+    assert "git/refs" in run
+    assert "-f type=commit" in run
+
+
+def test_the_push_is_verified_before_downstream_steps_rely_on_it() -> None:
+    assert "git/ref/tags/" in _step("Create and push tag")["run"]
+
+
+@pytest.mark.parametrize("fragment", ["Create and push tag", "Create GitHub Release"])
+def test_token_scoped_steps_still_fail_closed(fragment: str) -> None:
+    run = _step(fragment)["run"]
+    assert "set -euo pipefail" in run
+    assert "|| true" not in run


### PR DESCRIPTION
The other half of #252's L3 item. `release.yml`'s build job needs `contents: write` — it pushes the release tag and creates the GitHub Release — and that part is legitimate. What it did **not** need was the credential persisted in `.git/config` for the whole job:

```yaml
- uses: actions/checkout@...
  with:
    ref: ${{ github.event.pull_request.merge_commit_sha }}
    token: ${{ secrets.GITHUB_TOKEN }}    # <- lives for the whole job
```

That job then installs a PEP 517 frontend and backend and runs `python -m build`. Anything in that dependency tree could read a repo-write token straight off disk.

## What actually needed the token

Surveying every git/gh call in the job, exactly one operation needed remote write:

```
:147  git push origin "$RELEASE_TAG"
```

Everything else is local git reads (`describe`, `rev-parse`, `log`) or `gh` already using a step-scoped `GH_TOKEN`. So the tag push moves to the API and the checkout drops credentials entirely.

`GH_TOKEN` is declared on the **two steps** that need it, never at job level — the build step must not see it, and a job-level `env:` would hand it over.

## Two orderings this depends on

Both are easy to destroy while tidying, so both are now pinned by tests:

1. **The tag is created locally first, and kept.** `hatch-vcs` derives the version from the *local* tag, and the build step runs after this one — a remote-only tag would silently produce a `.devN` version instead of the release version. The existing `EXPECTED_VERSION` guard would catch it, but only after the tag was already public.

2. **The remote tag is an annotated tag object, then a ref** — not a bare ref. Creating only the ref leaves a lightweight tag where the local one is annotated.

The push is then verified via `git/ref/tags/...` so a failure surfaces right there rather than as a less legible `gh release create --verify-tag` error several steps later.

## Honest limitation

**This path cannot be exercised without performing a real release.** CI's shellcheck job covers only `.github/actions/**/*.sh`, not inline `run:` blocks, so nothing in CI executes this script.

What I did instead:
- `bash -n` and `shellcheck` both clean on the extracted script;
- seven meta-tests pin the properties above (credential absence, token scoping, local-tag-before-build ordering, annotated-tag two-step, verification, fail-closed `set -euo pipefail`);
- mutation-verified — restoring `token:` on the checkout reds the guard.

Worth watching the next release run.

`nox -s lint` and `nox -s typecheck` green; 28 workflow meta-tests pass.

Refs #252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)