### PR TITLE
fix(ci): keep credentials out of jobs that do not need them (#252)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       - name: 🛎️  Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: 🐍  Set up Python
@@ -78,6 +79,8 @@ jobs:
     steps:
       - name: 🛎️  Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: 🐍  Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
@@ -96,6 +99,29 @@ jobs:
           uv tool install nox
           uv tool run nox -s coverage_local
 
+      - name: 📤 Upload coverage artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: coverage-xml
+          path: coverage.xml
+          if-no-files-found: error
+
+  # Separate job so CODECOV_TOKEN is never present in a job that has just
+  # executed PR-supplied code. `nox -s coverage_local` runs the PR branch's own
+  # noxfile and test suite; holding an upload token in that same job hands it to
+  # anything that code chooses to do. Same build -> publish split the release
+  # path uses (#252).
+  coverage-upload:
+    runs-on: ubuntu-latest
+    needs: coverage
+    permissions:
+      contents: read
+    steps:
+      - name: 📥 Download coverage artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: coverage-xml
+
       - name: 📈 Coverage upload
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
@@ -110,6 +136,8 @@ jobs:
     steps:
       - name: 🛎️  Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: 🐍  Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
@@ -135,6 +163,8 @@ jobs:
     steps:
       - name: 🛎️  Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: 🐍  Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
@@ -194,6 +224,8 @@ jobs:
     steps:
       - name: 🛎️  Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: 🔍 ShellCheck composite action scripts
         run: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -50,6 +50,7 @@ jobs:
         if: steps.auth.outputs.configured == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 1
 
       # continue-on-error: an *expired* token still reaches this step (the gate
@@ -62,6 +63,17 @@ jobs:
         uses: anthropics/claude-code-action@239e3a730883eeb5c53db12b0fc9573b3024b126  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # KNOWN GAP, not an oversight (#252). This marketplace resolves to
+          # whatever HEAD is at run time, and the action's `plugin_marketplaces`
+          # input takes a bare Git URL with no documented ref/SHA syntax -- so
+          # unlike every `uses:` in this repo it cannot be pinned, and the
+          # repository's `sha_pinning_required` setting does not see it because
+          # the fetch happens at runtime rather than through `uses:`.
+          #
+          # Accepted because it is the same first-party origin as the
+          # SHA-pinned action above, and this job is review-only: no checkout
+          # credentials, and its writes are confined to PR comments. Revisit if
+          # the action gains a pinning syntax.
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,12 @@ on:
   pull_request_review:
     types: [submitted]
 
+# One agent per issue/PR at a time. Two @claude mentions in quick succession
+# otherwise race each other in the same workspace, both holding contents:write.
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   claude:
     if: |
@@ -36,6 +42,18 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 1
+          # persist-credentials is deliberately left on here, unlike every
+          # other checkout in this repo (#252). claude-code-action documents
+          # `use_commit_signing: false` (its default) as "Claude uses standard
+          # git commands", so it commits and pushes through the ambient git
+          # credential. Removing it would silently break @claude's ability to
+          # push, which is the point of this workflow.
+          #
+          # The residual risk is real and accepted: this job holds
+          # `contents: write` while running a model-driven agent over issue
+          # bodies, PR diffs and CI logs that are not author-gated (only the
+          # *trigger* is). The mitigations are the trigger gate above, the
+          # concurrency group below, and the SHA-pinned action.
 
       - name: Run Claude Code
         id: claude

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: 🛎️ Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: 🔍 Initialize CodeQL
         uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6

--- a/.github/workflows/guard-main-origin.yml
+++ b/.github/workflows/guard-main-origin.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Checkout PR head (for local composite action)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 

--- a/.github/workflows/rebase-reminder.yml
+++ b/.github/workflows/rebase-reminder.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Checkout PR head
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
           ref: dev
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,15 +234,23 @@ jobs:
             COMMIT_NOTES=$(git log --pretty=format:"- %s" "$PREV_TAG"..HEAD)
           fi
 
+          # Random per-run delimiter. A fixed `EOF` is only safe here by
+          # accident: `--pretty=format:"- %s"` prefixes every commit line, so a
+          # commit subject of literally `EOF` emits `- EOF` and cannot close
+          # the heredoc. Drop the `- ` prefix and it becomes a live injection --
+          # every following line would be parsed by the runner as a workflow
+          # command. Verified both ways; the guard should not be a side effect
+          # of a format string (#252).
+          DELIM="NOTES_EOF_$(openssl rand -hex 16)"
           {
-            echo "NOTES<<EOF"
+            echo "NOTES<<$DELIM"
             echo "### $RELEASE_TYPE"
             echo ""
             echo "**$PR_TITLE** (#$PR_NUMBER) by @$PR_AUTHOR"
             echo ""
             echo "### 📝 Commits"
             echo "$COMMIT_NOTES"
-            echo "EOF"
+            echo "$DELIM"
           } >> "$GITHUB_OUTPUT"
 
       - name: 🚀 Create GitHub Release

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -35,6 +35,11 @@ jobs:
         with:
           fetch-depth: 0
           # PAT preferred so pushes and PRs are not GITHUB_TOKEN-attributed (#206).
+          # Credentials are persisted here on purpose, unlike the read-only
+          # checkouts elsewhere (#252): this job really does
+          # `git push origin HEAD:refs/heads/sync/main-to-dev`. Note the
+          # persisted value is a PAT, which is broader than GITHUB_TOKEN, so
+          # keep this job free of third-party actions and untrusted input.
           token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Ensure main is reachable from dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,6 +232,31 @@ None. No FMP path we ship was newly retired by this changelog window.
   are shared with `EmbeddingConfig.__repr__`, which previously recursed
   while the config side did not. Non-secret values such as `maxBytes` are
   still shown.
+- **Checkouts no longer leave a repo-write token in the workspace
+  (#252 FMP-SEC-002).** Only 4 of 17 `actions/checkout` steps set
+  `persist-credentials: false`, so the rest wrote the job's token into
+  `.git/config` where every later step could read it — dependency
+  installs, build backends, third-party actions. Ten more now drop it.
+  The two that keep it are documented in place: `sync-main-to-dev.yml`
+  really pushes (and persists a *PAT*, broader than `GITHUB_TOKEN`), and
+  `claude.yml` runs an action whose default `use_commit_signing: false`
+  means it commits with standard git commands. A test asserts the
+  exception list by name so a third one has to be deliberate.
+- **`CODECOV_TOKEN` is no longer present in a job that runs PR code
+  (#252).** `nox -s coverage_local` executes the PR branch's own noxfile
+  and test suite; the upload token sat in that same job. Coverage now
+  uploads `coverage.xml` as an artifact and a separate `coverage-upload`
+  job — no secrets in the first, no repository code in the second —
+  performs the upload. It is deliberately not a required check: the
+  coverage threshold is still enforced in the `coverage` job, and a
+  telemetry upload should not gate merges.
+- **Release notes use a random `$GITHUB_OUTPUT` heredoc delimiter (#252).**
+  Not a live hole: `--pretty=format:"- %s"` prefixes every commit line, so
+  a commit subject of `EOF` emits `- EOF` and cannot close the heredoc
+  (verified both ways). But that protection is a side effect of a format
+  string — dropping the `- ` prefix would make every following line a
+  workflow command. The delimiter is now random per run, so the guard is
+  deliberate.
 - **The release build job no longer carries a persisted git credential
   (#252 FMP-SEC-002).** `release.yml`'s build job legitimately needs
   `contents: write` — it pushes the release tag and creates the GitHub

--- a/tests/unit/test_checkout_credentials.py
+++ b/tests/unit/test_checkout_credentials.py
@@ -1,0 +1,82 @@
+"""Checkouts do not leave repo-write credentials lying in the workspace (#252).
+
+``actions/checkout`` writes the job's token into ``.git/config`` unless told
+not to, where every later step can read it -- including dependency installs,
+build backends and third-party actions. Only two jobs in this repo actually
+push, so the rest have no reason to carry the credential at all.
+
+The exceptions are asserted by name rather than skipped, so adding a third one
+is a deliberate edit to this list and not an accident.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = sorted((REPO_ROOT / ".github" / "workflows").glob("*.yml"))
+
+# job name -> why this one keeps its credential.
+ALLOWED_TO_PERSIST = {
+    "claude": (
+        "claude-code-action runs standard git commands to commit and push; "
+        "dropping the credential silently breaks @claude"
+    ),
+    "sync-main-to-dev": "really runs `git push origin HEAD:refs/heads/...`",
+}
+
+
+def _checkout_steps() -> list[tuple[str, str, dict[str, Any]]]:
+    """(workflow, job, step) for every actions/checkout in the repo."""
+    found = []
+    for path in WORKFLOWS:
+        loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+        assert isinstance(loaded, dict), f"{path.name} is not a mapping"
+        for job_name, job in (loaded.get("jobs") or {}).items():
+            for step in job.get("steps") or []:
+                if "actions/checkout" in str(step.get("uses", "")):
+                    found.append((path.name, job_name, step))
+    return found
+
+
+def test_there_are_checkouts_to_check() -> None:
+    """Guard against the glob silently matching nothing."""
+    assert len(_checkout_steps()) >= 10
+
+
+def test_only_the_jobs_that_push_persist_credentials() -> None:
+    offenders = []
+    for workflow, job, step in _checkout_steps():
+        with_ = step.get("with") or {}
+        persists = with_.get("persist-credentials") is not False
+        if persists and job not in ALLOWED_TO_PERSIST:
+            offenders.append(f"{workflow}:{job}")
+
+    assert not offenders, (
+        f"these checkouts leave a repo-write token in .git/config for the "
+        f"whole job: {offenders}. Add `persist-credentials: false`, or add the "
+        f"job to ALLOWED_TO_PERSIST with a reason if it genuinely pushes."
+    )
+
+
+@pytest.mark.parametrize("job", sorted(ALLOWED_TO_PERSIST))
+def test_documented_exceptions_still_exist(job: str) -> None:
+    """A stale exception would silently widen the allowlist."""
+    assert any(j == job for _, j, _ in _checkout_steps()), (
+        f"{job!r} is listed as a credential-persisting exception but no such "
+        f"checkout exists any more; drop it from ALLOWED_TO_PERSIST"
+    )
+
+
+def test_read_only_checkouts_do_not_pass_an_explicit_token() -> None:
+    """`token:` re-persists the credential even with persist-credentials off."""
+    offenders = [
+        f"{workflow}:{job}"
+        for workflow, job, step in _checkout_steps()
+        if "token" in (step.get("with") or {}) and job not in ALLOWED_TO_PERSIST
+    ]
+    assert not offenders, offenders

--- a/tests/unit/test_workflow_permission_isolation.py
+++ b/tests/unit/test_workflow_permission_isolation.py
@@ -108,3 +108,30 @@ def test_the_testpypi_comment_is_a_separate_job() -> None:
     assert "environment" not in comment
     step_uses = " ".join(str(s.get("uses", "")) for s in comment["steps"])
     assert "download-artifact" not in step_uses
+
+
+def test_codecov_token_is_not_in_a_job_that_runs_pr_code() -> None:
+    """The upload token must not share a job with PR-supplied code (#252).
+
+    `nox -s coverage_local` runs the PR branch's own noxfile and test suite.
+    Holding an upload token in that same job hands it to whatever that code
+    decides to do. Split the same way the release path splits build from
+    publish: produce an artifact with no secrets, upload it from a job that
+    only downloads.
+    """
+    jobs = _jobs(REPO_ROOT / ".github" / "workflows" / "ci.yml")
+
+    coverage = yaml.dump(jobs["coverage"])
+    assert "CODECOV_TOKEN" not in coverage, (
+        "the coverage job executes PR-supplied test code; it must not hold "
+        "the upload token"
+    )
+    assert "nox" in coverage, "guard is vacuous if this job stops running tests"
+
+    upload = jobs["coverage-upload"]
+    assert "CODECOV_TOKEN" in yaml.dump(upload)
+    assert "nox" not in yaml.dump(upload), (
+        "the upload job must not execute repository code"
+    )
+    assert upload["needs"] == "coverage" or "coverage" in upload["needs"]
+    assert _write_scopes(upload.get("permissions")) == set()


### PR DESCRIPTION
Three separate ways a token sat somewhere it had no business being.

## 1. Checkouts

Only **4 of 17** `actions/checkout` steps set `persist-credentials: false`, so the rest wrote the job's token into `.git/config` where every later step could read it — dependency installs, PEP 517 backends, third-party actions.

Ten more now drop it. All of them only ever *read* (`git fetch`, `git describe`, `git ls-files`), and this is a public repo, so anonymous fetch is enough. (`rebase-reminder`'s `git push` turned out to be inside a markdown code block in a PR comment — instructions to a human, not a real push.)

**Two keep the credential, documented in place rather than silently skipped:**

| Job | Why |
|---|---|
| `sync-main-to-dev` | Really runs `git push`. Note it persists a **PAT**, broader than `GITHUB_TOKEN`. |
| `claude` | claude-code-action's default `use_commit_signing: false` is documented as *"Claude uses standard git commands"* — dropping the credential would silently break @claude's ability to push. Verified against the action's own `action.yml`. |

The test asserts that exception list **by name**, so a third one has to be a deliberate edit rather than an omission.

## 2. Codecov

`nox -s coverage_local` runs the PR branch's own noxfile and test suite, and `CODECOV_TOKEN` was injected into that same job — handing an upload token to whatever that code decides to do.

Coverage now uploads `coverage.xml` as an artifact; a separate job with **no repository code** performs the upload. Same build→publish split the release path already uses.

Deliberately **not** added to the required checks: the coverage threshold is still enforced in the `coverage` job, and a telemetry upload should not gate merges.

## 3. Release-notes heredoc

**Correcting the record: this was not exploitable as written, and the original finding overstated it.**

`--pretty=format:"- %s"` prefixes every commit line, so a commit subject of `EOF` emits `- EOF` and cannot close the heredoc. Verified against a scratch repo:

```
with "- %s":  "- EOF"   -> bare-EOF count = 0
with "%s":    "EOF"     -> bare-EOF count = 1
```

`%s` also collapses a multi-line first paragraph ("line1 line2"), so a newline cannot be smuggled in either.

But the protection is a *side effect of a format string*: drop the `- ` and every following line becomes a workflow command in `$GITHUB_OUTPUT`. The delimiter is now random per run, so the guard is deliberate.

## Not fixed — recorded as accepted

`claude-code-review.yml` fetches a plugin marketplace from a **mutable git HEAD at runtime**. The action's `plugin_marketplaces` input takes a bare Git URL with no documented ref/SHA syntax, so unlike every `uses:` in this repo it cannot be pinned — and the repository's `sha_pinning_required` setting cannot see a runtime fetch.

Accepted because it is the same first-party origin as the SHA-pinned action, and that job is review-only: no checkout credentials, writes confined to PR comments. Noted in the workflow so it reads as a decision.

Also adds a `concurrency` group to `claude.yml` so two @claude mentions cannot race in one workspace while both hold `contents: write`.

## Verification

Mutation-tested — removing `persist-credentials` from one workflow reds the guard with the offending job named:

```
AssertionError: these checkouts leave a repo-write token in .git/config
for the whole job: ['codeql.yml:analyze']
```

`2328 passed, 7 skipped`; all workflows parse; lint and mypy green.

Refs #252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)