### PR TITLE
fix(sec): redact handler_kwargs on the dump path (#252)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,6 +217,17 @@ None. No FMP path we ship was newly retired by this changelog window.
 
 ### Security
 
+- **`LogHandlerConfig.handler_kwargs` is redacted on the dump path too
+  (#252 FMP-SEC-007).** `__str__` was swept in the metadata-driven
+  redaction change, but `model_dump()` / `model_dump_json()` still emitted
+  these verbatim — and they are a bare `dict[str, Any]` handed straight to
+  a logging handler, so a `SysLogHandler` password or an HTTP handler's
+  credentials live there. `SecretStr` cannot reach inside an untyped bag,
+  so a `field_serializer` closes it, the same approach used for
+  `EmbeddingConfig.additional_kwargs`. Safe here because the only consumer
+  reads the attribute (`config.handler_kwargs.copy()` in `logger.py`),
+  so nothing rebuilds the model from its own dump. Operational kwargs such
+  as `maxBytes` and `backupCount` are still shown.
 - **Log redaction is type-complete and happens on the record (#252
   FMP-SEC-005).** Four gaps sharing one root cause — the filter gated on
   `isinstance(v, str | int | float)` to mask and `dict | list` to recurse:

--- a/fmp_data/config.py
+++ b/fmp_data/config.py
@@ -15,7 +15,14 @@ from pathlib import Path
 from typing import Any, Literal
 from urllib.parse import urlparse, urlsplit, urlunsplit
 
-from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    SecretStr,
+    field_serializer,
+    field_validator,
+)
 
 from fmp_data._redaction import redact_mapping
 from fmp_data.cache.config import CacheConfig
@@ -86,6 +93,22 @@ class LogHandlerConfig(BaseModel):
         default_factory=dict,
         description="Additional arguments for handler initialization",
     )
+
+    @field_serializer("handler_kwargs")
+    def _serialize_handler_kwargs(self, value: dict[str, Any]) -> dict[str, Any]:
+        """Redact on the dump path too, not only in ``__str__`` (#252).
+
+        ``dict[str, Any]`` is out of reach for ``SecretStr``, and these kwargs
+        go straight to a logging handler -- a ``SysLogHandler`` password or an
+        HTTP handler's credentials live here. ``__str__`` was fixed to sweep
+        them, but ``model_dump()`` / ``model_dump_json()`` still emitted them,
+        so anything serializing a config leaked.
+
+        Safe here for the same reason as ``EmbeddingConfig``: the only
+        consumer reads the attribute (``config.handler_kwargs.copy()`` in
+        ``logger.py``), so nothing rebuilds this model from its own dump.
+        """
+        return redact_mapping(value)
 
     @field_validator("level")
     @classmethod

--- a/tests/unit/test_config_secret_serialization.py
+++ b/tests/unit/test_config_secret_serialization.py
@@ -225,3 +225,52 @@ class TestDisplayRedactionIsNotANameAllowlist:
         assert "1048576" in text
         assert "backupCount" in text
         assert "base_url=" in text
+
+
+class TestHandlerKwargsOnTheDumpPath:
+    """`handler_kwargs` is out of `SecretStr`'s reach (#252).
+
+    It is a bare `dict[str, Any]` handed straight to a logging handler --
+    a `SysLogHandler` password or an HTTP handler's credentials live here.
+    `__str__` was swept, but `model_dump()` still emitted them.
+    """
+
+    PLANTED = "PLANTEDHANDLERSECRET"
+
+    def _config(self) -> ClientConfig:
+        from fmp_data.config import LoggingConfig, LogHandlerConfig
+
+        return ClientConfig(
+            api_key=API_KEY,
+            logging=LoggingConfig(
+                handlers={
+                    "file": LogHandlerConfig(
+                        class_name="RotatingFileHandler",
+                        handler_kwargs={
+                            "password": self.PLANTED,
+                            "maxBytes": 1048576,
+                            "backupCount": 3,
+                        },
+                    )
+                }
+            ),
+        )
+
+    def test_model_dump_does_not_leak(self) -> None:
+        assert self.PLANTED not in str(self._config().model_dump())
+
+    def test_model_dump_json_does_not_leak(self) -> None:
+        assert self.PLANTED not in self._config().model_dump_json()
+
+    def test_the_live_value_is_untouched(self) -> None:
+        """`logger.py` splats these into the handler constructor."""
+        config = self._config()
+        config.model_dump()  # must not mutate
+        kwargs = config.logging.handlers["file"].handler_kwargs
+        assert kwargs["password"] == self.PLANTED
+
+    def test_operational_kwargs_survive(self) -> None:
+        dumped = self._config().model_dump()
+        kwargs = dumped["logging"]["handlers"]["file"]["handler_kwargs"]
+        assert kwargs["maxBytes"] == 1048576
+        assert kwargs["backupCount"] == 3


### PR DESCRIPTION
Found by re-running the acceptance checks against merged `dev` **before** closing #252, rather than assuming the earlier fixes covered it:

```
config leaks: {'repr': False, 'str': False, 'dump': True, 'json': True}
dump handler_kwargs: {'password': 'pw123'}
```

#297 made `ClientConfig.__str__` sweep untyped bags — but only `__str__`. `model_dump()` and `model_dump_json()` still emitted `LogHandlerConfig.handler_kwargs` verbatim.

That field is a bare `dict[str, Any]` handed straight to a logging handler, so it is where a `SysLogHandler` password or an HTTP handler's credentials actually live. The credential *fields* were already safe after #294; this was the one untyped bag left on the serialization path.

## Fix

`SecretStr` cannot reach inside a `dict[str, Any]`, so a `field_serializer` closes it — the same approach already used for `EmbeddingConfig.additional_kwargs`.

Safe here for the same reason it is safe there: the only consumer reads the **attribute** (`config.handler_kwargs.copy()`, `logger.py:522`), so nothing rebuilds the model from its own dump. I checked that before writing it, because it is precisely the trap that rules this approach out on `ClientConfig`, where `LangChainConfig.from_env` round-trips through `model_dump()` and would rebuild itself from masked values.

## Not over-redacted

```
password in dump: False | json: False
useful kwargs kept: True      # maxBytes, backupCount
live value intact : pw123     # logger.py splats this into the handler
```

Both asserted — masking what the handler constructor receives would break logging outright.

## Verification

Mutation-tested: disabling the serializer reds both dump tests.

`2390 passed, 7 skipped`; lint, typecheck and security green.

Refs #252 — last code item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)