### PR TITLE
fix(ci): serialize publishes and stop ignoring ruff's bandit twins (#252)

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -17,6 +17,13 @@ on:
       - dev
   workflow_dispatch:
 
+# Serialize dev releases. Rapid pushes to `dev` would otherwise publish
+# out of order. Never cancel in progress -- a half-finished upload is
+# worse than a queued one (#252).
+concurrency:
+  group: dev-release-to-testpypi
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -14,6 +14,14 @@ on:
       - 'v*.*.*b*'             # Beta releases (v1.2.3b1)
       - 'v*.*.*dev*'           # Dev releases (v1.2.3dev1)
 
+# Serialize TestPyPI publishes. Two pushes to the same PR would otherwise
+# race, and the slower run's comment could overwrite the newer one --
+# advertising a stale version, the exact invariant #204 exists to protect.
+# Serializing (rather than cancelling) also avoids aborting an upload.
+concurrency:
+  group: publish-testpypi
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,14 @@ on:
 
 # Least privilege at workflow scope. Each job raises only what it needs.
 # Build/tag/GitHub Release: contents: write. Publish: id-token: write only.
+# Serialize releases. Two release PRs merging close together would
+# otherwise race on the same tag and the same PyPI version.
+# cancel-in-progress stays false: cancelling a run mid-upload is worse
+# than making the second one wait (#252).
+concurrency:
+  group: release-to-pypi
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,23 @@ None. No FMP path we ship was newly retired by this changelog window.
   `base.py` suppresses on its own paths, while nothing under `lc/` was
   redacting. Now redacted at the point of capture, so every branch of the
   envelope inherits it.
+- **Publish workflows serialize (#252).** `release.yml`,
+  `dev-release.yml` and `publish-testpypi.yml` had no `concurrency` group,
+  so two pushes to the same PR could both build and publish and the
+  slower run's comment could overwrite the newer one — advertising a
+  stale version, the exact invariant #204 exists to protect.
+  `cancel-in-progress` is deliberately `false`: making the second run
+  wait is strictly better than aborting one mid-upload.
+- **Ruff's bandit twins are no longer globally ignored (#252
+  FMP-SEC-008).** #278 removed `B603`/`B607` from `[tool.bandit] skips`,
+  but their flake8-bandit equivalents `S603`/`S607` stayed in
+  `[tool.ruff.lint] ignore` — so the narrowing looked done while the rule
+  was enforced by *neither* tool. The global ignore is now just `S101`;
+  the five real call sites carry a targeted `# noqa` with a reason
+  alongside the existing `# nosec`. `scripts/` was also exempt from both
+  ruff's `S` rules and bandit's `exclude_dirs`; both exemptions are gone
+  and both tools pass. A test pins the ruff ignore list next to the
+  existing bandit one, since splitting them is what let this drift.
 - **`ClientConfig.__str__` redaction is metadata-driven, not a name
   allowlist (#252 FMP-SEC-007).** It dumped the whole model and masked the
   three field names it knew about, so everything else rendered verbatim —

--- a/fmp_data/mcp/setup.py
+++ b/fmp_data/mcp/setup.py
@@ -376,7 +376,9 @@ class SetupWizard:
         import subprocess  # nosec B404
 
         try:
-            result = subprocess.run(  # nosec B603
+            # Fixed argv, no shell; `python_path` is the interpreter we just
+            # resolved, not user input.
+            result = subprocess.run(  # noqa: S603  # nosec B603
                 [python_path, "-c", "import fmp_data"], capture_output=True, timeout=5
             )
             if result.returncode != 0:

--- a/fmp_data/mcp/utils.py
+++ b/fmp_data/mcp/utils.py
@@ -65,12 +65,13 @@ def find_python_executable() -> str:
     # Try common Python commands
     for cmd in ["python3", "python", "python3.10", "python3.11", "python3.12"]:
         try:
-            result = subprocess.run(  # nosec B603
+            # Fixed argv from the literal list above; no shell.
+            result = subprocess.run(  # noqa: S603  # nosec B603
                 [cmd, "--version"], capture_output=True, text=True, timeout=2
             )
             if result.returncode == 0:
                 # Get the full path
-                which_result = subprocess.run(  # nosec B603
+                which_result = subprocess.run(  # noqa: S603  # nosec B603
                     (
                         ["which", cmd]
                         if platform.system() != "Windows"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,8 +213,6 @@ select = [
 ]
 ignore = [
     "S101",
-    "S603",
-    "S607",
 ]
 
 [tool.ruff.lint.per-file-ignores]
@@ -222,10 +220,6 @@ ignore = [
     "S101",
     "S106",
     "S107",
-]
-"scripts/*" = [
-    "S603",
-    "S607",
 ]
 "**/conftest.py" = [
     "S101",
@@ -472,7 +466,6 @@ output = "coverage.xml"
 [tool.bandit]
 exclude_dirs = [
     "tests",
-    "scripts",
     ".nox",
     ".venv",
     "build",

--- a/tests/unit/test_arg_model_deprecation.py
+++ b/tests/unit/test_arg_model_deprecation.py
@@ -322,7 +322,7 @@ def test_importing_an_arg_model_stays_silent() -> None:
         "import fmp_data.market.schema\n"
         "import fmp_data.models\n"
     )
-    result = subprocess.run(
+    result = subprocess.run(  # noqa: S603
         [sys.executable, "-c", code], capture_output=True, text=True
     )
     assert result.returncode == 0, (

--- a/tests/unit/test_bandit_skips.py
+++ b/tests/unit/test_bandit_skips.py
@@ -16,3 +16,44 @@ def test_bandit_global_skips_are_only_assert_used() -> None:
     assert '"B101"' in block
     for code in ("B404", "B603", "B607", "B608"):
         assert code not in block
+
+
+def _ruff_lint_block() -> str:
+    text = PYPROJECT.read_text(encoding="utf-8")
+    start = text.index("[tool.ruff.lint]")
+    end = text.index("[tool.ruff.lint.isort]")
+    return text[start:end]
+
+
+def test_ruff_does_not_globally_ignore_the_bandit_twins() -> None:
+    """#278 narrowed bandit's skips but not ruff's (#252).
+
+    `S603` / `S607` are flake8-bandit's twins of `B603` / `B607`. Removing the
+    latter from `[tool.bandit] skips` while the former stayed in
+    `[tool.ruff.lint] ignore` left the rule unenforced by *either* tool --
+    the narrowing looked done and was not.
+    """
+    block = _ruff_lint_block()
+    ignore = block[
+        block.index("ignore = [") : block.index("[tool.ruff.lint.per-file-ignores]")
+    ]
+    assert '"S101"' in ignore, "guard is vacuous if the ignore list moved"
+    for code in ("S603", "S607", "S608"):
+        assert f'"{code}"' not in ignore, (
+            f"{code} is globally ignored again; annotate the call site with a "
+            f"targeted `# noqa` and a reason instead"
+        )
+
+
+def test_scripts_are_scanned_by_both_tools() -> None:
+    """`scripts/` used to be exempt from ruff's S rules *and* bandit."""
+    text = PYPROJECT.read_text(encoding="utf-8")
+    per_file = text[
+        text.index("[tool.ruff.lint.per-file-ignores]") : text.index(
+            "[tool.ruff.lint.isort]"
+        )
+    ]
+    assert '"scripts/*"' not in per_file
+
+    bandit = text[text.index("[tool.bandit]") : text.index("[tool.bandit.assert_used]")]
+    assert '"scripts"' not in bandit

--- a/tests/unit/test_extras_coverage_gate.py
+++ b/tests/unit/test_extras_coverage_gate.py
@@ -152,7 +152,7 @@ def test_uv_lock_stays_uncommitted() -> None:
     """
     assert "uv.lock" in GITIGNORE.read_text(encoding="utf-8")
     tracked = subprocess.run(
-        ["git", "ls-files", "--", "uv.lock", "poetry.lock"],
+        ["git", "ls-files", "--", "uv.lock", "poetry.lock"],  # noqa: S607
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,

--- a/tests/unit/test_workflow_permission_isolation.py
+++ b/tests/unit/test_workflow_permission_isolation.py
@@ -135,3 +135,25 @@ def test_codecov_token_is_not_in_a_job_that_runs_pr_code() -> None:
     )
     assert upload["needs"] == "coverage" or "coverage" in upload["needs"]
     assert _write_scopes(upload.get("permissions")) == set()
+
+
+PUBLISH_WORKFLOWS = ("release.yml", "dev-release.yml", "publish-testpypi.yml")
+
+
+@pytest.mark.parametrize("name", PUBLISH_WORKFLOWS)
+def test_publish_workflows_serialize(name: str) -> None:
+    """Concurrent publishes race on version, tag and PR comment (#252).
+
+    Two pushes to the same PR both build and publish; the slower run's
+    comment can overwrite the newer one, advertising a stale version -- the
+    exact invariant #204 exists to protect.
+
+    `cancel-in-progress` must stay false: making the second run wait is
+    strictly better than aborting one mid-upload.
+    """
+    loaded = yaml.safe_load((REPO_ROOT / ".github" / "workflows" / name).read_text())
+    concurrency = loaded.get("concurrency")
+    assert concurrency, f"{name} has no concurrency group; publishes can race"
+    assert concurrency.get("cancel-in-progress") is False, (
+        f"{name} may cancel a run mid-upload"
+    )


### PR DESCRIPTION
Two independent CI-hardening leftovers.

## Concurrency

`release.yml`, `dev-release.yml` and `publish-testpypi.yml` had **no** `concurrency` group:

```
ci.yml           yes    document.yml          yes
release-pr.yml   yes    sync-main-to-dev.yml  yes
release.yml      NONE   publish-testpypi.yml  NONE   dev-release.yml  NONE
```

Two pushes to the same PR could both build and publish, and the slower run's comment could overwrite the newer one — advertising a stale version, which is the exact invariant #204 exists to protect.

`cancel-in-progress` is deliberately **false**. Making the second run wait is strictly better than aborting one mid-upload; serializing already fixes the staleness, because the newest run then finishes last.

## Ruff's S-rules

#278 removed `B603`/`B607` from `[tool.bandit] skips` — but their flake8-bandit twins `S603`/`S607` stayed in `[tool.ruff.lint] ignore`. So the narrowing *looked* done while the rule was enforced by **neither** tool. Same shape as every other finding on this issue: configured, not enforced.

Removing them surfaced exactly five call sites, all benign and all already carrying `# nosec B603` from #278:

```
fmp_data/mcp/setup.py:379           S603
fmp_data/mcp/utils.py:68,73         S603
tests/unit/test_arg_model_deprecation.py:325   S603
tests/unit/test_extras_coverage_gate.py:155    S607
```

Each now has a matching targeted `# noqa` with a reason, so the two tools agree instead of each assuming the other covers it. The global ignore is down to `S101`.

`scripts/` was separately exempt from ruff's S rules (`per-file-ignores`) **and** from bandit (`exclude_dirs`), so its one file was scanned by neither. It uses no subprocess and passes both cleanly, so both exemptions are gone rather than kept "just in case".

The meta-test now pins the ruff ignore list next to the existing bandit one — keeping them in separate tests is what let them drift apart in the first place.

## Verification

Mutation-tested:

| Reverted | Result |
|---|---|
| global `S603`/`S607` ignore restored | `test_ruff_does_not_globally_ignore_the_bandit_twins` reds |
| `release.yml` concurrency removed | `test_publish_workflows_serialize[release.yml]` reds |

`2374 passed, 7 skipped`; `lint`, `typecheck` **and** `security` all green — the last now with bandit also scanning `scripts/`.

Refs #252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)