### PR TITLE
fix(sec): make log redaction type-complete and record-level (#252)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -417,42 +417,42 @@
         "filename": "tests/unit/test_logger.py",
         "hashed_secret": "1e7772b7ee7a12f8dbb12351cabcb9dcd43221e8",
         "is_verified": false,
-        "line_number": 53
+        "line_number": 54
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/test_logger.py",
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_verified": false,
-        "line_number": 89
+        "line_number": 90
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/test_logger.py",
         "hashed_secret": "3b96880b8e11758bbf9796b9cd90aaa3ab4bab6e",
         "is_verified": false,
-        "line_number": 103
+        "line_number": 104
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/test_logger.py",
         "hashed_secret": "b4a76d8860918aa1332fb0aca06d2672d438eff7",
         "is_verified": false,
-        "line_number": 126
+        "line_number": 127
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/test_logger.py",
         "hashed_secret": "9749f120d973f95fcd9b26e5a575d83a1abcf1a1",
         "is_verified": false,
-        "line_number": 164
+        "line_number": 165
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/test_logger.py",
         "hashed_secret": "c753ca619f884268db1b142408217819016e9ceb",
         "is_verified": false,
-        "line_number": 184
+        "line_number": 185
       }
     ],
     "tests/unit/test_mcp.py": [
@@ -511,5 +511,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-14T15:13:33Z"
+  "generated_at": "2026-08-14T16:40:35Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,6 +217,31 @@ None. No FMP path we ship was newly retired by this changelog window.
 
 ### Security
 
+- **Log redaction is type-complete and happens on the record (#252
+  FMP-SEC-005).** Four gaps sharing one root cause — the filter gated on
+  `isinstance(v, str | int | float)` to mask and `dict | list` to recurse:
+  - `extra={"api_key": <bytes|tuple|set>}` was logged in the clear; only
+    `str`/`int`/`float` were masked. Every container type is now walked,
+    and `bytes` is decoded before masking rather than having its `repr`
+    masked (`b'****…'` was misleading about both value and length).
+  - A secret reachable only through a tuple was never reached.
+  - Nested extras were redacted inside `JsonFormatter.format` rather than
+    on the `LogRecord`, so a **second handler** — `logging.basicConfig()`,
+    a Sentry or OTel exporter — received the raw value from the same
+    record. Redaction now happens once on the record, so every handler
+    inherits it.
+  - `log_api_call` put positional arguments into `call_args` as a raw
+    tuple. Positional arguments have no names, so nothing downstream can
+    tell a credential from a ticker symbol; it now logs their *types*.
+    `call_kwargs` is named, and is masked as before.
+- **The LangChain tool error envelope redacts API keys (#252
+  FMP-SEC-005).** `fmp_data/lc/vector_store.py` returned `str(e)` inside
+  the tool's result dict, which goes into the agent scratchpad, the chat
+  history and any tracing backend. `str()` of an `httpx.HTTPStatusError`
+  stringifies the request URL, which carries `apikey=` — the exact leak
+  `base.py` suppresses on its own paths, while nothing under `lc/` was
+  redacting. Now redacted at the point of capture, so every branch of the
+  envelope inherits it.
 - **`ClientConfig.__str__` redaction is metadata-driven, not a name
   allowlist (#252 FMP-SEC-007).** It dumped the whole model and masked the
   three field names it knew about, so everything else rendered verbatim —

--- a/fmp_data/lc/vector_store.py
+++ b/fmp_data/lc/vector_store.py
@@ -22,7 +22,7 @@ except ModuleNotFoundError:  # pragma: no cover
         "Install with:  pip install 'fmp-data[langchain]'"
     ) from None
 
-from fmp_data.base import BaseClient
+from fmp_data.base import BaseClient, _redact_api_keys
 from fmp_data.exceptions import ConfigError
 from fmp_data.lc.registry import EndpointInfo, EndpointRegistry
 from fmp_data.logger import FMPLogger
@@ -863,8 +863,15 @@ class EndpointVectorStore:
                     return self._serialize_result(result)
 
                 except Exception as e:
-                    # Handle different types of errors
-                    error_message = str(e)
+                    # Handle different types of errors.
+                    # Redact at the point of capture so every branch below
+                    # inherits it. This dict is the tool's *return value*: it
+                    # goes into the agent scratchpad, the chat history and any
+                    # tracing backend. `str()` of an `httpx.HTTPStatusError`
+                    # stringifies the request URL, which carries `apikey=` --
+                    # the exact leak `base.py` suppresses on its own paths, but
+                    # nothing under `lc/` was redacting (#252 FMP-SEC-005).
+                    error_message = _redact_api_keys(str(e))
                     error_type = type(e).__name__
 
                     # ValueError covers method-level constraints the endpoint

--- a/fmp_data/logger.py
+++ b/fmp_data/logger.py
@@ -18,6 +18,50 @@ from fmp_data.config import LoggingConfig, LogHandlerConfig
 P = ParamSpec("P")
 R = TypeVar("R")
 
+# Attributes the stdlib puts on every LogRecord. Everything else in
+# ``record.__dict__`` came from a caller's ``extra=``, and is therefore fair
+# game for redaction. Rewriting the stdlib ones would corrupt formatting --
+# ``exc_info`` in particular is a tuple that formatters unpack.
+_STANDARD_LOGRECORD_ATTRS = frozenset(
+    {
+        "args",
+        "asctime",
+        "created",
+        "exc_info",
+        "exc_text",
+        "filename",
+        "funcName",
+        "getMessage",
+        "levelname",
+        "levelno",
+        "lineno",
+        "message",
+        "module",
+        "msecs",
+        "msg",
+        "name",
+        "pathname",
+        "process",
+        "processName",
+        "relativeCreated",
+        "stack_info",
+        "taskName",
+        "thread",
+        "threadName",
+    }
+)
+
+
+def _stringify(value: Any) -> str:
+    """Render a value for masking, including ``bytes``.
+
+    ``str(b"secret")`` yields ``b'secret'`` -- the credential survives with
+    decoration, which is worse than useless when the point is to mask it.
+    """
+    if isinstance(value, bytes | bytearray):
+        return value.decode("utf-8", errors="replace")
+    return str(value)
+
 
 class SensitiveDataFilter(logging.Filter):
     """Filter to mask sensitive data in log records"""
@@ -120,21 +164,31 @@ class SensitiveDataFilter(logging.Filter):
         record.args = ()
 
         for key, value in list(record.__dict__.items()):
-            if key.startswith("_"):
+            if key.startswith("_") or key in _STANDARD_LOGRECORD_ATTRS:
+                if key in {"exc_text", "stack_info"} and isinstance(value, str):
+                    record.__dict__[key] = self._mask_patterns_in_string(value)
                 continue
-            lowered = key.lower()
-            if lowered in self.sensitive_keys or any(
-                token in lowered for token in ("api_key", "apikey", "redis_url")
-            ):
-                if isinstance(value, str | int | float):
-                    record.__dict__[key] = self._mask_value(str(value))
-                elif isinstance(value, dict | list):
-                    record.__dict__[key] = self._mask_dict_recursive(deepcopy(value))
-            elif key in {"exc_text", "stack_info"} and isinstance(value, str):
-                record.__dict__[key] = self._mask_patterns_in_string(value)
+
+            if self._is_sensitive_key(key):
+                record.__dict__[key] = self._mask_value(_stringify(value))
+            else:
+                # Redact *every* extra, not only the sensitively-named ones.
+                # A secret nested under a benign key (`extra={"payload":
+                # {"api_key": ...}}`) used to be masked inside
+                # ``JsonFormatter.format`` instead of on the record, so any
+                # second handler -- ``logging.basicConfig()``, a Sentry or
+                # OTel exporter -- emitted the raw value (#252 FMP-SEC-005).
+                # Doing it here means every handler inherits the masking.
+                record.__dict__[key] = self._mask_dict_recursive(deepcopy(value))
 
         self._redact_traceback(record)
         return True
+
+    def _is_sensitive_key(self, key: str) -> bool:
+        lowered = key.lower()
+        return lowered in self.sensitive_keys or any(
+            token in lowered for token in ("api_key", "apikey", "redis_url")
+        )
 
     def _redact_traceback(self, record: logging.LogRecord) -> None:
         """Render and mask the traceback before any formatter can emit it.
@@ -155,27 +209,36 @@ class SensitiveDataFilter(logging.Filter):
         rendered = "".join(traceback.format_exception(*record.exc_info))
         record.exc_text = self._mask_patterns_in_string(rendered.rstrip("\n"))
 
-    def _mask_dict_recursive(self, d: Any, parent_key: str = "") -> Any:
-        """Recursively mask sensitive values in dictionaries and lists"""
-        if isinstance(d, dict):
-            result: dict[str, Any] = {}
-            for k, v in d.items():
-                key = k.lower() if isinstance(k, str) else k
-                is_sensitive = any(
-                    sensitive in str(key).lower() for sensitive in self.sensitive_keys
-                )
+    def _mask_dict_recursive(self, d: Any, parent_key: str = "", depth: int = 0) -> Any:
+        """Recursively mask sensitive values inside any container.
 
-                if is_sensitive and isinstance(v, str | int | float):
-                    result[k] = self._mask_value(str(v))
-                elif isinstance(v, dict):
-                    result[k] = self._mask_dict_recursive(v, f"{parent_key}.{k}")
-                elif isinstance(v, list):
-                    result[k] = self._mask_dict_recursive(v, parent_key)
-                else:
-                    result[k] = v
-            return result
-        elif isinstance(d, list):
-            return [self._mask_dict_recursive(item, parent_key) for item in d]
+        Type-complete on purpose. The previous version gated on
+        ``isinstance(v, str | int | float)`` to mask and ``dict | list`` to
+        recurse, so three shapes walked straight through unredacted (#252
+        FMP-SEC-005):
+
+        * a sensitive key holding ``bytes``, a ``tuple`` or a ``set``;
+        * ``log_api_call``'s ``call_args``, which is a *tuple* of positional
+          arguments -- the API key is routinely the first one;
+        * any secret reachable only through a tuple or set.
+        """
+        if depth >= 6:
+            return d
+        if isinstance(d, dict):
+            return {
+                k: (
+                    self._mask_value(_stringify(v))
+                    if isinstance(k, str) and self._is_sensitive_key(k)
+                    else self._mask_dict_recursive(v, f"{parent_key}.{k}", depth + 1)
+                )
+                for k, v in d.items()
+            }
+        if isinstance(d, list | tuple):
+            return type(d)(
+                self._mask_dict_recursive(i, parent_key, depth + 1) for i in d
+            )
+        if isinstance(d, set):
+            return {self._mask_dict_recursive(i, parent_key, depth + 1) for i in d}
         return d
 
 
@@ -522,7 +585,14 @@ def log_api_call(
                 safe_kwargs = deepcopy(kwargs)
                 log_context.update(
                     {
-                        "call_args": args[1:],  # Skip 'self' argument
+                        # Types, not values. Positional arguments have no
+                        # names, so nothing downstream can tell a credential
+                        # from a ticker symbol -- the filter masks by key name
+                        # and there is no key here, so a secret passed
+                        # positionally was logged verbatim (#252 FMP-SEC-005).
+                        # The data worth reading arrives through `call_kwargs`,
+                        # which is named and therefore maskable. Skip 'self'.
+                        "call_args": [type(a).__name__ for a in args[1:]],
                         "call_kwargs": safe_kwargs,
                     }
                 )

--- a/tests/unit/lc/test_method_dispatch.py
+++ b/tests/unit/lc/test_method_dispatch.py
@@ -652,3 +652,38 @@ def test_successful_dispatch_logs_no_fallback(tmp_path: Any) -> None:
 
     store.logger.warning.assert_not_called()
     store.logger.debug.assert_not_called()
+
+
+def test_tool_error_envelope_redacts_reflected_api_keys(tmp_path: Any) -> None:
+    """The envelope is the tool's return value, so it reaches the model (#252).
+
+    `str()` of an `httpx.HTTPStatusError` stringifies the request URL, which
+    for this client always carries `apikey=`. That dict goes into the agent
+    scratchpad, the chat history and any tracing backend -- `base.py` suppresses
+    this exact leak on its own paths, but nothing under `lc/` was redacting.
+    """
+    planted = "PLANTEDCREDENTIALVALUE"
+    boom = RuntimeError(
+        f"Server error '500' for url "
+        f"'https://financialmodelingprep.com/stable/profile?apikey={planted}'"
+    )
+    client = cast(
+        BaseClient,
+        SimpleNamespace(
+            request=Mock(side_effect=boom),
+            sec=SimpleNamespace(
+                search_industry_classification=Mock(side_effect=boom),
+            ),
+        ),
+    )
+    registry = _sec_registry("industry_classification_search")
+    store = _store_with(client, registry, tmp_path)
+    info = registry.get_endpoint("search_industry_classification")
+    assert info is not None
+
+    result = cast(Any, store.create_tool(info)).invoke({"symbol": "AAPL"})
+
+    assert result["status"] == "error"
+    rendered = repr(result)
+    assert planted not in rendered, f"tool envelope leaked the key: {rendered}"
+    assert "[REDACTED]" in rendered

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -1,5 +1,6 @@
 # tests/test_logger.py
 import asyncio
+import io
 import json
 import logging
 import os
@@ -1110,3 +1111,129 @@ class TestLoggerIntegration:
         output = test_stream.getvalue()
         assert "secret123" not in output
         assert "api_key=" in output
+
+
+class TestRedactionIsTypeComplete:
+    """Redaction must not depend on a value happening to be a str (#252).
+
+    The filter gated on ``isinstance(v, str | int | float)`` to mask and
+    ``dict | list`` to recurse, so several ordinary shapes walked straight
+    through: a sensitive key holding ``bytes``/``tuple``/``set``, and any
+    secret reachable only through a tuple.
+    """
+
+    PLANTED = "PLANTEDCREDENTIALVALUE"
+
+    def _json(self, **extra):
+        record = logging.LogRecord("t", logging.INFO, "p", 1, "call", None, None)
+        record.__dict__.update(extra)
+        SensitiveDataFilter().filter(record)
+        return JsonFormatter().format(record)
+
+    @pytest.mark.parametrize("wrap", [bytes, tuple, set, list, str])
+    def test_sensitive_key_masked_whatever_the_container(self, wrap) -> None:
+        value = (
+            self.PLANTED.encode()
+            if wrap is bytes
+            else self.PLANTED
+            if wrap is str
+            else wrap([self.PLANTED])
+        )
+        assert self.PLANTED not in self._json(api_key=value)
+
+    def test_secret_reachable_only_through_a_tuple(self) -> None:
+        assert self.PLANTED not in self._json(
+            payload={"creds": ({"api_key": self.PLANTED},)}
+        )
+
+    def test_bytes_are_decoded_before_masking(self) -> None:
+        """Not a leak either way -- `_mask_value` masks the middle regardless --
+        but `str(b"...")` masks the *repr*, leaving `b'` decoration and a
+        misleading length in the log. Decoding first keeps the mask honest."""
+        from fmp_data.logger import _stringify
+
+        masker = SensitiveDataFilter()
+        raw = b"PLANTEDCREDENTIALVALUE"
+        assert masker._mask_value(_stringify(raw)) == "PL******************UE"
+        assert not masker._mask_value(_stringify(raw)).startswith("b'")
+
+    def test_non_secret_extras_survive(self) -> None:
+        """Over-redaction would make the logs useless."""
+        out = self._json(symbol="AAPL", attempt=3)
+        assert '"symbol": "AAPL"' in out
+        assert '"attempt": 3' in out
+
+    def test_standard_record_attributes_are_not_rewritten(self) -> None:
+        """`exc_info` is a tuple formatters unpack; mangling it breaks them."""
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            record = logging.LogRecord(
+                "t", logging.ERROR, "p", 1, "m", None, sys.exc_info()
+            )
+        SensitiveDataFilter().filter(record)
+        assert isinstance(record.exc_info, tuple)
+        assert record.exc_info[0] is ValueError
+
+
+class TestEveryHandlerSeesRedactedExtras:
+    """Redaction happens on the record, not inside one formatter (#252).
+
+    Nested extras were masked inside ``JsonFormatter.format``, so a second
+    handler -- ``logging.basicConfig()``, a Sentry or OTel exporter -- got the
+    raw value from the same record.
+    """
+
+    def test_a_second_plain_handler_sees_masked_extras(self) -> None:
+        from fmp_data.logger import FMPLogger
+
+        planted = "PLANTEDCREDENTIALVALUE"
+        buf = io.StringIO()
+        handler = logging.StreamHandler(buf)
+        handler.setFormatter(logging.Formatter("%(message)s | %(nested)s"))
+        package_logger = logging.getLogger("fmp_data")
+        package_logger.addHandler(handler)
+        try:
+            FMPLogger().get_logger("fmp_data.base").info(
+                "call", extra={"nested": {"api_key": planted}}
+            )
+        finally:
+            package_logger.removeHandler(handler)
+
+        assert planted not in buf.getvalue()
+        assert "api_key" in buf.getvalue()
+
+
+class TestLogApiCallPositionalArguments:
+    """Positional arguments have no names, so nothing can judge them (#252).
+
+    ``call_args`` was the raw tuple of positional arguments; the filter masks
+    by key name and there is no key inside a tuple, so a credential passed
+    positionally was logged verbatim.
+    """
+
+    def test_positional_values_are_replaced_by_their_types(self) -> None:
+        from fmp_data.logger import log_api_call
+
+        planted = "PLANTEDCREDENTIALVALUE"
+        buf = io.StringIO()
+        handler = logging.StreamHandler(buf)
+        handler.setFormatter(JsonFormatter())
+        handler.addFilter(SensitiveDataFilter())
+        logger = logging.getLogger("fmp_data.test_positional")
+        logger.addHandler(handler)
+        logger.setLevel(logging.DEBUG)
+        logger.propagate = False
+
+        class Service:
+            @log_api_call(logger=logger)
+            def request(self, positional, **kwargs):
+                return "ok"
+
+        Service().request(planted, symbol="AAPL", api_key=planted)
+        out = buf.getvalue()
+
+        assert planted not in out
+        assert '"call_args": ["str"]' in out
+        # Named arguments stay readable except for the credential.
+        assert '"symbol": "AAPL"' in out


### PR DESCRIPTION
Four gaps in `SensitiveDataFilter` sharing one root cause: it gated on `isinstance(v, str | int | float)` to mask and `dict | list` to recurse, so anything else walked straight through.

```
api_key as bytes          leaked? True
api_key as tuple          leaked? True
api_key as set            leaked? True
api_key as str (control)  leaked? False
```

## 1–2. Type completeness

A sensitive key holding `bytes`/`tuple`/`set` was logged in the clear, and a secret reachable *only* through a tuple was never reached. Every container type is now walked.

`bytes` is decoded before masking rather than having its `repr` masked. **Not a leak either way** — `_mask_value` masks the middle regardless — but it misstates both the value and its length:

```
with _stringify: PL******************UE
with str()     : b'*********************E'
```

I checked this specifically because the mutation test *didn't* fire, so it's described as a readability fix rather than a security one.

## 3. Redaction moved onto the record

Nested extras were redacted inside `JsonFormatter.format` instead of on the `LogRecord`, so a **second handler** saw the raw value from the same record:

```
USERROOT call | extras={'api_key': 'SECRETKEY_abcdefghijklmnop_1234567890'}
```

That is what `logging.basicConfig()`, a Sentry exporter or an OTel log exporter looks like — i.e. the common case for a library consumer, who gets our filter on our handler and raw secrets on theirs.

Redaction now happens once on the record so every handler inherits it. Standard `LogRecord` attributes are excluded by name — `exc_info` is a tuple formatters unpack, and rewriting it would corrupt them (asserted).

## 4. `log_api_call` positional arguments

`call_args` was the raw tuple of positionals. They have no names, so nothing downstream can distinguish a credential from a ticker symbol — the filter masks by key, and there is no key inside a tuple.

It now logs their **types**. The single decorated method is `BaseClient.request(self, endpoint, **kwargs)`, so this loses nothing readable:

```json
"call_args": ["str"],
"call_kwargs": {"symbol": "AAPL", "api_key": "SE*********************************90"}
```

## Also: the LangChain tool error envelope

`fmp_data/lc/vector_store.py` returned `str(e)` inside the dict that **is** the tool's return value — it goes into the agent scratchpad, the chat history and any tracing backend. `str()` of an `httpx.HTTPStatusError` stringifies the request URL, which carries `apikey=`.

That is the exact leak `base.py` goes out of its way to suppress on its own paths, while `grep -rl _redact_api_keys fmp_data/` matched only `base.py`. Now redacted at the point of capture, so every branch of the envelope inherits it.

## One finding that needed no fix

The nested-`redis_url` case from the same family is already closed: #294 made that field `SecretStr`, so the dump no longer carries the password. Verified rather than assumed.

## Verification

Mutation-tested — each mechanism reverted independently reds its own tests:

| Reverted | Result |
|---|---|
| tuple recursion | `test_secret_reachable_only_through_a_tuple` |
| record-level redaction | `test_a_second_plain_handler_sees_masked_extras` |
| `call_args` types | `test_positional_values_are_replaced_by_their_types` |
| lc envelope redaction | `test_tool_error_envelope_redacts_reflected_api_keys` |

Over-redaction is checked too: `symbol="AAPL"` and `attempt=3` still appear.

`2375 passed, 7 skipped`; lint and mypy green.

Refs #252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)