### PR TITLE
fix(sec): escape the symbol in get_company_logo_url (#252)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -294,7 +294,7 @@
         "filename": "tests/unit/test_async_clients.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 3126
+        "line_number": 3157
       }
     ],
     "tests/unit/test_base.py": [
@@ -511,5 +511,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-14T15:03:29Z"
+  "generated_at": "2026-08-14T15:13:33Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,6 +229,16 @@ None. No FMP path we ship was newly retired by this changelog window.
   first (hatch-vcs derives the version from the local tag, and the build
   runs after) and the remote tag is created as an annotated tag object
   rather than a bare ref, so it matches.
+- **`get_company_logo_url` escapes the symbol (#252 FMP-SEC-010).** That
+  builder assembles its URL with a raw f-string and never calls
+  `Endpoint.build_url`, so it did not inherit the path sanitizing added
+  when FMP-SEC-010 was closed — the sweep behind that fix only covered
+  `build_url` callers. `symbol` reaches this method from an LLM through
+  the `company_logo_url` MCP tool, and
+  `get_company_logo_url("../../stable/profile")` returned a URL pointing
+  at a different path on the origin. Now percent-encoded and rejected
+  for separators and dot-segments, matching every other path parameter.
+  Dotted tickers such as `BRK.B` still work.
 - **The TestPyPI publish job no longer holds repo-write (#252 FMP-SEC-002).**
   ``test-release-publish`` carried ``pull-requests: write`` and
   ``issues: write`` alongside ``id-token: write`` purely so it could post

--- a/fmp_data/company/async_client.py
+++ b/fmp_data/company/async_client.py
@@ -114,7 +114,7 @@ from fmp_data.fundamental.models import (
 )
 from fmp_data.helpers import deprecated
 from fmp_data.intelligence.models import DividendEvent, EarningEvent, StockSplitEvent
-from fmp_data.models import MarketCapitalization
+from fmp_data.models import MarketCapitalization, _safe_path_segment
 
 
 def _format_date(value: date | None) -> str | None:
@@ -193,7 +193,12 @@ class AsyncCompanyClient(AsyncEndpointGroup):
         if not symbol or not symbol.strip():
             raise InvalidSymbolError()
         base_url = self.client.config.base_url.rstrip("/")
-        return f"{base_url}/image-stock/{symbol}.png"
+        # This builder never goes through `Endpoint.build_url`, so it does not
+        # inherit that method's path sanitizing -- the #252 FMP-SEC-010 sweep
+        # only covered `build_url` callers and missed it. `symbol` reaches here
+        # from an LLM via the `company_logo_url` MCP tool, so escape it the same
+        # way rather than interpolating it raw.
+        return f"{base_url}/image-stock/{_safe_path_segment(symbol)}.png"
 
     async def get_quote(self, symbol: str) -> Quote:
         """Get real-time stock quote"""

--- a/fmp_data/company/client.py
+++ b/fmp_data/company/client.py
@@ -109,7 +109,7 @@ from fmp_data.fundamental.models import (
 )
 from fmp_data.helpers import deprecated
 from fmp_data.intelligence.models import DividendEvent, EarningEvent, StockSplitEvent
-from fmp_data.models import MarketCapitalization
+from fmp_data.models import MarketCapitalization, _safe_path_segment
 
 
 def _format_date(value: date | None) -> str | None:
@@ -182,7 +182,12 @@ class CompanyClient(EndpointGroup):
         if not symbol or not symbol.strip():
             raise InvalidSymbolError()
         base_url = self.client.config.base_url.rstrip("/")
-        return f"{base_url}/image-stock/{symbol}.png"
+        # This builder never goes through `Endpoint.build_url`, so it does not
+        # inherit that method's path sanitizing -- the #252 FMP-SEC-010 sweep
+        # only covered `build_url` callers and missed it. `symbol` reaches here
+        # from an LLM via the `company_logo_url` MCP tool, so escape it the same
+        # way rather than interpolating it raw.
+        return f"{base_url}/image-stock/{_safe_path_segment(symbol)}.png"
 
     def get_quote(self, symbol: str) -> Quote:
         """Get real-time stock quote"""

--- a/tests/unit/test_async_clients.py
+++ b/tests/unit/test_async_clients.py
@@ -434,6 +434,37 @@ class TestAsyncCompanyClient:
         with pytest.raises(InvalidSymbolError, match="Symbol is required"):
             async_client.get_company_logo_url(" ")
 
+    @pytest.mark.parametrize(
+        "symbol",
+        ["../../stable/profile", "a/b", "..", "%2f..%2f", "a\\b"],
+    )
+    def test_get_company_logo_url_rejects_path_escapes(self, mock_client, symbol):
+        """This builder bypasses `Endpoint.build_url` (#252 FMP-SEC-010).
+
+        The original sweep only covered `build_url` callers, so this raw
+        f-string was missed -- and `symbol` reaches it from an LLM through
+        the `company_logo_url` MCP tool.
+        """
+        from fmp_data.company.async_client import AsyncCompanyClient
+
+        mock_client.config = MagicMock(base_url="https://example.com")
+        async_client = AsyncCompanyClient(mock_client)
+
+        with pytest.raises(Exception, match="Invalid path parameter"):
+            async_client.get_company_logo_url(symbol)
+
+    def test_get_company_logo_url_allows_dotted_tickers(self, mock_client):
+        """`BRK.B` is a real ticker; only `.`/`..` segments are traversal."""
+        from fmp_data.company.async_client import AsyncCompanyClient
+
+        mock_client.config = MagicMock(base_url="https://example.com")
+        async_client = AsyncCompanyClient(mock_client)
+
+        assert (
+            async_client.get_company_logo_url("BRK.B")
+            == "https://example.com/image-stock/BRK.B.png"
+        )
+
     @pytest.mark.asyncio
     async def test_get_historical_prices_wraps_single_result(self, mock_client):
         """Test get_historical_prices wraps non-list results."""

--- a/tests/unit/test_company.py
+++ b/tests/unit/test_company.py
@@ -1619,3 +1619,43 @@ class TestCompanyHistoricalEODUnwrap:
     def test_leftover_company_endpoints_bind_row_type(self, endpoint, row_type):
         """Leftover company declarations bind T as the payload/row type."""
         assert endpoint.response_model is row_type
+
+
+class TestCompanyLogoUrl:
+    """`get_company_logo_url` bypasses `Endpoint.build_url` (#252 FMP-SEC-010).
+
+    The original sweep only covered `build_url` callers, so this raw f-string
+    was missed -- and `symbol` reaches it from an LLM through the
+    `company_logo_url` MCP tool.
+    """
+
+    @staticmethod
+    def _client() -> CompanyClient:
+        from fmp_data.config import ClientConfig
+
+        config = ClientConfig(
+            api_key="test_key",  # pragma: allowlist secret
+            base_url="https://example.com",
+        )
+        return CompanyClient(BaseClient(config))
+
+    def test_normal_symbol_is_unchanged(self) -> None:
+        assert (
+            self._client().get_company_logo_url("AAPL")
+            == "https://example.com/image-stock/AAPL.png"
+        )
+
+    def test_dotted_ticker_still_works(self) -> None:
+        """`BRK.B` is a real ticker; only `.`/`..` segments are traversal."""
+        assert (
+            self._client().get_company_logo_url("BRK.B")
+            == "https://example.com/image-stock/BRK.B.png"
+        )
+
+    @pytest.mark.parametrize(
+        "symbol",
+        ["../../stable/profile", "a/b", "..", "%2f..%2f", "a\\b"],
+    )
+    def test_path_escapes_are_rejected(self, symbol: str) -> None:
+        with pytest.raises(Exception, match="Invalid path parameter"):
+            self._client().get_company_logo_url(symbol)


### PR DESCRIPTION
`get_company_logo_url` assembles its URL with a raw f-string and never calls `Endpoint.build_url`, so it never inherited the path sanitizing added when FMP-SEC-010 was closed.

That fix's acceptance note recorded *"a whole-package sweep found no other unconstrained path param."* The sweep covered `build_url` callers — and this builder is not one.

## Reproduced on `dev`

```
>>> c.company.get_company_logo_url("../../stable/profile?apikey=x&z")
https://financialmodelingprep.com/image-stock/../../stable/profile?apikey=x&z.png
```

`symbol` is not a trusted input here: `company_logo_url` is a registered MCP tool (`company/mapping.py:646`), so the value arrives from an LLM.

## Scope, honestly

Lower severity than the original SEC-010, and worth stating plainly:

- it returns a **string** rather than issuing a request;
- **no API key is attached** to this URL;
- `..` normalizes within the host, so the **origin cannot change**.

Worst case is a caller fetching a different path on the same origin. Still a real hole in a finding recorded as closed, and the fix is two lines.

## Fix

Both sync and async route `symbol` through `_safe_path_segment` — the same helper `build_url` uses — so the rule stays defined in one place rather than duplicated.

```
normal   : https://example.com/image-stock/AAPL.png
dotted   : https://example.com/image-stock/BRK.B.png
'../../stable/profile?apikey=x&z' : REJECTED ValidationError
'a/b'                             : REJECTED ValidationError
'..'                              : REJECTED ValidationError
'%2f..%2f'                        : REJECTED ValidationError
'a\b'                             : REJECTED ValidationError
```

Dotted tickers such as `BRK.B` still work — only `.` and `..` *segments* are traversal, which the existing helper already gets right.

## Verification

Mutation-verified: reverting either builder reds 10 tests (5 parametrized escapes × sync and async).

`2302 passed, 7 skipped`; `nox -s lint` and `nox -s typecheck` green. Rebased onto #294.

Refs #252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)