### PR TITLE
fix(sec): drive config redaction from metadata, not a name allowlist (#252)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,6 +217,21 @@ None. No FMP path we ship was newly retired by this changelog window.
 
 ### Security
 
+- **`ClientConfig.__str__` redaction is metadata-driven, not a name
+  allowlist (#252 FMP-SEC-007).** It dumped the whole model and masked the
+  three field names it knew about, so everything else rendered verbatim —
+  including a secret inside `LogHandlerConfig.handler_kwargs`, a bare
+  `dict[str, Any]` that needs no subclass to reach, and any credential
+  field added by a subclass. Redaction now runs in three passes: fields
+  marked `repr=False` (pydantic's own not-for-display signal, which every
+  credential field already carries, so a subclass gets correct behaviour
+  from the standard idiom); a recursive sweep for secret-shaped keys,
+  which is the only handle available on untyped bags; then the two values
+  worth rendering richer than `***` (the API key's leading characters and
+  the Redis host). The shape rules moved to `fmp_data/_redaction.py` and
+  are shared with `EmbeddingConfig.__repr__`, which previously recursed
+  while the config side did not. Non-secret values such as `maxBytes` are
+  still shown.
 - **The release build job no longer carries a persisted git credential
   (#252 FMP-SEC-002).** `release.yml`'s build job legitimately needs
   `contents: write` — it pushes the release tag and creates the GitHub

--- a/fmp_data/_redaction.py
+++ b/fmp_data/_redaction.py
@@ -1,0 +1,107 @@
+"""Shared rules for hiding credentials in display strings (#252).
+
+Two different places need the same judgement about "does this look like a
+secret": ``ClientConfig.__str__`` renders arbitrary nested config for humans,
+and ``EmbeddingConfig.__repr__`` renders the kwargs bag it splats into a
+provider. Keeping one implementation means the rules cannot drift apart, and
+means widening the token list fixes both at once.
+
+This is a *display* safeguard, not an access control. Values are still fully
+available on the model; only the rendered text is masked.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Matched against ``_``/``-`` separated parts of a key name, so ``api_key``,
+# ``client-secret`` and ``refreshToken`` are caught but ``keyboard`` is not.
+_SECRET_KEY_TOKENS = frozenset(
+    {
+        "key",
+        "apikey",
+        "token",
+        "secret",
+        "password",
+        "passwd",
+        "pwd",
+        "passphrase",
+        "credential",
+        "credentials",
+        "authorization",
+        "auth",
+        "bearer",
+        "signature",
+        "private",
+    }
+)
+
+_MASK = "***"
+
+# Deeper structures are elided rather than walked. Config is not expected to
+# nest this far, and an unbounded walk on a cyclic or adversarial structure is
+# not worth the risk in a `__str__`.
+_MAX_DEPTH = 6
+
+
+def _split_key(key: str) -> list[str]:
+    """Split a key name into comparable parts, including camelCase.
+
+    The boundary is a *lower-to-upper* transition, not any capital: splitting
+    on every capital shreds an all-caps name, so ``API_KEY`` would become
+    ``["a", "p", "i", ...]`` and match nothing.
+    """
+    normalized = key.replace("-", "_")
+    parts: list[str] = []
+    for chunk in normalized.split("_"):
+        # `refreshToken` -> ["refresh", "Token"]; `API` stays `["API"]`
+        current = ""
+        for char in chunk:
+            if char.isupper() and current and not current[-1].isupper():
+                parts.append(current)
+                current = char
+            else:
+                current += char
+        if current:
+            parts.append(current)
+    return [part.lower() for part in parts if part]
+
+
+def is_secret_key(key: str) -> bool:
+    """True when a key name looks like it holds a credential."""
+    return any(part in _SECRET_KEY_TOKENS for part in _split_key(key))
+
+
+def redact_value(value: Any, depth: int = 0) -> Any:
+    """Copy a value with secret-shaped entries inside containers replaced.
+
+    Recursion matters: credentials show up in *nested* untyped bags --
+    ``OpenAIEmbeddings`` takes ``default_headers={"Authorization": ...}``, and
+    ``LogHandlerConfig.handler_kwargs`` is a bare ``dict[str, Any]`` handed
+    straight to a logging handler. A top-level-only scan copies those by
+    reference and prints the secret verbatim (#273).
+    """
+    if depth >= _MAX_DEPTH:
+        return "..."
+    if isinstance(value, dict):
+        return {
+            key: (
+                _MASK
+                if isinstance(key, str) and is_secret_key(key)
+                else redact_value(item, depth + 1)
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, list | tuple):
+        return type(value)(redact_value(item, depth + 1) for item in value)
+    if isinstance(value, set):
+        return {redact_value(item, depth + 1) for item in value}
+    return value
+
+
+def redact_mapping(data: dict[str, Any]) -> dict[str, Any]:
+    """Copy a mapping with secret-shaped keys masked, recursively."""
+    return {
+        key: (_MASK if is_secret_key(key) else redact_value(value))
+        for key, value in data.items()
+    }

--- a/fmp_data/config.py
+++ b/fmp_data/config.py
@@ -17,6 +17,7 @@ from urllib.parse import urlparse, urlsplit, urlunsplit
 
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator
 
+from fmp_data._redaction import redact_mapping
 from fmp_data.cache.config import CacheConfig
 from fmp_data.exceptions import ConfigError
 
@@ -217,7 +218,15 @@ class RateLimitConfig(BaseModel):
 
 
 class ClientConfig(BaseModel):
-    """Base client configuration for FMP Data API"""
+    """Base client configuration for FMP Data API.
+
+    Adding a credential field, here or on a subclass: type it ``SecretStr``
+    and mark it ``repr=False``. ``SecretStr`` keeps it out of ``model_dump``
+    and ``model_dump_json``; ``repr=False`` keeps it out of ``__str__`` and
+    ``__repr__``. Neither is a name allowlist, so nothing here needs editing
+    to make a new field safe -- read the value back with
+    ``.get_secret_value()`` (#252).
+    """
 
     # Configure model
     model_config = ConfigDict(
@@ -340,23 +349,46 @@ class ClientConfig(BaseModel):
         return v
 
     def __str__(self) -> str:
-        """String representation with masked API key.
+        """String representation with credentials masked.
 
-        The masks are computed from the *fields*, not from ``model_dump()``.
-        Now that the credential fields are ``SecretStr`` the dump already
-        yields ``SecretStr('**********')``, and re-masking that would print
-        a mask of a mask -- losing the leading-4-character affordance that
-        makes this string useful for telling two keys apart.
+        Redaction is driven by field metadata and key shape, not by a list of
+        field names. The previous version dumped the whole model and masked
+        three names it knew about, so anything else rendered verbatim: a
+        subclass field, or a secret inside ``LogHandlerConfig.handler_kwargs``
+        -- a bare ``dict[str, Any]`` that needs no subclass to reach (#252).
+
+        Three passes, narrowest signal first:
+
+        1. ``repr=False`` fields. That is pydantic's own "not for display"
+           marker and every credential field already carries it, so a subclass
+           gets correct behaviour from the standard idiom rather than from
+           being added to a list here.
+        2. A recursive sweep for secret-shaped *keys*, which is the only
+           handle available on untyped ``dict[str, Any]`` bags.
+        3. The two values worth rendering richer than ``***``.
+
+        The richer masks are computed from the *fields*, not from the dump:
+        credential fields are ``SecretStr``, so the dump already holds
+        ``SecretStr('**********')`` and re-masking that would print a mask of
+        a mask -- losing the leading-4-character affordance that makes this
+        string useful for telling two keys apart.
         """
         data = self.model_dump()
-        if data.get("api_key"):
+
+        for name, field in type(self).model_fields.items():
+            if field.repr is False and data.get(name) is not None:
+                data[name] = "***"
+
+        data = redact_mapping(data)
+
+        if getattr(self, "api_key", None):
             data["api_key"] = _mask_secret(self.api_key)
         embedding_api_key = getattr(self, "embedding_api_key", None)
-        if data.get("embedding_api_key") and embedding_api_key:
+        if embedding_api_key:
             data["embedding_api_key"] = _mask_secret(embedding_api_key)
         cache = data.get("cache")
-        if isinstance(cache, dict) and cache.get("redis_url") and self.cache:
-            cache["redis_url"] = _redact_url_userinfo(self.cache.redis_url or "")
+        if isinstance(cache, dict) and self.cache and self.cache.redis_url:
+            cache["redis_url"] = _redact_url_userinfo(self.cache.redis_url)
 
         # Create a string representation from the masked data
         fields = []

--- a/fmp_data/lc/embedding.py
+++ b/fmp_data/lc/embedding.py
@@ -5,60 +5,11 @@ import os
 from typing import Any
 
 from langchain_core.embeddings import Embeddings
-from pydantic import BaseModel, ConfigDict, Field, SecretStr
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_serializer
 
+from fmp_data._redaction import redact_mapping
 from fmp_data.exceptions import ConfigError
 from fmp_data.lc.utils import check_package_dependency
-
-_SECRET_KWARG_TOKENS = (
-    "key",
-    "token",
-    "secret",
-    "password",
-    "passwd",
-    "authorization",
-    "auth",
-)
-
-
-def _is_secret_key(key: str) -> bool:
-    """True when a kwargs key name looks like it holds a credential."""
-    parts = key.lower().replace("-", "_").split("_")
-    return any(part in _SECRET_KWARG_TOKENS for part in parts)
-
-
-def _redact_value(value: Any, depth: int = 0) -> Any:
-    """Redact secret-shaped entries inside nested containers.
-
-    Recursion matters: providers take credential-bearing *nested* kwargs --
-    ``OpenAIEmbeddings`` accepts ``default_headers={"Authorization": ...}``
-    and ``model_kwargs={"api_key": ...}``, and both are splatted straight
-    into the provider below. A top-level-only scan copied those dicts by
-    reference, so ``repr`` printed the secret verbatim (#273).
-
-    ``depth`` bounds pathological nesting; deeper values are elided rather
-    than walked.
-    """
-    if depth >= 6:
-        return "..."
-    if isinstance(value, dict):
-        return {
-            key: ("***" if _is_secret_key(str(key)) else _redact_value(item, depth + 1))
-            for key, item in value.items()
-        }
-    if isinstance(value, list | tuple):
-        return type(value)(_redact_value(item, depth + 1) for item in value)
-    if isinstance(value, set):
-        return {_redact_value(item, depth + 1) for item in value}
-    return value
-
-
-def _redact_kwargs(data: dict[str, Any]) -> dict[str, Any]:
-    """Copy a kwargs map with secret-shaped values replaced, recursively."""
-    return {
-        key: ("***" if _is_secret_key(key) else _redact_value(value))
-        for key, value in data.items()
-    }
 
 
 class EmbeddingProvider(str, Enum):
@@ -94,13 +45,31 @@ class EmbeddingConfig(BaseModel):
 
     model_config = ConfigDict(from_attributes=True, arbitrary_types_allowed=True)
 
+    @field_serializer("additional_kwargs")
+    def _serialize_additional_kwargs(self, value: dict[str, Any]) -> dict[str, Any]:
+        """Redact on ``model_dump`` too, not only in ``repr`` (#252).
+
+        ``additional_kwargs`` is ``dict[str, Any]``, so ``SecretStr`` cannot
+        reach inside it -- providers take credential-bearing nested kwargs
+        such as ``default_headers={"Authorization": ...}``. A serializer is
+        the only place to catch those on the dump path, and it covers a third
+        party calling ``model_dump()`` directly.
+
+        Safe here, unlike on ``ClientConfig``: every consumer reads the
+        attribute (``**self.additional_kwargs``), so nothing rebuilds this
+        model from its own dump. ``ClientConfig`` cannot use this approach
+        because ``LangChainConfig.from_env`` round-trips through
+        ``model_dump()`` and would rebuild itself from the masked values.
+        """
+        return redact_mapping(value)
+
     def __repr__(self) -> str:
         """Hide API keys and secret-shaped kwargs from ``repr`` (#273)."""
         return (
             f"{type(self).__name__}("
             f"provider={self.provider!r}, "
             f"model_name={self.model_name!r}, "
-            f"additional_kwargs={_redact_kwargs(self.additional_kwargs)!r})"
+            f"additional_kwargs={redact_mapping(self.additional_kwargs)!r})"
         )
 
     def get_embeddings(self) -> Embeddings:

--- a/tests/unit/lc/test_embedding.py
+++ b/tests/unit/lc/test_embedding.py
@@ -164,3 +164,44 @@ def test_get_embeddings_cohere(mock_cohere):
     mock_cohere.assert_called_once_with(
         cohere_api_key="test-key", model="embed-english-v2.0"
     )
+
+
+class TestAdditionalKwargsSerialization:
+    """`additional_kwargs` must not leak on the dump path either (#252).
+
+    `SecretStr` cannot reach inside a `dict[str, Any]`, and providers take
+    credential-bearing nested kwargs -- `OpenAIEmbeddings` accepts
+    `default_headers={"Authorization": ...}`. `repr` was fixed in #273; the
+    dump was not, so a structured log or JSON error report still emitted it.
+    """
+
+    PLANTED = "PLANTEDCREDENTIAL_aaaa"
+
+    def _config(self) -> EmbeddingConfig:
+        return EmbeddingConfig(
+            api_key="EMBEDKEY_bbbb",  # pragma: allowlist secret
+            additional_kwargs={
+                "default_headers": {"Authorization": f"Bearer {self.PLANTED}"},
+                "model_kwargs": {"api_key": self.PLANTED},
+                "timeout": 30,
+            },
+        )
+
+    def test_model_dump_does_not_leak_nested_credentials(self) -> None:
+        assert self.PLANTED not in str(self._config().model_dump())
+
+    def test_model_dump_json_does_not_leak_nested_credentials(self) -> None:
+        assert self.PLANTED not in self._config().model_dump_json()
+
+    def test_repr_still_does_not_leak(self) -> None:
+        assert self.PLANTED not in repr(self._config())
+
+    def test_the_live_kwargs_are_untouched(self) -> None:
+        """`get_embeddings` splats these into the provider; masking them
+        there would authenticate as nobody."""
+        config = self._config()
+        config.model_dump()  # must not mutate
+        assert config.additional_kwargs["model_kwargs"]["api_key"] == self.PLANTED
+
+    def test_non_secret_kwargs_survive_the_dump(self) -> None:
+        assert self._config().model_dump()["additional_kwargs"]["timeout"] == 30

--- a/tests/unit/test_config_secret_serialization.py
+++ b/tests/unit/test_config_secret_serialization.py
@@ -150,3 +150,78 @@ def test_truthiness_still_works_for_the_client_guards() -> None:
 
     assert not SecretStr("")
     assert SecretStr("x")
+
+
+class TestDisplayRedactionIsNotANameAllowlist:
+    """`__str__` must not depend on a hard-coded list of field names (#252).
+
+    The previous version dumped the whole model and masked the three names it
+    knew about (`api_key`, `embedding_api_key`, `cache.redis_url`). Anything
+    else rendered verbatim -- and `LogHandlerConfig.handler_kwargs` is a bare
+    `dict[str, Any]` handed straight to a logging handler, so no subclass was
+    needed to reach it.
+    """
+
+    @staticmethod
+    def _with_handler_kwargs(**kwargs: object) -> ClientConfig:
+        from fmp_data.config import LoggingConfig, LogHandlerConfig
+
+        return ClientConfig(
+            api_key=API_KEY,
+            logging=LoggingConfig(
+                handlers={
+                    "remote": LogHandlerConfig(
+                        class_name="StreamHandler", handler_kwargs=dict(kwargs)
+                    )
+                }
+            ),
+        )
+
+    def test_secret_in_untyped_handler_kwargs(self) -> None:
+        planted = "LOGHANDLERSECRET_bbbbbbbb"
+        config = self._with_handler_kwargs(credentials=("user", planted))
+        assert planted not in str(config)
+        assert planted not in repr(config)
+
+    def test_secret_nested_deeper_in_handler_kwargs(self) -> None:
+        """A top-level-only scan copies nested containers by reference."""
+        planted = "DEEPSECRET_cccccccc"
+        config = self._with_handler_kwargs(outer={"inner": {"api_key": planted}})
+        assert planted not in str(config)
+
+    def test_camel_case_key_is_recognised(self) -> None:
+        planted = "CAMELSECRET_dddddddd"
+        config = self._with_handler_kwargs(refreshToken=planted)
+        assert planted not in str(config)
+
+    def test_subclass_credential_field(self) -> None:
+        """A subclass must not have to edit `ClientConfig.__str__`."""
+        planted = "SUBCLASS_SECRET_gggggggg"
+
+        class WebhookConfig(ClientConfig):
+            webhook_secret: str | None = None
+
+        config = WebhookConfig(api_key=API_KEY, webhook_secret=planted)
+        assert planted not in str(config)
+        assert planted not in repr(config)
+
+    def test_repr_false_is_honoured_even_without_a_secret_shaped_name(self) -> None:
+        """`repr=False` is pydantic's own not-for-display marker."""
+        from pydantic import Field
+
+        planted = "OPAQUE_dddddddd"
+
+        class OpaqueConfig(ClientConfig):
+            internal_note: str | None = Field(default=None, repr=False)
+
+        config = OpaqueConfig(api_key=API_KEY, internal_note=planted)
+        assert planted not in str(config)
+
+    def test_non_secret_values_are_still_shown(self) -> None:
+        """Over-redaction would make this string useless for debugging."""
+        config = self._with_handler_kwargs(maxBytes=1048576, backupCount=3)
+        text = str(config)
+        assert "maxBytes" in text
+        assert "1048576" in text
+        assert "backupCount" in text
+        assert "base_url=" in text

--- a/tests/unit/test_redaction_rules.py
+++ b/tests/unit/test_redaction_rules.py
@@ -1,0 +1,97 @@
+"""The shared secret-shape rules used by config and embedding display (#252).
+
+``ClientConfig.__str__`` and ``EmbeddingConfig.__repr__`` both need the same
+judgement about what looks like a credential. They used to disagree -- the
+embedding side recursed into nested containers and the config side did not --
+so these rules now live in one module and are tested directly rather than only
+through the two callers.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from fmp_data._redaction import is_secret_key, redact_mapping, redact_value
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "api_key",
+        "apikey",
+        "API_KEY",
+        "client-secret",
+        "refreshToken",
+        "accessToken",
+        "password",
+        "passwd",
+        "pwd",
+        "passphrase",
+        "credentials",
+        "credential",
+        "Authorization",
+        "auth",
+        "bearer",
+        "signature",
+        "private_key",
+    ],
+)
+def test_secret_shaped_names_are_recognised(key: str) -> None:
+    assert is_secret_key(key)
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "keyboard",
+        "monkey",
+        "timeout",
+        "base_url",
+        "maxBytes",
+        "backupCount",
+        "level",
+        "class_name",
+    ],
+)
+def test_ordinary_names_are_left_alone(key: str) -> None:
+    """Over-redaction makes the display useless; whole parts must match."""
+    assert not is_secret_key(key)
+
+
+def test_nested_containers_are_walked_not_copied_by_reference() -> None:
+    planted = "PLANTED_aaaaaaaa"
+    source = {"outer": {"inner": [{"api_key": planted}]}}
+
+    redacted = redact_value(source)
+
+    assert planted not in repr(redacted)
+    # The original must be untouched -- this is a display copy, not a mutation.
+    assert source["outer"]["inner"][0]["api_key"] == planted
+
+
+def test_tuples_and_sets_keep_their_type() -> None:
+    assert isinstance(redact_value(("a", "b")), tuple)
+    assert isinstance(redact_value(["a"]), list)
+    assert isinstance(redact_value({"a"}), set)
+
+
+def test_recursion_is_bounded() -> None:
+    """A `__str__` must not be a place where a deep structure can hang."""
+    deep: dict[str, object] = {"k": "v"}
+    for _ in range(50):
+        deep = {"nest": deep}
+
+    assert "..." in repr(redact_value(deep))
+
+
+def test_redact_mapping_masks_top_level_secret_names() -> None:
+    planted = "PLANTED_bbbbbbbb"
+    assert redact_mapping({"api_key": planted, "timeout": 30}) == {
+        "api_key": "***",
+        "timeout": 30,
+    }
+
+
+def test_non_string_keys_do_not_raise() -> None:
+    """Untyped bags can be keyed by anything."""
+    assert redact_value({1: "a", None: "b"}) == {1: "a", None: "b"}


### PR DESCRIPTION
The last `repr`/`str` gap on #252. `ClientConfig.__str__` dumped the whole model and masked the three field names it happened to know about — everything else rendered verbatim.

## Reproduced on `dev`

```
A allowlisted api_key       leak: False
B handler_kwargs secret     leak: True
C subclass secret field     leak: True
D nested api_key in kwargs  leak: True
```

**B needs no subclass.** `LogHandlerConfig.handler_kwargs` is a bare `dict[str, Any]` handed straight to a logging handler, so a credential in it reached `str()`/`repr()` of a stock config.

## Fix

Three passes, narrowest signal first:

1. **Fields marked `repr=False`** — pydantic's own not-for-display marker, which every credential field already carries. A subclass gets correct behaviour from the standard idiom rather than by being added to a list here. That was the actual defect: an allowlist can only cover fields someone remembered to add.
2. **A recursive sweep for secret-shaped keys** — the only handle available on untyped bags.
3. **The two values worth rendering richer than `***`** — the API key's leading characters and the Redis host.

Over-redaction would make the string useless for debugging, so this is checked in both directions:

```
api_key prefix kept : True     ->  api_key='SUPE***'
redis host visible  : True     ->  redis://***@localhost:6379/0
useful kwargs kept  : True     ->  maxBytes, backupCount, base_url
kwarg password gone : True
```

Token matching is on whole `_` / `-` / camelCase-separated parts, so `keyboard` and `monkey` are not secrets.

## Shared rules

The shape rules move to `fmp_data/_redaction.py`, now shared with `EmbeddingConfig` — which had its own copy that **recursed** while the config side did not. One implementation means they cannot drift again.

Writing direct tests for the shared module immediately caught a bug in my own camelCase splitter: splitting on *every* capital shredded `API_KEY` into `["a","p","i",...]`, matching nothing. The boundary is a lower-to-upper transition.

## Also: `EmbeddingConfig.additional_kwargs` on the dump path

`SecretStr` cannot reach inside a `dict[str, Any]`, and providers take credential-bearing nested kwargs (`default_headers={"Authorization": ...}`). `repr` was fixed in #273; the dump was not.

A `field_serializer` closes it. Safe **there** and not on `ClientConfig`, because every consumer reads the attribute (`**self.additional_kwargs`) — whereas `LangChainConfig.from_env` rebuilds itself from `ClientConfig`'s dump, so a masking serializer there would poison the round-trip.

The live kwargs are asserted untouched, since masking what `get_embeddings` splats into the provider would authenticate as nobody.

## Verification

| Mutation | Result |
|---|---|
| drop the recursive sweep | 4 failed |
| drop the `repr=False` pass | 1 failed |
| disable the `field_serializer` | 2 failed |
| none (as landed) | all pass |

`2363 passed, 7 skipped`; `nox -s lint` and `nox -s typecheck` green.

Refs #252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)