### PR TITLE
feat(schema): re-export TechnicalInterval from the public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ This cut also aligns the client with the 2026 FMP `/stable` surface
 (diluted P/E, screener pagination, Senate/House `senateID`, rating-bulk
 scores, delisted companies), finishes the `Endpoint[T]` / `_unwrap_list`
 typing migration, types period / interval / timeframe as closed
-vocabularies (`Period`, `Interval`, `Timeframe`), and adds a local
-VCR-backed client-method sweep.
+vocabularies (`Period`, `Interval`, `TechnicalInterval`, `Timeframe`),
+and adds a local VCR-backed client-method sweep.
 
 **Read before upgrading.** One public-type break, narrow:
 
@@ -179,15 +179,18 @@ None. No FMP path we ship was newly retired by this changelog window.
 ### Added
 
 - **Closed request vocabularies for period, interval, and timeframe
-  (#306, #308).** Client methods now take `Period` / `PeriodFiscal` /
-  `PeriodAnnualQuarter`, `Interval`, and `Timeframe` (`Literal` aliases
-  in `fmp_data.schema`) instead of a naked `str`. Three period types on
-  purpose: financial reports and batch bulk accept only `FY`/`Q1`–`Q4`.
-  Endpoint `valid_values` are derived from the same aliases. Plain
-  strings still work at runtime. Re-exported from `fmp_data` (`__all__`):
-  `from fmp_data import Period, PeriodFiscal, PeriodAnnualQuarter,
-  Interval, Timeframe`. The e2e harness samples required closed params
-  from the method annotation, not a global `"annual"` table.
+  (#306, #308, #311).** Client methods now take `Period` / `PeriodFiscal` /
+  `PeriodAnnualQuarter`, `Interval`, `TechnicalInterval`, and `Timeframe`
+  (`Literal` aliases in `fmp_data.schema`) instead of a naked `str`. Three
+  period types on purpose: financial reports and batch bulk accept only
+  `FY`/`Q1`–`Q4`. Endpoint `valid_values` are derived from the same
+  aliases. Plain strings still work at runtime. Re-exported from
+  `fmp_data` (`__all__`): `from fmp_data import Period, PeriodFiscal,
+  PeriodAnnualQuarter, Interval, TechnicalInterval, Timeframe`.
+  `TechnicalClient.interval=` takes `TechnicalInterval` (`Interval` plus
+  `"daily"` / `"hourly"`), not `Timeframe` (`1day`). The e2e harness
+  samples required closed params from the method annotation, not a
+  global `"annual"` table.
 
 - **Local VCR-backed client-method e2e sweep.** Maintainer script
   `scripts/e2e_endpoints.py` (`make e2e-record` / `make e2e-replay`) calls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,18 +179,22 @@ None. No FMP path we ship was newly retired by this changelog window.
 ### Added
 
 - **Closed request vocabularies for period, interval, and timeframe
-  (#306, #308, #311).** Client methods now take `Period` / `PeriodFiscal` /
-  `PeriodAnnualQuarter`, `Interval`, `TechnicalInterval`, and `Timeframe`
-  (`Literal` aliases in `fmp_data.schema`) instead of a naked `str`. Three
-  period types on purpose: financial reports and batch bulk accept only
-  `FY`/`Q1`–`Q4`. Endpoint `valid_values` are derived from the same
-  aliases. Plain strings still work at runtime. Re-exported from
-  `fmp_data` (`__all__`): `from fmp_data import Period, PeriodFiscal,
-  PeriodAnnualQuarter, Interval, TechnicalInterval, Timeframe`.
-  `TechnicalClient.interval=` takes `TechnicalInterval` (`Interval` plus
-  `"daily"` / `"hourly"`), not `Timeframe` (`1day`). The e2e harness
-  samples required closed params from the method annotation, not a
-  global `"annual"` table.
+  (#306, #308).** Client methods now take `Period` / `PeriodFiscal` /
+  `PeriodAnnualQuarter`, `Interval`, and `Timeframe` (`Literal` aliases
+  in `fmp_data.schema`) instead of a naked `str`. Three period types on
+  purpose: financial reports and batch bulk accept only `FY`/`Q1`–`Q4`.
+  Endpoint `valid_values` are derived from the same aliases. Plain
+  strings still work at runtime. Re-exported from `fmp_data` (`__all__`):
+  `from fmp_data import Period, PeriodFiscal, PeriodAnnualQuarter,
+  Interval, Timeframe`. The e2e harness samples required closed params
+  from the method annotation, not a global `"annual"` table.
+
+- **Public re-export of `TechnicalInterval` (#311).** Annotate
+  `TechnicalClient.interval=` against
+  `from fmp_data import TechnicalInterval`. It is `Interval` plus
+  `"daily"` / `"hourly"`, not `Timeframe` (`1day`). Client-only leftover
+  aliases mapped by `_normalize_timeframe`; endpoint `valid_values` stay
+  on `Timeframe` / `Interval`.
 
 - **Local VCR-backed client-method e2e sweep.** Maintainer script
   `scripts/e2e_endpoints.py` (`make e2e-record` / `make e2e-replay`) calls

--- a/LLM.md
+++ b/LLM.md
@@ -74,13 +74,22 @@ Period, interval, and timeframe parameters are typed `Literal` aliases.
 Import them from the package root when annotating:
 
 ```python
-from fmp_data import Interval, Period, PeriodAnnualQuarter, PeriodFiscal, Timeframe
+from fmp_data import (
+    Interval,
+    Period,
+    PeriodAnnualQuarter,
+    PeriodFiscal,
+    TechnicalInterval,
+    Timeframe,
+)
 ```
 
 Keep the three period types distinct. Most statement endpoints take `Period`
 (`annual` / `quarter` / `FY` / `Q1`–`Q4`). Financial reports and batch bulk
 take only `PeriodFiscal`. Some company series take only `PeriodAnnualQuarter`.
-`Timeframe` is `Interval` plus `"1day"`. Plain strings still work at runtime.
+`Timeframe` is `Interval` plus `"1day"`. `TechnicalClient.interval=` takes
+`TechnicalInterval` (`daily` / `hourly`), not `Timeframe`. Plain strings
+still work at runtime.
 
 ## Responses and data handling
 Endpoints return Pydantic models (or lists of models). Use attributes directly

--- a/LLM.md
+++ b/LLM.md
@@ -88,8 +88,8 @@ Keep the three period types distinct. Most statement endpoints take `Period`
 (`annual` / `quarter` / `FY` / `Q1`–`Q4`). Financial reports and batch bulk
 take only `PeriodFiscal`. Some company series take only `PeriodAnnualQuarter`.
 `Timeframe` is `Interval` plus `"1day"`. `TechnicalClient.interval=` takes
-`TechnicalInterval` (`daily` / `hourly`), not `Timeframe`. Plain strings
-still work at runtime.
+`TechnicalInterval` (`Interval` plus `"daily"` / `"hourly"`), not
+`Timeframe`. Plain strings still work at runtime.
 
 ## Responses and data handling
 Endpoints return Pydantic models (or lists of models). Use attributes directly

--- a/README.md
+++ b/README.md
@@ -504,25 +504,19 @@ with FMPDataClient.from_env() as client:
 
 ### 4. Technical Indicators
 ```python
-from datetime import date
-
 from fmp_data import FMPDataClient, TechnicalInterval, Timeframe
 
 with FMPDataClient.from_env() as client:
     # Simple Moving Average
     timeframe: Timeframe = "1day"
+    sma = client.technical.get_sma("AAPL", period_length=20, timeframe=timeframe)
+
+    # leftover interval aliases map onto Timeframe (daily→1day)
     interval: TechnicalInterval = "daily"
-    sma = client.technical.get_sma(
-        "AAPL", period_length=20, timeframe=timeframe, interval=interval
-    )
+    sma_daily = client.technical.get_sma("AAPL", period_length=20, interval=interval)
 
     # RSI (Relative Strength Index)
     rsi = client.technical.get_rsi("AAPL", period_length=14, timeframe="1day")
-
-    # MACD
-    macd = client.technical.get_macd(
-        "AAPL", fast_period=12, slow_period=26, signal_period=9
-    )
 ```
 
 ### 5. Alternative Data

--- a/README.md
+++ b/README.md
@@ -506,12 +506,15 @@ with FMPDataClient.from_env() as client:
 ```python
 from datetime import date
 
-from fmp_data import FMPDataClient, Timeframe
+from fmp_data import FMPDataClient, TechnicalInterval, Timeframe
 
 with FMPDataClient.from_env() as client:
     # Simple Moving Average
     timeframe: Timeframe = "1day"
-    sma = client.technical.get_sma("AAPL", period_length=20, timeframe=timeframe)
+    interval: TechnicalInterval = "daily"
+    sma = client.technical.get_sma(
+        "AAPL", period_length=20, timeframe=timeframe, interval=interval
+    )
 
     # RSI (Relative Strength Index)
     rsi = client.technical.get_rsi("AAPL", period_length=14, timeframe="1day")

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -2,18 +2,28 @@
 
 ## Closed request vocabularies
 
-`Period`, `PeriodFiscal`, `PeriodAnnualQuarter`, `Interval`, and
-`Timeframe` are re-exported from `fmp_data`. They are the typed contracts
-for client method parameters. Import them from the package root:
+`Period`, `PeriodFiscal`, `PeriodAnnualQuarter`, `Interval`,
+`TechnicalInterval`, and `Timeframe` are re-exported from `fmp_data`.
+They are the typed contracts for client method parameters. Import them
+from the package root:
 
 ```python
-from fmp_data import Interval, Period, PeriodAnnualQuarter, PeriodFiscal, Timeframe
+from fmp_data import (
+    Interval,
+    Period,
+    PeriodAnnualQuarter,
+    PeriodFiscal,
+    TechnicalInterval,
+    Timeframe,
+)
 ```
 
 Do not collapse the three period aliases. Most statement endpoints take
 `Period` (`annual` / `quarter` / `FY` / `Q1`–`Q4`). Financial reports and
 batch bulk accept only `PeriodFiscal`. Some company series take only
 `PeriodAnnualQuarter`. `Timeframe` is `Interval` plus `"1day"`.
+`TechnicalClient.interval=` takes `TechnicalInterval` (`Interval` plus
+`"daily"` / `"hourly"`), not `Timeframe`.
 
 ## Main Clients
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -115,13 +115,22 @@ from the package root when you want to annotate against the live client
 contracts:
 
 ```python
-from fmp_data import Interval, Period, PeriodAnnualQuarter, PeriodFiscal, Timeframe
+from fmp_data import (
+    Interval,
+    Period,
+    PeriodAnnualQuarter,
+    PeriodFiscal,
+    TechnicalInterval,
+    Timeframe,
+)
 ```
 
 There are three period types on purpose: most statement endpoints take
 `Period` (`annual` / `quarter` / `FY` / `Q1`–`Q4`). Financial reports and
 batch bulk take only `PeriodFiscal`. Some company series take only
 `PeriodAnnualQuarter`. `Timeframe` is `Interval` plus `"1day"`.
+`TechnicalClient.interval=` takes `TechnicalInterval` (`daily` /
+`hourly`), not `Timeframe`.
 
 ### Response Caching
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -129,8 +129,8 @@ There are three period types on purpose: most statement endpoints take
 `Period` (`annual` / `quarter` / `FY` / `Q1`–`Q4`). Financial reports and
 batch bulk take only `PeriodFiscal`. Some company series take only
 `PeriodAnnualQuarter`. `Timeframe` is `Interval` plus `"1day"`.
-`TechnicalClient.interval=` takes `TechnicalInterval` (`daily` /
-`hourly`), not `Timeframe`.
+`TechnicalClient.interval=` takes `TechnicalInterval` (`Interval` plus
+`"daily"` / `"hourly"`), not `Timeframe`.
 
 ### Response Caching
 

--- a/fmp_data/__init__.py
+++ b/fmp_data/__init__.py
@@ -41,6 +41,7 @@ from fmp_data.schema import (
     Period,
     PeriodAnnualQuarter,
     PeriodFiscal,
+    TechnicalInterval,
     Timeframe,
 )
 
@@ -71,6 +72,7 @@ __all__ = [
     "PeriodFiscal",
     "RateLimitConfig",
     "RateLimitError",
+    "TechnicalInterval",
     "Timeframe",
     "ValidationError",
     "VectorStoreCreationError",

--- a/tests/unit/test_closed_vocabularies.py
+++ b/tests/unit/test_closed_vocabularies.py
@@ -145,7 +145,7 @@ def test_getting_started_income_statement_examples_use_period() -> None:
 
 
 def test_closed_vocabularies_are_public_exports() -> None:
-    """#308: callers annotate against the live contracts from fmp_data."""
+    """#308 / #311: callers annotate against the live contracts from fmp_data."""
     import fmp_data
 
     assert fmp_data.Period is Period
@@ -153,14 +153,19 @@ def test_closed_vocabularies_are_public_exports() -> None:
     assert fmp_data.PeriodAnnualQuarter is PeriodAnnualQuarter
     assert fmp_data.Interval is Interval
     assert fmp_data.Timeframe is Timeframe
+    assert fmp_data.TechnicalInterval is TechnicalInterval
     for name in (
         "Period",
         "PeriodFiscal",
         "PeriodAnnualQuarter",
         "Interval",
+        "TechnicalInterval",
         "Timeframe",
     ):
         assert name in fmp_data.__all__, name
+    assert "1day" not in literal_values(fmp_data.TechnicalInterval)
+    assert "daily" in literal_values(fmp_data.TechnicalInterval)
+    assert "hourly" in literal_values(fmp_data.TechnicalInterval)
 
 
 def test_deprecated_time_interval_tracks_technical_interval() -> None:

--- a/tests/unit/test_closed_vocabularies.py
+++ b/tests/unit/test_closed_vocabularies.py
@@ -125,6 +125,31 @@ def test_legacy_enums_are_unpacked_from_the_literal_tuples() -> None:
     assert IntradayTimeInterval.FOUR_HOURS.value == "4hour"
 
 
+def test_readme_sma_example_does_not_stack_interval_on_timeframe() -> None:
+    """interval overrides timeframe; examples must show one or the other."""
+    from pathlib import Path
+    import re
+
+    text = (Path(__file__).resolve().parents[2] / "README.md").read_text(
+        encoding="utf-8"
+    )
+    fence = re.compile(r"```(?:python)?\n(.*?)```", re.S)
+    stacked = [
+        i
+        for i, block in enumerate(fence.findall(text))
+        if "get_sma" in block
+        and (
+            re.search(r"get_sma\([^)]*timeframe\s*=[^)]*interval\s*=", block, re.S)
+            or re.search(r"get_sma\([^)]*interval\s*=[^)]*timeframe\s*=", block, re.S)
+        )
+    ]
+    assert not stacked, (
+        "get_sma examples must not pass both timeframe and interval; "
+        "interval overrides timeframe:\n  README.md fence(s) "
+        + ", ".join(map(str, stacked))
+    )
+
+
 def test_getting_started_income_statement_examples_use_period() -> None:
     """#308: get_income_statement takes Period, not PeriodAnnualQuarter."""
     from pathlib import Path


### PR DESCRIPTION
## Summary

Follow-up to #310 / #308. Live `TechnicalClient` methods take `interval: TechnicalInterval | None` (`Interval` plus `"daily"` / `"hourly"`), mapped onto `Timeframe` by `_normalize_timeframe`. Callers who wanted to annotate that parameter still had to import `fmp_data.schema`.

- Re-export `TechnicalInterval` from `fmp_data` and list it in `__all__`.
- Document it next to the other closed vocabularies. Do not collapse it into `Timeframe`: `"1day"` is not a valid leftover `interval=` value.
- Pin the public export and that `daily` / `hourly` stay on this alias.
- Fold `#311` into the 2.7.0 notes (same policy as #312; release PR #304 is still open).
- Show `Timeframe` and `TechnicalInterval` as separate `get_sma` examples so `interval=` cannot silently override `timeframe=`.

Closes #311

## Test plan

- [x] `tests/unit/test_closed_vocabularies.py` (`test_closed_vocabularies_are_public_exports`, `test_readme_sma_example_does_not_stack_interval_on_timeframe`)
- [x] `uv run pytest tests/unit` — 2083 passed, 19 skipped
- [x] ruff + mypy via pre-commit
- [x] rebased onto `origin/dev` after #312

## Review notes

No review threads on the original push. CodeRabbit auto-review is disabled for PRs targeting `dev`; do not block on it. Findings from the local review (changelog conflict, README interval/timeframe stack, `get_macd` ghost example, incomplete `daily`/`hourly` wording) are addressed on this branch.