### PR TITLE
feat(e2e): VCR client-method sweep and live schema fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,8 @@ cover/
 
 # VCR cassettes (large recorded API responses, regenerated locally)
 tests/integration/vcr_cassettes/
+tests/e2e/vcr_cassettes/
+tests/e2e/reports/
 
 # Build
 *.manifest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,13 @@ None. No FMP path we ship was newly retired by this changelog window.
 
 ### Added
 
+- **Local VCR-backed client-method e2e sweep.** Maintainer script
+  `scripts/e2e_endpoints.py` (`make e2e-record` / `make e2e-replay`) calls
+  every public sync `FMPDataClient` method, records gitignored cassettes
+  under `tests/e2e/vcr_cassettes/`, and prints a per-method report. Opt-in
+  (`-m not e2e` in addopts); not run by `make test`. First live pass
+  covered 265 methods: 239 ok, 26 deprecated skips.
+
 - **FMP hosted MCP vs `fmp-mcp` positioning (#230).** Docs-only: we are not
   wrapping FMP's remote MCP URL. README + `docs/mcp/index.md` point at
   `docs/mcp/hosted.md`, which records the 2026-08-12 decision (A+D: position
@@ -168,6 +175,12 @@ None. No FMP path we ship was newly retired by this changelog window.
     `DEFAULT_TOOLS`). LangChain indexes the same semantics key.
 
 ### Fixed
+
+- **`HolderIndustryBreakdown.industry_title` accepts `null`.** A live
+  13F industry-breakdown row sends `industryTitle: null`; the field was
+  required `str` and the whole call raised `ValidationError`.
+- **`CryptoNewsArticle.symbol` accepts `null`.** General crypto news
+  often has no pair; the required `str` field rejected those rows.
 
 - **`FMPLogger.get_logger(__name__)` no longer doubles `fmp_data.` (#238).**
   The root logger is already `fmp_data`; `getChild(__name__)` was emitting

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 #
 # For maintainer/developer commands, see Makefile.dev
 
-.PHONY: help install install-dev venv test test-unit test-integration test-integration-replay test-integration-record lint format fix check clean update update-dev
+.PHONY: help install install-dev venv test test-unit test-integration test-integration-replay test-integration-record e2e-list e2e-record e2e-replay lint format fix check clean update update-dev
 .PHONY: mcp-setup mcp-test mcp-list mcp-status ci
 
 # Default target
@@ -47,6 +47,9 @@ help: ## Show available commands
 	@echo "  $(GREEN)make test-unit$(RESET)       Run unit tests only"
 	@echo "  $(GREEN)make test-integration$(RESET) Run integration tests (replay by default)"
 	@echo "  $(GREEN)make test-integration-record$(RESET) Record/refresh integration cassettes"
+	@echo "  $(GREEN)make e2e-list$(RESET)         List client methods the e2e sweep covers"
+	@echo "  $(GREEN)make e2e-record$(RESET)       Record live e2e cassettes (set GROUP= / METHOD=)"
+	@echo "  $(GREEN)make e2e-replay$(RESET)       Replay e2e cassettes (no network)"
 	@echo "  $(GREEN)make lint$(RESET)            Check code quality"
 	@echo "  $(GREEN)make format$(RESET)          Check code formatting"
 	@echo "  $(GREEN)make fix$(RESET)             Auto-fix code issues"
@@ -154,6 +157,32 @@ test-integration-record: venv ## Record/update integration VCR cassettes (set TE
 		if [ -z "$$FMP_TEST_API_KEY" ]; then echo "$(YELLOW)FMP_TEST_API_KEY is required for recording.$(RESET)" && exit 1; fi; \
 		export FMP_VCR_RECORD=new_episodes; \
 		. .venv/bin/activate && pytest -q $${TESTS:-tests/integration}
+
+e2e-list: venv ## List every public sync method the e2e sweep will call
+	@echo "$(BOLD)$(BLUE)📋 E2E client-method sweep cases...$(RESET)"
+	@. .venv/bin/activate && python scripts/e2e_endpoints.py list $(if $(GROUP),--group $(GROUP),) $(if $(METHOD),--method $(METHOD),)
+
+e2e-record: venv ## Record live e2e cassettes (set GROUP=company METHOD=get_profile REFRESH=1 SKIP_BULK=1)
+	@echo "$(BOLD)$(YELLOW)🎥 Recording e2e client-method cassettes...$(RESET)"
+	@eval "$$(python3 scripts/export_dotenv.py .env)"; \
+		if [ -z "$$FMP_TEST_API_KEY" ] && [ -n "$$FMP_API_KEY" ]; then export FMP_TEST_API_KEY="$$FMP_API_KEY"; fi; \
+		if [ -z "$$FMP_API_KEY" ] && [ -n "$$FMP_TEST_API_KEY" ]; then export FMP_API_KEY="$$FMP_TEST_API_KEY"; fi; \
+		if [ -z "$$FMP_TEST_API_KEY" ]; then echo "$(YELLOW)FMP_TEST_API_KEY is required for recording.$(RESET)" && exit 1; fi; \
+		. .venv/bin/activate && python scripts/e2e_endpoints.py record \
+			$(if $(GROUP),--group $(GROUP),) \
+			$(if $(METHOD),--method $(METHOD),) \
+			$(if $(REFRESH),--refresh,) \
+			$(if $(SKIP_BULK),--skip-bulk,)
+
+e2e-replay: venv ## Replay e2e cassettes without hitting the API
+	@echo "$(BOLD)$(BLUE)🧪 Replaying e2e client-method cassettes...$(RESET)"
+	@eval "$$(python3 scripts/export_dotenv.py .env)"; \
+		if [ -z "$$FMP_TEST_API_KEY" ] && [ -n "$$FMP_API_KEY" ]; then export FMP_TEST_API_KEY="$$FMP_API_KEY"; fi; \
+		if [ -z "$$FMP_API_KEY" ] && [ -n "$$FMP_TEST_API_KEY" ]; then export FMP_API_KEY="$$FMP_TEST_API_KEY"; fi; \
+		. .venv/bin/activate && python scripts/e2e_endpoints.py replay \
+			$(if $(GROUP),--group $(GROUP),) \
+			$(if $(METHOD),--method $(METHOD),) \
+			$(if $(SKIP_BULK),--skip-bulk,)
 
 lint: ## Check code quality with ruff
 	@echo "$(BOLD)$(BLUE)🔍 Checking code quality...$(RESET)"

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -33,6 +33,25 @@ FMP_TEST_API_KEY=your_test_api_key FMP_VCR_RECORD=new_episodes uv run pytest tes
 FMP_TEST_API_KEY=your_test_api_key FMP_VCR_RECORD=new_episodes uv run pytest tests/integration/test_sec.py  # pragma: allowlist secret
 ```
 
+7. Full client-method e2e sweep (local, spends quota on record):
+```bash
+# list every public sync method
+uv run python scripts/e2e_endpoints.py list
+
+# record one group, or everything
+uv run python scripts/e2e_endpoints.py record --group company
+uv run python scripts/e2e_endpoints.py record --skip-bulk
+
+# replay without hitting the API
+uv run python scripts/e2e_endpoints.py replay
+```
+
+This sweep calls every public `FMPDataClient` method, writes VCR cassettes
+under `tests/e2e/vcr_cassettes/` (gitignored), and writes a JSON report to
+`tests/e2e/reports/last-report.json`. It is deselected from `make test`.
+Use it to debug model/path drift after an FMP change. The cheaper
+declaration probe remains `pytest tests/e2e/ -m live`.
+
 ## Test Structure
 
 ```

--- a/docs/superpowers/specs/2026-08-14-e2e-client-sweep-design.md
+++ b/docs/superpowers/specs/2026-08-14-e2e-client-sweep-design.md
@@ -1,0 +1,130 @@
+# E2E client-method sweep
+
+**Date:** 2026-08-14
+**Base:** `dev`
+**Status:** approved (approach B)
+
+## Problem
+
+Two existing layers almost cover "is this package ready?" and both miss
+the thing we actually ship:
+
+- `tests/e2e/test_live_signatures.py` probes every `Endpoint` declaration
+  against the live API. It never goes through `FMPDataClient`, never
+  parses models, and has no VCR. A passing run can still leave a broken
+  client method.
+- `tests/integration/` calls real client methods under VCR, but only the
+  methods someone wrote by hand. Cassettes are gitignored.
+
+A dead path, a wrong unwrap, or a Pydantic schema that no longer matches
+the wire can therefore reach a release.
+
+## Goal
+
+A **local, opt-in harness** that calls every public **sync** client
+method through `FMPDataClient`, records the HTTP traffic with VCR, and
+reports per-method pass / empty / error. Maintainers record once (or
+one group / one method), then replay while fixing models and paths
+without spending quota.
+
+This is not CI. Default `make test` / `pytest` must not run it.
+
+## Non-goals
+
+- Async client sweep (same models; doubles cost). Add later if needed.
+- Replacing handwritten integration tests or the live signature probe.
+- Committing cassettes (large, secret-sensitive; same policy as
+  `tests/integration/vcr_cassettes/`).
+- Rich field-by-field assertions. Those stay in `tests/integration/`.
+
+## Design
+
+### Discovery
+
+Walk `FMPDataClient` group properties (`company`, `market`, …) and
+collect every public method on the sync client class. A method is a
+sweep case. Deprecated methods (`__fmp_deprecated__`) are listed and
+skipped. Private helpers (`_unwrap_*`, `_format_date`, …) are ignored.
+
+Endpoint maps are attached when present, for the report (`path`,
+`version`). They are **not** the source of cases: the public client is
+what callers use, and several live methods are not in a map.
+
+### Samples
+
+Required method parameters are filled from a name-based sample table
+(symbol, cik, dates, …). Optional date parameters are also filled with
+**anchored** dates so VCR query strings stay stable (`date.today()`
+inside SEC search is the failure mode this prevents).
+
+Inferences:
+
+- method name contains `etf` → `SPY`
+- `mutual_fund` / fund-disclosure → `VTSAX`
+- `crypto` → `BTCUSD`
+- `forex` → `EURUSD`
+- `commodity` → `GCUSD`
+- `symbols` (batch) → `["AAPL", "MSFT"]`
+- economic `indicator_name` → `GDP`
+- senate / house `name` → `Nancy Pelosi`
+
+Bulk CSV methods (`*_bulk` on `batch`) run by default and can be
+skipped with `--skip-bulk`. `company.get_company_logo_url` is local
+(no HTTP) and is invoked without a cassette.
+
+### VCR
+
+Reuse the integration sanitizers (API key scrub, 401 drop, safe
+persister). Cassettes live in `tests/e2e/vcr_cassettes/{group}/{method}.yaml`
+and are gitignored.
+
+| Command | Record mode |
+|---|---|
+| `record` | `new_episodes` |
+| `record --refresh` | `all` |
+| `replay` | `none` |
+
+Replay of a missing cassette is an error for that case, not a live call.
+
+### Assertions
+
+A case **ok**s when the method returns without raising and the payload
+is non-empty (list/bytes/string length, or a model instance). Empty
+success is `empty` (fail unless the method is on an allowlist of
+entity-sensitive endpoints). Any exception is `error`. Deprecated is
+`skip`.
+
+Validation mode defaults to the package default (`warn`). `--strict`
+sets `FMP_VALIDATION_MODE=strict` so extra/missing fields fail loudly.
+
+### Entry points
+
+```text
+uv run python scripts/e2e_endpoints.py list
+uv run python scripts/e2e_endpoints.py record [--group G] [--method M] [--refresh]
+uv run python scripts/e2e_endpoints.py replay [--group G] [--method M]
+make e2e-record
+make e2e-replay
+```
+
+A pytest module `tests/e2e/test_client_sweep.py` marked `e2e` wraps
+replay so it can be invoked as pytest. `addopts` deselects `e2e` the
+same way it already deselects `live`.
+
+The report is JSON + a table on stdout:
+`tests/e2e/reports/last-report.json` (gitignored).
+
+## Layout
+
+| Path | Role |
+|---|---|
+| `tests/e2e/harness.py` | discovery, samples, classify, run |
+| `scripts/e2e_endpoints.py` | CLI |
+| `tests/e2e/test_client_sweep.py` | optional pytest replay wrapper |
+| `tests/unit/test_e2e_sweep.py` | unit tests (no network) |
+
+## Quota
+
+A full record is one request per public sync method (a few hundred),
+plus retries on 429. Throttle ~200ms between live calls. Filter with
+`--group` / `--method` when iterating on a fix.

--- a/fmp_data/institutional/models.py
+++ b/fmp_data/institutional/models.py
@@ -857,7 +857,9 @@ class HolderIndustryBreakdown(BaseModel):
     report_date: date = Field(description="Filing date", alias="date")
     cik: CIK = Field(description="Institution CIK")
     investor_name: str = Field(alias="investorName", description="Investor name")
-    industry_title: str = Field(alias="industryTitle", description="Industry title")
+    industry_title: str | None = Field(
+        default=None, alias="industryTitle", description="Industry title"
+    )
     weight: float = Field(description="Industry weight in portfolio")
     last_weight: float | None = Field(
         default=None, alias="lastWeight", description="Previous weight"

--- a/fmp_data/intelligence/models.py
+++ b/fmp_data/intelligence/models.py
@@ -296,7 +296,9 @@ class CryptoNewsArticle(BaseModel):
     site: str = Field(description="Source website")
     text: str = Field(description="Article preview text/summary")
     url: HttpUrl = Field(description="Full article URL")
-    symbol: str = Field(description="Cryptocurrency trading pair symbol")
+    symbol: str | None = Field(
+        default=None, description="Cryptocurrency trading pair symbol"
+    )
     publisher: str | None = Field(default=None, description="News publisher")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -354,13 +354,13 @@ addopts = [
     "--disable-warnings",
     "--strict-markers",
     "--strict-config",
-    # Live-API tests are opt-in. `make test` sources .env and promotes
-    # FMP_API_KEY to FMP_TEST_API_KEY, so without this a maintainer running
-    # the project's own test command spends ~700 requests against a 250/day
-    # quota. Override with `-m live` on the command line, which wins over
-    # addopts.
+    # Live-API tests and the VCR client-method sweep are opt-in. `make test`
+    # sources .env and promotes FMP_API_KEY to FMP_TEST_API_KEY, so without
+    # this a maintainer running the project's own test command spends ~700
+    # requests against a 250/day quota. Override with `-m live` or `-m e2e`
+    # on the command line, which wins over addopts.
     "-m",
-    "not live",
+    "not live and not e2e",
 ]
 testpaths = [
     "tests",
@@ -387,6 +387,7 @@ markers = [
     "asyncio: marks tests as asyncio tests",
     "mcp: marks tests as MCP-specific tests",
     "live: hits the real FMP API and spends quota; deselected by default, run with -m live",
+    "e2e: full client-method VCR sweep; deselected by default, record with scripts/e2e_endpoints.py",
 ]
 asyncio_mode = "strict"
 asyncio_default_fixture_loop_scope = "function"

--- a/scripts/e2e_endpoints.py
+++ b/scripts/e2e_endpoints.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Record or replay a full client-method sweep against the FMP API.
+
+This is a maintainer tool. It spends quota in ``record`` mode. Replay uses
+VCR cassettes under ``tests/e2e/vcr_cassettes/`` and never hits the network.
+
+Examples::
+
+    uv run python scripts/e2e_endpoints.py list
+    uv run python scripts/e2e_endpoints.py record --group company
+    uv run python scripts/e2e_endpoints.py record --method get_profile --refresh
+    uv run python scripts/e2e_endpoints.py replay
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+import os
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from dotenv import load_dotenv  # noqa: E402
+
+from fmp_data import ClientConfig, FMPDataClient  # noqa: E402
+from fmp_data.config import (  # noqa: E402
+    LoggingConfig,
+    LogHandlerConfig,
+    RateLimitConfig,
+)
+from tests.e2e.harness import (  # noqa: E402
+    CLIENT_GROUPS,
+    REPORT_PATH,
+    discover_cases,
+    format_report,
+    run_cases,
+    select_cases,
+    write_report,
+)
+
+
+def _load_env() -> None:
+    env_path = ROOT / ".env"
+    if env_path.is_file():
+        load_dotenv(env_path, override=False)
+    if not os.getenv("FMP_TEST_API_KEY") and os.getenv("FMP_API_KEY"):
+        os.environ["FMP_TEST_API_KEY"] = os.environ["FMP_API_KEY"]
+    if not os.getenv("FMP_API_KEY") and os.getenv("FMP_TEST_API_KEY"):
+        os.environ["FMP_API_KEY"] = os.environ["FMP_TEST_API_KEY"]
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Sweep every public sync FMPDataClient method under VCR."
+    )
+    parser.add_argument(
+        "command",
+        choices=("list", "record", "replay"),
+        help="list cases, record live traffic, or replay cassettes",
+    )
+    parser.add_argument(
+        "--group",
+        choices=CLIENT_GROUPS,
+        help="restrict to one client group",
+    )
+    parser.add_argument(
+        "--method",
+        help="restrict to one method name (can combine with --group)",
+    )
+    parser.add_argument(
+        "--refresh",
+        action="store_true",
+        help="with record: overwrite existing cassettes (VCR mode 'all')",
+    )
+    parser.add_argument(
+        "--skip-bulk",
+        action="store_true",
+        help="skip batch *_bulk CSV downloads",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="set validation_mode=strict so extra/missing fields fail",
+    )
+    parser.add_argument(
+        "--report",
+        type=Path,
+        default=REPORT_PATH,
+        help=f"JSON report path (default: {REPORT_PATH})",
+    )
+    parser.add_argument(
+        "--throttle",
+        type=float,
+        default=0.2,
+        help="seconds to wait between live calls (record only)",
+    )
+    return parser.parse_args(argv)
+
+
+def _make_client(*, strict: bool, replay: bool) -> FMPDataClient:
+    api_key = os.getenv("FMP_TEST_API_KEY") or os.getenv("FMP_API_KEY")
+    if not api_key:
+        if replay:
+            api_key = "DUMMY_API_KEY"  # pragma: allowlist secret
+        else:
+            raise SystemExit("FMP_TEST_API_KEY (or FMP_API_KEY) is required to record.")
+    if not replay and len(api_key.strip()) < 10:
+        raise SystemExit("FMP_TEST_API_KEY appears to be invalid.")
+
+    config = ClientConfig(
+        api_key=api_key,
+        base_url=os.getenv("FMP_TEST_BASE_URL", "https://financialmodelingprep.com"),
+        timeout=int(float(os.getenv("FMP_TEST_TIMEOUT", "30"))),
+        max_retries=2,
+        validation_mode="strict" if strict else "warn",
+        logging=LoggingConfig(
+            level="ERROR",
+            handlers={
+                "console": LogHandlerConfig(
+                    class_name="StreamHandler",
+                    level="ERROR",
+                    format="%(levelname)s %(name)s: %(message)s",
+                )
+            },
+        ),
+        rate_limit=RateLimitConfig(
+            daily_limit=5000, requests_per_second=5, requests_per_minute=250
+        ),
+    )
+    return FMPDataClient(config=config)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    _load_env()
+    cases = select_cases(
+        discover_cases(),
+        group=args.group,
+        method=args.method,
+        skip_bulk=args.skip_bulk,
+    )
+    if not cases:
+        print("No cases matched.", file=sys.stderr)
+        return 2
+
+    if args.command == "list":
+        for case in cases:
+            flags = []
+            if case.deprecated:
+                flags.append("deprecated")
+            if case.bulk:
+                flags.append("bulk")
+            suffix = f"  [{', '.join(flags)}]" if flags else ""
+            path = f"  {case.endpoint_path}" if case.endpoint_path else ""
+            print(f"{case.group}.{case.method}{path}{suffix}")
+        print(f"\n{len(cases)} case(s)", file=sys.stderr)
+        return 0
+
+    if args.command == "record":
+        record_mode = "all" if args.refresh else "new_episodes"
+        os.environ["FMP_VCR_RECORD"] = record_mode
+    else:
+        record_mode = "none"
+        os.environ["FMP_VCR_RECORD"] = "none"
+
+    client = _make_client(strict=args.strict, replay=args.command == "replay")
+    try:
+        rows = run_cases(
+            cases,
+            client=client,
+            record_mode=record_mode,
+            throttle=args.throttle,
+        )
+    finally:
+        client.close()
+
+    payload = [row.as_dict() for row in rows]
+    write_report(args.report, payload)
+    print(format_report(payload))
+    print(f"\nreport: {args.report}", file=sys.stderr)
+
+    failed = any(row.status in {"error", "empty"} for row in rows)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -1,0 +1,550 @@
+"""Local VCR-backed sweep of every public sync client method.
+
+This is a maintainer tool, not a default test. Discovery walks
+``FMPDataClient`` group properties; each public method is one case.
+See ``docs/superpowers/specs/2026-08-14-e2e-client-sweep-design.md``.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass, field
+from datetime import date
+import importlib
+import inspect
+import json
+import os
+from pathlib import Path
+import re
+import time
+from typing import Any
+
+from fmp_data.client import FMPDataClient
+from fmp_data.exceptions import RateLimitError
+from fmp_data.tool_binding import bindable_params
+
+CLIENT_GROUPS: tuple[str, ...] = (
+    "alternative",
+    "batch",
+    "company",
+    "economics",
+    "fundamental",
+    "index",
+    "institutional",
+    "intelligence",
+    "investment",
+    "market",
+    "sec",
+    "technical",
+    "transcripts",
+)
+
+ANCHORED_FROM = date(2024, 1, 1)
+ANCHORED_TO = date(2024, 1, 31)
+ANCHORED_AS_OF = date(2024, 9, 30)
+
+# Methods whose emptiness is about the entity, not a broken declaration.
+ALLOW_EMPTY: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("investment", "get_etf_holdings"),
+        ("investment", "get_etf_info"),
+        ("investment", "get_etf_sector_weightings"),
+        ("investment", "get_etf_country_weightings"),
+        ("investment", "get_mutual_fund_dates"),
+        ("investment", "get_fund_disclosure"),
+        ("investment", "search_fund_disclosure_holders"),
+        ("institutional", "get_form_13f"),
+        ("institutional", "get_form_13f_dates"),
+        ("institutional", "get_institutional_ownership_extract"),
+        ("institutional", "get_institutional_ownership_dates"),
+        ("institutional", "get_holder_performance_summary"),
+        ("institutional", "get_holder_industry_breakdown"),
+        ("intelligence", "get_senate_trades_by_name"),
+        ("intelligence", "get_house_trades_by_name"),
+        ("intelligence", "search_crowdfunding"),
+        ("intelligence", "get_crowdfunding_by_cik"),
+        ("intelligence", "search_equity_offering"),
+        ("intelligence", "get_equity_offering_by_cik"),
+        ("economics", "get_commitment_of_traders_report"),
+        ("economics", "get_commitment_of_traders_analysis"),
+        ("market", "get_historical_industry_performance"),
+        ("market", "get_historical_industry_pe"),
+        ("market", "search_symbol"),
+        ("institutional", "search_cik_by_name"),
+    }
+)
+
+CASSETTE_ROOT = Path(__file__).resolve().parent / "vcr_cassettes"
+REPORT_PATH = Path(__file__).resolve().parent / "reports" / "last-report.json"
+
+
+@dataclass(frozen=True)
+class SweepCase:
+    group: str
+    method: str
+    func: Callable[..., Any]
+    deprecated: bool
+    bulk: bool
+    endpoint_path: str | None = None
+
+
+@dataclass
+class CaseRow:
+    group: str
+    method: str
+    status: str
+    detail: str = ""
+    path: str | None = None
+    elapsed_ms: float = 0.0
+    kwargs: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "group": self.group,
+            "method": self.method,
+            "status": self.status,
+            "detail": self.detail,
+            "path": self.path,
+            "elapsed_ms": self.elapsed_ms,
+            "kwargs": _jsonable(self.kwargs),
+        }
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    return value
+
+
+def _client_class(group: str) -> type:
+    prop = getattr(FMPDataClient, group)
+    getter = prop.fget
+    if getter is None:  # pragma: no cover - properties always have fget
+        raise TypeError(f"{group} is not a client property")
+    annotation = inspect.signature(getter).return_annotation
+    if annotation is inspect.Signature.empty:
+        raise TypeError(f"{group} property has no return annotation")
+    if isinstance(annotation, str):
+        hints = inspect.get_annotations(getter, eval_str=True)
+        annotation = hints.get("return", annotation)
+    if not isinstance(annotation, type):
+        raise TypeError(f"{group} return annotation is not a class: {annotation!r}")
+    return annotation
+
+
+def _endpoint_path(group: str, method: str) -> str | None:
+    try:
+        module = importlib.import_module(f"fmp_data.{group}.mapping")
+    except ImportError:
+        return None
+    for attr, value in vars(module).items():
+        if attr.endswith("_ENDPOINT_MAP") and isinstance(value, dict):
+            endpoint = value.get(method)
+            if endpoint is not None:
+                version = getattr(getattr(endpoint, "version", None), "value", None)
+                path = getattr(endpoint, "path", None)
+                if path:
+                    return f"{version}/{path}" if version else str(path)
+    return None
+
+
+def discover_cases() -> list[SweepCase]:
+    """Every public sync method on every ``FMPDataClient`` group."""
+    cases: list[SweepCase] = []
+    for group in CLIENT_GROUPS:
+        client_cls = _client_class(group)
+        for name, func in inspect.getmembers(client_cls, predicate=inspect.isfunction):
+            if name.startswith("_"):
+                continue
+            cases.append(
+                SweepCase(
+                    group=group,
+                    method=name,
+                    func=func,
+                    deprecated=bool(getattr(func, "__fmp_deprecated__", False)),
+                    bulk=name.endswith("_bulk"),
+                    endpoint_path=_endpoint_path(group, name),
+                )
+            )
+    cases.sort(key=lambda case: (case.group, case.method))
+    return cases
+
+
+def select_cases(
+    cases: Sequence[SweepCase],
+    *,
+    group: str | None = None,
+    method: str | None = None,
+    skip_bulk: bool = False,
+) -> list[SweepCase]:
+    if group is not None and group not in CLIENT_GROUPS:
+        raise ValueError(f"unknown group: {group}")
+    selected = list(cases)
+    if group is not None:
+        selected = [case for case in selected if case.group == group]
+    if method is not None:
+        selected = [case for case in selected if case.method == method]
+    if skip_bulk:
+        selected = [case for case in selected if not case.bulk]
+    return selected
+
+
+def _inferred_symbol(group: str, method: str) -> str:
+    name = method.lower()
+    if "etf" in name:
+        return "SPY"
+    if "mutual_fund" in name or "fund_disclosure" in name:
+        return "VTSAX"
+    if "crypto" in name:
+        return "BTCUSD"
+    if "forex" in name:
+        return "EURUSD"
+    if "commodity" in name or "commodities" in name:
+        return "GCUSD"
+    if group == "alternative":
+        return "BTCUSD"
+    return "AAPL"
+
+
+def _inferred_name(method: str) -> str:
+    name = method.lower()
+    if "senate" in name or "house" in name:
+        return "Nancy Pelosi"
+    if "mutual_fund" in name:
+        return "Vanguard"
+    return "Apple"
+
+
+def _inferred_query(method: str) -> str:
+    name = method.lower()
+    if "cusip" in name:
+        return "037833100"
+    if "isin" in name:
+        return "US0378331005"
+    if "cik" in name:
+        return "0000320193"
+    return "Apple"
+
+
+# Methods whose contract is "at least one of these optionals".
+_ONE_OF_DEFAULTS: dict[tuple[str, str], dict[str, Any]] = {
+    ("sec", "search_industry_classification"): {"symbol": "AAPL"},
+}
+
+
+_FIXED_SAMPLES: dict[str, Any] = {
+    "symbols": ["AAPL", "MSFT"],
+    "cik": "0001067983",
+    "from_date": ANCHORED_FROM,
+    "start_date": ANCHORED_FROM,
+    "to_date": ANCHORED_TO,
+    "end_date": ANCHORED_TO,
+    "date": ANCHORED_AS_OF,
+    "holdings_date": ANCHORED_AS_OF,
+    "report_date": ANCHORED_AS_OF,
+    "target_date": ANCHORED_AS_OF,
+    "trade_date": ANCHORED_AS_OF,
+    "indicator_name": "GDP",
+    "company": "Apple",
+    "reporting_name": "Cook",
+    "form_type": "10-K",
+    "exchange": "NASDAQ",
+    "year": 2024,
+    "quarter": 3,
+    "period": "FY",
+    "period_length": 10,
+    "timeframe": "1day",
+    "interval": "5min",
+    "limit": 5,
+    "page": 0,
+    "sector": "Technology",
+    "industry": "Software",
+    "sic_code": "3571",
+    "sicCode": "3571",
+    "part": 0,
+    "part_number": 0,
+}
+
+
+def sample_for(param_name: str, group: str, method: str) -> Any | None:
+    """A representative value for ``param_name``, or ``None`` if unknown."""
+    if param_name == "symbol":
+        return _inferred_symbol(group, method)
+    if param_name == "name":
+        return _inferred_name(method)
+    if param_name == "query":
+        return _inferred_query(method)
+    return _FIXED_SAMPLES.get(param_name)
+
+
+# Optional params we still fill: dates (VCR stability) and limit (smaller bodies).
+_ALWAYS_FILL = frozenset(
+    {
+        "from_date",
+        "to_date",
+        "start_date",
+        "end_date",
+        "date",
+        "holdings_date",
+        "report_date",
+        "target_date",
+        "trade_date",
+        "limit",
+    }
+)
+
+# Pin path/query values that already exist in recorded cassettes. Do not
+# put ``interval`` in ``_ALWAYS_FILL``: technical methods treat it as an
+# override of ``timeframe`` and would stop matching their 1day cassettes.
+_METHOD_OVERRIDES: dict[tuple[str, str], dict[str, Any]] = {
+    ("company", "get_intraday_prices"): {"interval": "5min"},
+}
+
+# Public methods that never perform HTTP. Calling them under VCR in replay
+# mode fails with "missing cassette".
+NO_HTTP_METHODS: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("company", "get_company_logo_url"),
+    }
+)
+
+
+def build_kwargs(case: SweepCase) -> dict[str, Any]:
+    """Keyword arguments for ``case``.
+
+    Required parameters are always filled. Optional date parameters are
+    filled with anchored values so VCR query strings stay stable. Other
+    optional parameters keep the method default -- overriding ``period``
+    with a global sample is how we used to send ``annual`` to endpoints
+    that only accept ``FY``.
+    """
+    kwargs: dict[str, Any] = {}
+    for name, param in bindable_params(case.func).items():
+        required = param.default is inspect.Parameter.empty
+        if not required and name not in _ALWAYS_FILL:
+            continue
+        value = sample_for(name, case.group, case.method)
+        if value is not None:
+            kwargs[name] = value
+    kwargs.update(_ONE_OF_DEFAULTS.get((case.group, case.method), {}))
+    kwargs.update(_METHOD_OVERRIDES.get((case.group, case.method), {}))
+    return kwargs
+
+
+def missing_required(case: SweepCase, kwargs: dict[str, Any]) -> list[str]:
+    missing: list[str] = []
+    for name, param in bindable_params(case.func).items():
+        if param.default is inspect.Parameter.empty and name not in kwargs:
+            missing.append(name)
+    return missing
+
+
+def _payload_size(value: Any) -> int:
+    if value is None:
+        return 0
+    if isinstance(value, (list, tuple, set, bytes, str)):
+        return len(value)
+    historical = getattr(value, "historical", None)
+    if isinstance(historical, list):
+        return len(historical)
+    return 1
+
+
+def redact_text(text: str) -> str:
+    """Strip live API keys from exception text before it hits a report."""
+    scrubbed = text
+    for key in (
+        os.getenv("FMP_TEST_API_KEY", "").strip(),
+        os.getenv("FMP_API_KEY", "").strip(),
+    ):
+        if key:
+            scrubbed = scrubbed.replace(
+                key, "DUMMY_API_KEY"
+            )  # pragma: allowlist secret
+    return re.sub(
+        r"(?i)(apikey=)([^&\s\"']+)",
+        r"\1DUMMY_API_KEY",  # pragma: allowlist secret
+        scrubbed,
+    )
+
+
+def classify_result(value: Any, *, allow_empty: bool) -> str:
+    if isinstance(value, BaseException):
+        return "error"
+    if _payload_size(value) == 0:
+        return "ok" if allow_empty else "empty"
+    return "ok"
+
+
+def format_report(rows: Sequence[dict[str, Any]]) -> str:
+    counts = Counter(str(row.get("status", "unknown")) for row in rows)
+    header = (
+        f"ok={counts.get('ok', 0)} empty={counts.get('empty', 0)} "
+        f"error={counts.get('error', 0)} skip={counts.get('skip', 0)} "
+        f"total={len(rows)}"
+    )
+    lines = [header]
+    for row in rows:
+        status = str(row.get("status", "unknown"))
+        if status == "ok":
+            continue
+        group = row.get("group", "?")
+        method = row.get("method", "?")
+        detail = row.get("detail") or ""
+        suffix = f"  {detail}" if detail else ""
+        lines.append(f"{group}.{method}  {status}{suffix}")
+    return "\n".join(lines)
+
+
+def write_report(path: Path, rows: Sequence[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"count": len(rows), "rows": list(rows)}
+    path.write_text(json.dumps(payload, indent=2, default=str) + "\n", encoding="utf-8")
+
+
+def cassette_relpath(case: SweepCase) -> str:
+    return f"{case.group}/{case.method}.yaml"
+
+
+def _make_vcr(record_mode: str) -> Any:
+    import vcr
+
+    from tests.integration.conftest import (
+        SafeFilesystemPersister,
+        drop_unauthorized_response,
+        scrub_api_key,
+        scrub_response_secrets,
+    )
+
+    CASSETTE_ROOT.mkdir(parents=True, exist_ok=True)
+    config = vcr.VCR(
+        serializer="yaml",
+        cassette_library_dir=str(CASSETTE_ROOT),
+        record_mode=record_mode,
+        match_on=["method", "host", "path", "query"],
+        filter_headers=["authorization", "x-api-key", "apikey"],
+        before_record_request=scrub_api_key,
+        before_record_response=scrub_response_secrets,
+        decode_compressed_response=True,
+        filter_query_parameters=["apikey"],
+        path_transformer=lambda path: str(CASSETTE_ROOT / path),
+    )
+    config.register_persister(SafeFilesystemPersister)
+    config.before_playback_response = drop_unauthorized_response
+    return config
+
+
+def _call_with_retries(
+    func: Callable[..., Any], kwargs: dict[str, Any], *, attempts: int = 5
+) -> Any:
+    wait = 1.0
+    for attempt in range(attempts):
+        try:
+            return func(**kwargs)
+        except RateLimitError as exc:
+            if attempt == attempts - 1:
+                raise
+            delay = wait
+            if exc.retry_after:
+                delay = max(delay, float(exc.retry_after))
+            time.sleep(delay)
+            wait = min(wait * 2, 32.0)
+    raise RuntimeError("unreachable")  # pragma: no cover
+
+
+def run_cases(
+    cases: Iterable[SweepCase],
+    *,
+    client: FMPDataClient,
+    record_mode: str,
+    throttle: float = 0.2,
+) -> list[CaseRow]:
+    """Execute ``cases`` under VCR. ``record_mode='none'`` never hits the API."""
+    vcr_instance = _make_vcr(record_mode)
+    rows: list[CaseRow] = []
+    for case in cases:
+        kwargs = build_kwargs(case)
+        missing = missing_required(case, kwargs)
+        if case.deprecated:
+            rows.append(
+                CaseRow(
+                    group=case.group,
+                    method=case.method,
+                    status="skip",
+                    detail="deprecated",
+                    path=case.endpoint_path,
+                    kwargs=kwargs,
+                )
+            )
+            continue
+        if missing:
+            rows.append(
+                CaseRow(
+                    group=case.group,
+                    method=case.method,
+                    status="error",
+                    detail=f"no sample for required params: {', '.join(missing)}",
+                    path=case.endpoint_path,
+                    kwargs=kwargs,
+                )
+            )
+            continue
+
+        cassette = cassette_relpath(case)
+        method = getattr(getattr(client, case.group), case.method)
+        local = (case.group, case.method) in NO_HTTP_METHODS
+        if (
+            not local
+            and record_mode == "none"
+            and not (CASSETTE_ROOT / cassette).is_file()
+        ):
+            rows.append(
+                CaseRow(
+                    group=case.group,
+                    method=case.method,
+                    status="error",
+                    detail=f"missing cassette {cassette}",
+                    path=case.endpoint_path,
+                    kwargs=kwargs,
+                )
+            )
+            continue
+
+        started = time.perf_counter()
+        try:
+            if local:
+                value = method(**kwargs)
+            else:
+                with vcr_instance.use_cassette(cassette):
+                    value = _call_with_retries(method, kwargs)
+        except Exception as exc:
+            value = exc
+        elapsed_ms = (time.perf_counter() - started) * 1000
+        allow_empty = (case.group, case.method) in ALLOW_EMPTY
+        status = classify_result(value, allow_empty=allow_empty)
+        detail = ""
+        if isinstance(value, BaseException):
+            detail = redact_text(f"{type(value).__name__}: {value}")
+        elif status == "empty":
+            detail = "empty payload"
+        else:
+            detail = f"n={_payload_size(value)}"
+        rows.append(
+            CaseRow(
+                group=case.group,
+                method=case.method,
+                status=status,
+                detail=detail,
+                path=case.endpoint_path,
+                elapsed_ms=round(elapsed_ms, 1),
+                kwargs=kwargs,
+            )
+        )
+        if record_mode != "none":
+            time.sleep(throttle)
+    return rows

--- a/tests/e2e/test_client_sweep.py
+++ b/tests/e2e/test_client_sweep.py
@@ -1,0 +1,55 @@
+"""Optional pytest wrapper around the VCR replay of the client-method sweep.
+
+Deselected by default (``-m not e2e``). Record first::
+
+    uv run python scripts/e2e_endpoints.py record
+    uv run pytest tests/e2e/test_client_sweep.py -m e2e
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tests.e2e.harness import (
+    CASSETTE_ROOT,
+    discover_cases,
+    format_report,
+    run_cases,
+    select_cases,
+)
+
+pytestmark = pytest.mark.e2e
+
+
+def test_client_sweep_replay() -> None:
+    """Replay recorded client-method cassettes; never hits the live API."""
+    if not any(CASSETTE_ROOT.rglob("*.yaml")):
+        pytest.skip(
+            "No e2e cassettes. Record with: "
+            "uv run python scripts/e2e_endpoints.py record"
+        )
+
+    os.environ.setdefault("FMP_VCR_RECORD", "none")
+    from fmp_data import ClientConfig, FMPDataClient
+
+    api_key = (
+        os.getenv("FMP_TEST_API_KEY")
+        or os.getenv("FMP_API_KEY")
+        or "DUMMY_API_KEY"  # pragma: allowlist secret
+    )
+    client = FMPDataClient(config=ClientConfig(api_key=api_key, timeout=10))
+    try:
+        rows = run_cases(
+            select_cases(discover_cases()),
+            client=client,
+            record_mode="none",
+            throttle=0.0,
+        )
+    finally:
+        client.close()
+
+    payload = [row.as_dict() for row in rows]
+    bad = [row for row in rows if row.status in {"error", "empty"}]
+    assert not bad, format_report(payload)

--- a/tests/e2e/test_live_signatures.py
+++ b/tests/e2e/test_live_signatures.py
@@ -13,7 +13,8 @@ maintainer running the project's own test command with a populated ``.env``
 fired this whole suite: roughly 700 live requests -- a 275-endpoint 404 sweep
 plus a paired sentinel call per optional parameter -- against a default quota of
 250 a day. The marker is what makes "opt-in" true for ``make test`` as well as
-for CI.
+for CI. The same ``addopts`` line also deselects the VCR client-method
+sweep (``e2e``).
 
 Why this exists: a one-off probe of all 275 declarations found 28 paths that
 return 404 for every request, three endpoints whose ``from``/``to`` are
@@ -67,7 +68,7 @@ from fmp_data.models import Endpoint, ParamLocation
 API_KEY = os.getenv("FMP_TEST_API_KEY") or os.getenv("FMP_API_KEY")
 
 pytestmark = [
-    # Deselected by `-m "not live"` in addopts. This is the gate that holds
+    # Deselected by `-m "not live and not e2e"` in addopts. This is the gate that holds
     # for `make test`, which supplies a key from .env whether or not you meant
     # to spend one; the skipif below only helps when no key exists at all.
     pytest.mark.live,

--- a/tests/unit/test_e2e_sweep.py
+++ b/tests/unit/test_e2e_sweep.py
@@ -1,0 +1,221 @@
+"""Unit tests for the local VCR-backed client-method e2e harness."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from fmp_data.exceptions import FMPError
+from tests.e2e.harness import (
+    NO_HTTP_METHODS,
+    build_kwargs,
+    classify_result,
+    discover_cases,
+    format_report,
+    redact_text,
+    select_cases,
+    write_report,
+)
+
+
+def test_discover_cases_includes_public_client_methods() -> None:
+    cases = discover_cases()
+    keys = {(case.group, case.method) for case in cases}
+
+    assert ("company", "get_profile") in keys
+    assert ("market", "get_gainers") in keys
+    assert ("batch", "get_quotes") in keys
+    assert ("alternative", "get_crypto_quote") in keys
+    assert len(cases) > 200
+
+
+def test_discover_cases_skips_private_helpers() -> None:
+    cases = discover_cases()
+    names = {case.method for case in cases}
+    assert not any(name.startswith("_") for name in names)
+
+
+def test_discover_cases_marks_deprecated_methods() -> None:
+    cases = discover_cases()
+    deprecated = {(case.group, case.method) for case in cases if case.deprecated}
+    assert ("company", "get_core_information") in deprecated
+
+
+def test_kwargs_for_get_profile_use_aapl() -> None:
+    case = next(
+        case
+        for case in discover_cases()
+        if case.group == "company" and case.method == "get_profile"
+    )
+    assert build_kwargs(case) == {"symbol": "AAPL"}
+
+
+def test_kwargs_for_crypto_quote_use_btcusd() -> None:
+    case = next(
+        case
+        for case in discover_cases()
+        if case.group == "alternative" and case.method == "get_crypto_quote"
+    )
+    assert build_kwargs(case)["symbol"] == "BTCUSD"
+
+
+def test_kwargs_for_etf_holdings_use_spy() -> None:
+    case = next(
+        case
+        for case in discover_cases()
+        if case.group == "investment" and case.method == "get_etf_holdings"
+    )
+    kwargs = build_kwargs(case)
+    assert kwargs["symbol"] == "SPY"
+
+
+def test_kwargs_for_search_by_cik_use_a_cik() -> None:
+    case = next(
+        case
+        for case in discover_cases()
+        if case.group == "market" and case.method == "search_by_cik"
+    )
+    assert build_kwargs(case)["query"] == "0000320193"
+
+
+def test_kwargs_for_search_by_cusip_use_a_cusip() -> None:
+    case = next(
+        case
+        for case in discover_cases()
+        if case.group == "market" and case.method == "search_by_cusip"
+    )
+    assert build_kwargs(case)["query"] == "037833100"
+
+
+def test_kwargs_for_insider_trading_by_name_fill_reporting_name() -> None:
+    case = next(
+        case
+        for case in discover_cases()
+        if case.group == "institutional"
+        and case.method == "get_insider_trading_by_name"
+    )
+    assert build_kwargs(case)["reporting_name"] == "Cook"
+
+
+def test_kwargs_for_industry_classification_supply_a_one_of_param() -> None:
+    case = next(
+        case
+        for case in discover_cases()
+        if case.group == "sec" and case.method == "search_industry_classification"
+    )
+    kwargs = build_kwargs(case)
+    assert kwargs.get("symbol") == "AAPL"
+    case = next(
+        case
+        for case in discover_cases()
+        if case.group == "batch" and case.method == "get_quotes"
+    )
+    assert build_kwargs(case)["symbols"] == ["AAPL", "MSFT"]
+
+
+def test_kwargs_do_not_override_method_period_default() -> None:
+    case = next(
+        case
+        for case in discover_cases()
+        if case.group == "company" and case.method == "get_financial_reports_json"
+    )
+    kwargs = build_kwargs(case)
+    assert "period" not in kwargs
+    assert kwargs["year"] == 2024
+
+
+def test_kwargs_pin_intraday_interval_for_vcr_paths() -> None:
+    case = next(
+        case
+        for case in discover_cases()
+        if case.group == "company" and case.method == "get_intraday_prices"
+    )
+    assert build_kwargs(case)["interval"] == "5min"
+
+
+def test_logo_url_is_local_and_needs_no_cassette() -> None:
+    assert ("company", "get_company_logo_url") in NO_HTTP_METHODS
+
+
+def test_kwargs_fill_optional_dates_with_anchored_values() -> None:
+    case = next(
+        case
+        for case in discover_cases()
+        if case.group == "sec" and case.method == "search_by_symbol"
+    )
+    kwargs = build_kwargs(case)
+    assert kwargs["from_date"] == date(2024, 1, 1)
+    assert kwargs["to_date"] == date(2024, 1, 31)
+
+
+def test_select_cases_filters_by_group_and_method() -> None:
+    cases = discover_cases()
+    selected = select_cases(cases, group="transcripts", method="get_transcript")
+    assert len(selected) == 1
+    assert selected[0].group == "transcripts"
+    assert selected[0].method == "get_transcript"
+
+
+def test_select_cases_can_drop_bulk() -> None:
+    cases = discover_cases()
+    selected = select_cases(cases, skip_bulk=True)
+    assert all(not case.bulk for case in selected)
+    assert any(case.bulk for case in cases)
+
+
+def test_classify_non_empty_list_is_ok() -> None:
+    result = classify_result([object()], allow_empty=False)
+    assert result == "ok"
+
+
+def test_classify_empty_list_is_empty() -> None:
+    result = classify_result([], allow_empty=False)
+    assert result == "empty"
+
+
+def test_classify_empty_list_is_ok_when_allowed() -> None:
+    result = classify_result([], allow_empty=True)
+    assert result == "ok"
+
+
+def test_classify_exception_is_error() -> None:
+    result = classify_result(FMPError("nope"), allow_empty=False)
+    assert result == "error"
+
+
+def test_format_report_counts_statuses() -> None:
+    text = format_report(
+        [
+            {"group": "company", "method": "get_profile", "status": "ok"},
+            {"group": "company", "method": "get_peers", "status": "empty"},
+            {"group": "market", "method": "get_gainers", "status": "error"},
+        ]
+    )
+    assert "ok=1" in text
+    assert "empty=1" in text
+    assert "error=1" in text
+    assert "company.get_peers" in text
+
+
+def test_write_report_round_trips_json(tmp_path: Path) -> None:
+    path = tmp_path / "report.json"
+    rows = [{"group": "company", "method": "get_profile", "status": "ok"}]
+    write_report(path, rows)
+    assert path.is_file()
+    assert "get_profile" in path.read_text(encoding="utf-8")
+
+
+def test_redact_text_masks_apikey_query_values() -> None:
+    raw = (
+        "No match for the request "
+        "(<Request (GET) https://example.test/x?apikey=SUPERSECRETKEY123>)"
+    )
+    assert "SUPERSECRETKEY123" not in redact_text(raw)
+    assert "apikey=DUMMY_API_KEY" in redact_text(raw)  # pragma: allowlist secret
+
+
+def test_unknown_group_is_rejected() -> None:
+    with pytest.raises(ValueError, match="unknown group"):
+        select_cases(discover_cases(), group="not-a-group")

--- a/tests/unit/test_institutional.py
+++ b/tests/unit/test_institutional.py
@@ -9,6 +9,7 @@ from fmp_data.institutional.models import (
     CIKMapping,
     FailToDeliver,
     Form13F,
+    HolderIndustryBreakdown,
     HolderPerformanceSummary,
     InsiderStatistic,
     InsiderTrade,
@@ -1048,3 +1049,17 @@ class TestHolderPerformanceSummaryInertQuarterFilter:
             "year": 2023,
             "quarter": 3,
         }
+
+
+def test_holder_industry_breakdown_allows_null_title() -> None:
+    """FMP sends industryTitle: null on some holder rows (live 2026-08-14)."""
+    item = HolderIndustryBreakdown.model_validate(
+        {
+            "date": "2024-09-30",
+            "cik": "0001067983",
+            "investorName": "BERKSHIRE HATHAWAY INC",
+            "industryTitle": None,
+            "weight": 0.1,
+        }
+    )
+    assert item.industry_title is None

--- a/tests/unit/test_intelligence.py
+++ b/tests/unit/test_intelligence.py
@@ -1581,3 +1581,19 @@ class TestMarketIntelligenceClientAnalyst:
         assert kwargs["page"] == 0
         assert isinstance(result, list)
         assert result[0].symbol == "MSFT"
+
+
+def test_crypto_news_article_allows_null_symbol() -> None:
+    """General crypto news often has symbol: null (live 2026-08-14)."""
+    item = CryptoNewsArticle.model_validate(
+        {
+            "publishedDate": "2024-01-15T10:00:00",
+            "title": "Crypto Update",
+            "image": "https://example.com/image.jpg",
+            "site": "Crypto News",
+            "text": "News content",
+            "url": "https://example.com/crypto",
+            "symbol": None,
+        }
+    )
+    assert item.symbol is None


### PR DESCRIPTION
## Summary

Adds a **local** end-to-end harness that calls every public sync `FMPDataClient` method through the real package, records VCR cassettes, and reports per-method pass/empty/error. Default `make test` does not run it (new `e2e` marker, deselected next to `live`).

The first live record found two real schema bugs, which this PR also fixes:

- `HolderIndustryBreakdown.industry_title` now allows `null` (13F rows send it)
- `CryptoNewsArticle.symbol` now allows `null` (general crypto news often has no pair)

## How to run

```bash
# list every case
make e2e-list
# or: uv run python scripts/e2e_endpoints.py list

# record (spends quota). Filter with GROUP= / METHOD= / SKIP_BULK=1
make e2e-record GROUP=company
make e2e-record SKIP_BULK=1

# replay without hitting the API
make e2e-replay
```

Cassettes go to `tests/e2e/vcr_cassettes/` (gitignored). JSON report: `tests/e2e/reports/last-report.json`.

## First live pass (skip-bulk)

| Status | Count |
|---|---|
| ok | 239 |
| skip (deprecated) | 26 |
| empty | 0 |
| error | 0 |
| **total** | **265** |

Bulk CSV (`batch.*_bulk`) is included unless `--skip-bulk`. Replay of the recorded skip-bulk set is green.

## Test plan

- [x] Unit tests for discovery, samples, classification, redaction (`tests/unit/test_e2e_sweep.py`)
- [x] Model tests for the two null-field fixes
- [x] Live record of all non-bulk groups
- [x] Full cassette replay: 239 ok / 26 skip / 0 fail
- [ ] Reviewer: optional `make e2e-record GROUP=company` if you want to refresh cassettes locally