### PR TITLE
fix(ci): do not SIGPIPE the sdist version-assert after a good build

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -166,8 +166,11 @@ jobs:
             exit 1
           fi
           SDIST="${sdists[0]}"
-          META_VERSION=$(tar -xOf "$SDIST" --wildcards '*/PKG-INFO' 2>/dev/null \
-            | awk -F': ' '/^Version:/{print $2; exit}')
+          # Read PKG-INFO in full first. `tar | awk ... exit` under pipefail
+          # dies with tar's SIGPIPE (exit 2) after awk closes the pipe — the
+          # sdist is fine, the job is not.
+          PKG_INFO=$(tar -xOf "$SDIST" --wildcards '*/PKG-INFO')
+          META_VERSION=$(awk -F': ' '/^Version:/{print $2; exit}' <<<"$PKG_INFO")
           if [ -z "${META_VERSION:-}" ]; then
             echo "::error::Could not read Version: from sdist PKG-INFO"
             exit 1

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -140,8 +140,11 @@ jobs:
             exit 1
           fi
           SDIST="${sdists[0]}"
-          META_VERSION=$(tar -xOf "$SDIST" --wildcards '*/PKG-INFO' 2>/dev/null \
-            | awk -F': ' '/^Version:/{print $2; exit}')
+          # Read PKG-INFO in full first. `tar | awk ... exit` under pipefail
+          # dies with tar's SIGPIPE (exit 2) after awk closes the pipe — the
+          # sdist is fine, the job is not.
+          PKG_INFO=$(tar -xOf "$SDIST" --wildcards '*/PKG-INFO')
+          META_VERSION=$(awk -F': ' '/^Version:/{print $2; exit}' <<<"$PKG_INFO")
           if [ -z "${META_VERSION:-}" ]; then
             echo "::error::Could not read Version: from sdist PKG-INFO"
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,8 +202,11 @@ jobs:
             exit 1
           fi
           SDIST="${sdists[0]}"
-          META_VERSION=$(tar -xOf "$SDIST" --wildcards '*/PKG-INFO' 2>/dev/null \
-            | awk -F': ' '/^Version:/{print $2; exit}')
+          # Read PKG-INFO in full first. `tar | awk ... exit` under pipefail
+          # dies with tar's SIGPIPE (exit 2) after awk closes the pipe — the
+          # sdist is fine, the job is not.
+          PKG_INFO=$(tar -xOf "$SDIST" --wildcards '*/PKG-INFO')
+          META_VERSION=$(awk -F': ' '/^Version:/{print $2; exit}' <<<"$PKG_INFO")
           if [ -z "${META_VERSION:-}" ]; then
             echo "::error::Could not read Version: from sdist PKG-INFO"
             exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,13 @@ None. No FMP path we ship was newly retired by this changelog window.
 
 ### Fixed
 
+- **TestPyPI / Dev-Release / Release sdist version-assert no longer
+  SIGPIPEs.** `set -euo pipefail` plus `tar -xOf … | awk … exit` made
+  GNU tar exit 2 after a successful build (awk closed the pipe on the
+  first `Version:` line). The sdist was fine; the job still went red,
+  so the 2.7.0 release PR never published a TestPyPI comment. PKG-INFO
+  is now read in full before the version line is parsed.
+
 - **`HolderIndustryBreakdown.industry_title` accepts `null`.** A live
   13F industry-breakdown row sends `industryTitle: null`; the field was
   required `str` and the whole call raised `ValidationError`.

--- a/tests/unit/test_publish_pins.py
+++ b/tests/unit/test_publish_pins.py
@@ -26,6 +26,26 @@ def test_publish_installs_without_require_hashes() -> None:
     assert offenders == []
 
 
+_SDIST_ASSERT_WORKFLOWS = (
+    "release.yml",
+    "publish-testpypi.yml",
+    "dev-release.yml",
+)
+
+# The 2.7.0 cut failed here: `tar | awk ... exit` under pipefail is
+# SIGPIPE (GNU tar exit 2) after a successful build.
+_PIPE_AND_EARLY_AWK = "| awk -F': ' '/^Version:/{print $2; exit}'"
+
+
+def test_sdist_version_assert_does_not_sigpipe_tar() -> None:
+    """PKG-INFO must be fully extracted before the Version: line is parsed."""
+    for name in _SDIST_ASSERT_WORKFLOWS:
+        text = (WORKFLOWS / name).read_text(encoding="utf-8")
+        assert "tar -xOf" in text, name
+        assert _PIPE_AND_EARLY_AWK not in text, name
+        assert "PKG_INFO=$(tar -xOf \"$SDIST\" --wildcards '*/PKG-INFO')" in text, name
+
+
 def test_publish_builds_use_no_isolation() -> None:
     offenders: list[str] = []
     for path in sorted(WORKFLOWS.glob("*.yml")):


### PR DESCRIPTION
## Summary

Unblocks TestPyPI validation on release PR #304.

`set -euo pipefail` plus `tar -xOf … | awk … exit` makes GNU tar exit 2 after a **successful** sdist build (awk closes the pipe on the first `Version:` line). Observed on #304: wheel and sdist written, job red, no TestPyPI comment. Same snippet lives in `publish-testpypi.yml`, `dev-release.yml`, and `release.yml`.

PKG-INFO is now read in full before the version line is parsed. A unit test pins the three copies so the pipe form cannot come back.

## Test plan

- [x] `pytest tests/unit/test_publish_pins.py`
- [ ] Test-Matrix on this PR
- [ ] After merge, #304 TestPyPI publishes and comments version + SHA