### PR TITLE
fix(review): address #304 release-PR review comments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,10 +134,7 @@ jobs:
             echo "VERSION_NUMBER=$NEW_VERSION"
           } >> "$GITHUB_OUTPUT"
 
-      - name: 🏷️ Create and push tag
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
+      - name: 🏷️ Create local tag
         run: |
           set -euo pipefail
           git config user.name github-actions
@@ -150,9 +147,10 @@ jobs:
             exit 1
           fi
 
-          # Fail loudly if the tag already exists. The previous behaviour
-          # skipped creation, still built, and published with skip-existing —
-          # a green check that re-advertised whatever was already on PyPI.
+          # Fail loudly if the tag already exists locally. The previous
+          # behaviour skipped creation, still built, and published with
+          # skip-existing — a green check that re-advertised whatever was
+          # already on PyPI.
           if git rev-parse -q --verify "refs/tags/${RELEASE_TAG}" > /dev/null; then
             echo "::error::Tag ${RELEASE_TAG} already exists. Refusing to re-release."
             echo "If this is intentional, delete the tag and re-run, or bump the version."
@@ -162,29 +160,10 @@ jobs:
           # Create the tag locally FIRST and keep it. hatch-vcs derives the
           # version from the local tag, and the build step below runs after
           # this one -- a remote-only tag would silently produce a .devN
-          # version instead of the release version.
+          # version instead of the release version. The remote tag is pushed
+          # only after the build and sdist version check succeed.
           git tag -a "$RELEASE_TAG" -m "Release $RELEASE_TAG"
-
-          # Publish it through the API rather than `git push`: the checkout no
-          # longer persists credentials, so there is no git remote auth. Two
-          # calls keep the remote tag *annotated*, matching the local one --
-          # creating the ref alone would leave a lightweight tag.
-          COMMIT_SHA="$(git rev-parse "${RELEASE_TAG}^{commit}")"
-          TAG_SHA="$(gh api "repos/${REPO}/git/tags" \
-            -f tag="$RELEASE_TAG" \
-            -f message="Release $RELEASE_TAG" \
-            -f object="$COMMIT_SHA" \
-            -f type=commit \
-            --jq .sha)"
-          gh api "repos/${REPO}/git/refs" \
-            -f ref="refs/tags/${RELEASE_TAG}" \
-            -f sha="$TAG_SHA" > /dev/null
-
-          # Confirm the remote actually has it before anything downstream
-          # relies on it (`gh release create --verify-tag` would fail later
-          # and less legibly).
-          gh api "repos/${REPO}/git/ref/tags/${RELEASE_TAG}" > /dev/null
-          echo "Pushed tag ${RELEASE_TAG} -> ${COMMIT_SHA}"
+          echo "Created local tag ${RELEASE_TAG}"
 
       - name: 📦 Build distribution
         env:
@@ -219,6 +198,40 @@ jobs:
 
           (cd dist && sha256sum ./* > ../SHA256SUMS)
           cat SHA256SUMS
+
+      - name: 🏷️ Push tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          RELEASE_TAG="${{ steps.version.outputs.VERSION }}"
+
+          if [ -z "$RELEASE_TAG" ] || [ "$RELEASE_TAG" = "v" ]; then
+            echo "::error::Refusing to push empty/invalid tag '$RELEASE_TAG'"
+            exit 1
+          fi
+
+          # Publish it through the API rather than `git push`: the checkout no
+          # longer persists credentials, so there is no git remote auth. Two
+          # calls keep the remote tag *annotated*, matching the local one --
+          # creating the ref alone would leave a lightweight tag.
+          COMMIT_SHA="$(git rev-parse "${RELEASE_TAG}^{commit}")"
+          TAG_SHA="$(gh api "repos/${REPO}/git/tags" \
+            -f tag="$RELEASE_TAG" \
+            -f message="Release $RELEASE_TAG" \
+            -f object="$COMMIT_SHA" \
+            -f type=commit \
+            --jq .sha)"
+          gh api "repos/${REPO}/git/refs" \
+            -f ref="refs/tags/${RELEASE_TAG}" \
+            -f sha="$TAG_SHA" > /dev/null
+
+          # Confirm the remote actually has it before anything downstream
+          # relies on it (`gh release create --verify-tag` would fail later
+          # and less legibly).
+          gh api "repos/${REPO}/git/ref/tags/${RELEASE_TAG}" > /dev/null
+          echo "Pushed tag ${RELEASE_TAG} -> ${COMMIT_SHA}"
 
       - name: 📋 Generate release notes from PR
         id: release_notes

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -385,21 +385,21 @@
         "filename": "tests/unit/test_config.py",
         "hashed_secret": "bb5e31f5e4adb0f4343409954e3dfe95accd3004",
         "is_verified": false,
-        "line_number": 476
+        "line_number": 483
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/test_config.py",
         "hashed_secret": "5daae97f0240d1a05e6f1767e81a8d1ad60383ac",
         "is_verified": false,
-        "line_number": 688
+        "line_number": 695
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/test_config.py",
         "hashed_secret": "a9014473b8f457d319c2702f5970452513306608",
         "is_verified": false,
-        "line_number": 718
+        "line_number": 725
       }
     ],
     "tests/unit/test_export_dotenv.py": [
@@ -446,13 +446,6 @@
         "hashed_secret": "9749f120d973f95fcd9b26e5a575d83a1abcf1a1",
         "is_verified": false,
         "line_number": 165
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/unit/test_logger.py",
-        "hashed_secret": "c753ca619f884268db1b142408217819016e9ceb",
-        "is_verified": false,
-        "line_number": 185
       }
     ],
     "tests/unit/test_mcp.py": [
@@ -511,5 +504,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-14T16:40:35Z"
+  "generated_at": "2026-08-15T00:56:52Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -249,6 +249,14 @@ None. No FMP path we ship was newly retired by this changelog window.
   so the 2.7.0 release PR never published a TestPyPI comment. PKG-INFO
   is now read in full before the version line is parsed.
 
+- **Release-PR review follow-ups (#304).** Loopback HTTP now requires a
+  real loopback *address* (``127.evil.example`` is rejected). Log extras
+  redact string leaves and ``Authorization`` mapping keys. MCP Python
+  manifests accept ``TOOLS: list[str] = [...]``. Redis ``SCAN MATCH``
+  escapes glob metacharacters in the key prefix. The release remote tag
+  is created only after the sdist version check. Makefile ``.env``
+  loading strips dotenv-style inline comments.
+
 - **`HolderIndustryBreakdown.industry_title` accepts `null`.** A live
   13F industry-breakdown row sends `industryTitle: null`; the field was
   required `str` and the whole call raised `ValidationError`.

--- a/README.md
+++ b/README.md
@@ -484,6 +484,8 @@ with FMPDataClient.from_env() as client:
 
 ### 3. Market Data
 ```python
+from datetime import date
+
 from fmp_data import FMPDataClient
 
 with FMPDataClient.from_env() as client:

--- a/docs/mcp/configurations.md
+++ b/docs/mcp/configurations.md
@@ -118,8 +118,9 @@ Preferred new format:
 
 YAML (`tools: [company.profile]`) and TOML (`tools = ["company.profile"]`)
 are accepted the same way. TOML has no top-level array form; use a
-`tools` table. On Python 3.10 the `mcp` extra pulls in `tomli` for that
-parse; 3.11+ uses stdlib `tomllib`.
+top-level `tools` *key* (`tools = ["..."]`), not a `[tools]` table.
+On Python 3.10 the `mcp` extra pulls in `tomli` for that parse; 3.11+
+uses stdlib `tomllib`.
 
 You can still create a legacy Python manifest by:
 

--- a/fmp_data/base.py
+++ b/fmp_data/base.py
@@ -683,7 +683,11 @@ class BaseClient:
             return self._parse_json_response(response)
         except httpx.HTTPStatusError as exc:
             return self._handle_http_status_error(endpoint_for_error, exc)
-        except json.JSONDecodeError as exc:
+        except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as exc:
+            # Same trio as `_get_error_details`. `response.json()` can raise
+            # UnicodeDecodeError on a non-UTF-8 body, and JSONDecodeError is
+            # only a subclass of ValueError — leaving those out let a 2xx
+            # non-UTF-8 body escape as a raw decode error instead of FMPError.
             # Redact, exactly as the sibling error path does. A 2xx carrying a
             # non-JSON body is routine -- WAF and CDN block pages echo the full
             # request URL, and ours carries `apikey=` -- so this branch put the

--- a/fmp_data/cache/redis_backend.py
+++ b/fmp_data/cache/redis_backend.py
@@ -42,6 +42,17 @@ class RedisCache(CacheBackend):
     def _prefixed(self, key: str) -> str:
         return f"{self._key_prefix}{key}"
 
+    @staticmethod
+    def _escape_scan_match(prefix: str) -> str:
+        """Escape Redis SCAN glob metacharacters in a key prefix."""
+        return (
+            prefix.replace("\\", "\\\\")
+            .replace("*", "\\*")
+            .replace("?", "\\?")
+            .replace("[", "\\[")
+            .replace("]", "\\]")
+        )
+
     def get(self, key: str) -> Any | None:
         try:
             raw = cast(str | None, self._client.get(self._prefixed(key)))
@@ -70,7 +81,7 @@ class RedisCache(CacheBackend):
             logger.warning("Redis delete error for key %s", key, exc_info=True)
 
     def clear(self) -> None:
-        pattern = f"{self._key_prefix}*"
+        pattern = f"{self._escape_scan_match(self._key_prefix)}*"
         cursor: int = 0
         try:
             while True:

--- a/fmp_data/config.py
+++ b/fmp_data/config.py
@@ -10,6 +10,7 @@ File: fmp_data/config.py
 from __future__ import annotations
 
 from collections.abc import Callable
+from ipaddress import ip_address
 import os
 from pathlib import Path
 from typing import Any, Literal
@@ -42,11 +43,21 @@ def _reveal(value: SecretStr | str | None) -> str | None:
 
 
 def _is_loopback_host(hostname: str | None) -> bool:
-    """True for localhost / loopback literals used by local test servers."""
+    """True for localhost / loopback *addresses* used by local test servers.
+
+    A prefix check on ``127.`` is not enough: ``127.evil.example`` would
+    then be treated as loopback and ``http://`` would be allowed, sending
+    ``apikey`` without TLS.
+    """
     if not hostname:
         return False
     host = hostname.strip("[]").lower()
-    return host in {"localhost", "127.0.0.1", "::1"} or host.startswith("127.")
+    if host == "localhost":
+        return True
+    try:
+        return ip_address(host).is_loopback
+    except ValueError:
+        return False
 
 
 def _mask_secret(value: SecretStr | str) -> str:

--- a/fmp_data/logger.py
+++ b/fmp_data/logger.py
@@ -105,6 +105,7 @@ class SensitiveDataFilter(logging.Filter):
             "access_token",
             "refresh_token",
             "auth_token",
+            "authorization",
             "bearer_token",
             "key",
         }
@@ -239,6 +240,10 @@ class SensitiveDataFilter(logging.Filter):
             )
         if isinstance(d, set):
             return {self._mask_dict_recursive(i, parent_key, depth + 1) for i in d}
+        if isinstance(d, str):
+            return self._mask_patterns_in_string(d)
+        if isinstance(d, bytes | bytearray):
+            return self._mask_patterns_in_string(_stringify(d))
         return d
 
 

--- a/fmp_data/mcp/utils.py
+++ b/fmp_data/mcp/utils.py
@@ -435,6 +435,35 @@ def _string_list_from_ast(node: ast.AST, path: Path) -> list[str]:
     return tools
 
 
+def _tools_list_from_assignment(
+    stmt: ast.Assign | ast.AnnAssign, path: Path, already: list[str] | None
+) -> list[str]:
+    """Extract ``TOOLS`` from a module-level assignment or annotated assignment."""
+    value: ast.expr | None
+    if isinstance(stmt, ast.Assign):
+        ok = (
+            len(stmt.targets) == 1
+            and isinstance(stmt.targets[0], ast.Name)
+            and stmt.targets[0].id == "TOOLS"
+        )
+        value = stmt.value
+    else:
+        ok = isinstance(stmt.target, ast.Name) and stmt.target.id == "TOOLS"
+        value = stmt.value
+    if not ok or value is None:
+        raise ValueError(
+            f"{path} is not a data-only manifest: only a module-level "
+            "TOOLS = [...] assignment is allowed. A Python manifest "
+            "does not execute."
+        )
+    if already is not None:
+        raise ValueError(
+            f"{path} is not a data-only manifest: TOOLS is assigned "
+            "more than once. A Python manifest does not execute."
+        )
+    return _string_list_from_ast(value, path)
+
+
 def _parse_python_manifest(source: str, path: Path) -> list[str]:
     """Parse a legacy ``TOOLS = ["..."]`` file without executing it."""
     try:
@@ -450,23 +479,8 @@ def _parse_python_manifest(source: str, path: Path) -> list[str]:
             and isinstance(stmt.value.value, str)
         ):
             continue
-        if isinstance(stmt, ast.Assign):
-            if (
-                len(stmt.targets) != 1
-                or not isinstance(stmt.targets[0], ast.Name)
-                or stmt.targets[0].id != "TOOLS"
-            ):
-                raise ValueError(
-                    f"{path} is not a data-only manifest: only a module-level "
-                    "TOOLS = [...] assignment is allowed. A Python manifest "
-                    "does not execute."
-                )
-            if tools is not None:
-                raise ValueError(
-                    f"{path} is not a data-only manifest: TOOLS is assigned "
-                    "more than once. A Python manifest does not execute."
-                )
-            tools = _string_list_from_ast(stmt.value, path)
+        if isinstance(stmt, ast.Assign | ast.AnnAssign):
+            tools = _tools_list_from_assignment(stmt, path, tools)
             continue
         raise ValueError(
             f"{path} is not a data-only manifest: only a docstring and "

--- a/scripts/export_dotenv.py
+++ b/scripts/export_dotenv.py
@@ -11,8 +11,11 @@ stripped. No interpolation, no command substitution. Process-hijack keys
 from __future__ import annotations
 
 from pathlib import Path
+import re
 import shlex
 import sys
+
+_INLINE_COMMENT = re.compile(r"\s+#")
 
 # A trusted .env can still clobber the maintainer shell if we export these.
 _BLOCKED_KEYS = frozenset(
@@ -55,8 +58,15 @@ def export_lines(text: str) -> list[str]:
         if key in _BLOCKED_KEYS or key.startswith("DYLD_"):
             continue
         value = value.strip()
-        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
-            value = value[1:-1]
+        if value and value[0] in {"'", '"'}:
+            quote = value[0]
+            end = value.find(quote, 1)
+            if end != -1:
+                value = value[1:end]
+            elif len(value) >= 2 and value[-1] == quote:
+                value = value[1:-1]
+        else:
+            value = _INLINE_COMMENT.split(value, maxsplit=1)[0].rstrip()
         lines.append(f"export {key}={shlex.quote(value)}")
     return lines
 

--- a/tests/unit/test_codeql_workflow.py
+++ b/tests/unit/test_codeql_workflow.py
@@ -22,7 +22,7 @@ def test_codeql_workflow_is_sha_pinned() -> None:
         if ref.startswith("./"):
             continue
         action, _, pin = ref.partition("@")
-        pin = pin.split()[0]
+        pin = pin.split()[0] if pin.strip() else ""
         assert len(pin) == 40 and all(c in "0123456789abcdef" for c in pin), (
             f"{action} is not pinned to a 40-char SHA: {pin!r}"
         )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -425,6 +425,13 @@ class TestClientConfig:
             with pytest.raises(ValidationError):
                 ClientConfig(api_key="test_key", base_url=url)
 
+    def test_http_loopback_prefix_is_not_enough(self) -> None:
+        """``127.evil.example`` is not a loopback address."""
+        with pytest.raises(ValidationError, match="https except for loopback"):
+            ClientConfig(api_key="test_key", base_url="http://127.evil.example")
+        config = ClientConfig(api_key="test_key", base_url="http://127.0.0.1:8000")
+        assert config.base_url == "http://127.0.0.1:8000"
+
     def test_api_key_validation(self):
         """Test API key validation"""
         # Valid API key

--- a/tests/unit/test_export_dotenv.py
+++ b/tests/unit/test_export_dotenv.py
@@ -55,3 +55,26 @@ def test_export_lines_drops_process_hijack_keys() -> None:
     assert "PYTHONPATH=" not in joined
     assert "DYLD_" not in joined
     assert "IFS=" not in joined
+
+
+def test_export_lines_strips_unquoted_inline_comments() -> None:
+    """Match python-dotenv: ``\\s+#`` starts a comment on unquoted values."""
+    text = "\n".join(
+        [
+            "UNQUOTED=plain # trailing",
+            "TABBED=plain\t# tab comment",
+            'QUOTED="hash # stays"',
+            'QUOTED_THEN_COMMENT="keep" # drop',
+            "HASHONLY=abc#def",
+        ]
+    )
+    lines = export_dotenv.export_lines(text)
+    joined = "\n".join(lines)
+    assert "export UNQUOTED=plain" in joined
+    assert "trailing" not in joined
+    assert "export TABBED=plain" in joined
+    assert "tab comment" not in joined
+    assert "hash # stays" in joined
+    assert "export QUOTED_THEN_COMMENT=keep" in joined
+    assert "drop" not in joined
+    assert any("HASHONLY=" in line and "abc#def" in line for line in lines)

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -182,11 +182,11 @@ class TestSensitiveDataFilter:
     ) -> None:
         from fmp_data.logger import FMPLogger
 
-        secret = "childsecretkey99"  # noqa: S105
+        planted = "childdummyvalue99"
         log = FMPLogger().get_logger("fmp_data.base")
         caplog.set_level(logging.INFO, logger="fmp_data.base")
-        log.info("child saw api_key=%s", secret)
-        assert secret not in caplog.text
+        log.info("child saw api_key=%s", planted)
+        assert planted not in caplog.text
         assert "api_key=" in caplog.text
 
     def test_every_pattern_masks_without_raising(self) -> None:
@@ -1202,6 +1202,25 @@ class TestEveryHandlerSeesRedactedExtras:
 
         assert planted not in buf.getvalue()
         assert "api_key" in buf.getvalue()
+
+    def test_string_leaves_and_authorization_keys_are_masked(self) -> None:
+        """Pattern-shaped strings and Authorization mapping keys are redacted."""
+        planted = "PLANTEDCREDENTIALVALUE"
+        filt = SensitiveDataFilter()
+        record = logging.LogRecord(
+            name="fmp_data.test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="payload",
+            args=(),
+            exc_info=None,
+        )
+        record.__dict__["payload"] = f"apikey={planted}"
+        record.__dict__["headers"] = {"Authorization": f"Bearer {planted}"}
+        assert filt.filter(record) is True
+        assert planted not in str(record.__dict__["payload"])
+        assert planted not in str(record.__dict__["headers"])
 
 
 class TestLogApiCallPositionalArguments:

--- a/tests/unit/test_mcp_utils.py
+++ b/tests/unit/test_mcp_utils.py
@@ -977,16 +977,13 @@ class TestPythonManifestIsParsedAsData:
 
         assert "assigned more than once" in str(excinfo.value)
 
-    def test_refuses_an_annotated_tools_assignment(self, tmp_path: Path) -> None:
-        """Current behaviour: ``TOOLS: list[str] = [...]`` is not accepted."""
+    def test_accepts_an_annotated_tools_assignment(self, tmp_path: Path) -> None:
+        """``TOOLS: list[str] = [...]`` is still a data-only assignment."""
         manifest = _write_manifest(
             tmp_path, "annotated.py", "TOOLS: list[str] = ['company.profile']\n"
         )
 
-        with pytest.raises(ValueError) as excinfo:
-            mcp_utils.load_manifest_tools(manifest)
-
-        assert "only a docstring and TOOLS" in str(excinfo.value)
+        assert mcp_utils.load_manifest_tools(manifest) == ["company.profile"]
 
     @pytest.mark.parametrize(
         ("shape", "source"),

--- a/tests/unit/test_path_params.py
+++ b/tests/unit/test_path_params.py
@@ -30,3 +30,17 @@ def test_safe_path_segment_rejects_traversal() -> None:
     with pytest.raises(ValidationError, match="not allowed"):
         _safe_path_segment("%2e%2e/%2e%2e/stable/profile")
     assert _safe_path_segment("1min") == "1min"
+
+
+def test_safe_path_segment_rejects_encoded_separators_without_a_literal() -> None:
+    """Encoded / and \\ must be rejected even when the raw string has none."""
+    with pytest.raises(ValidationError, match="not allowed"):
+        _safe_path_segment("%2fstable")
+    with pytest.raises(ValidationError, match="not allowed"):
+        _safe_path_segment("%2Fstable")
+    with pytest.raises(ValidationError, match="not allowed"):
+        _safe_path_segment("%5cstable")
+    with pytest.raises(ValidationError, match="not allowed"):
+        _safe_path_segment(".")
+    with pytest.raises(ValidationError, match="not allowed"):
+        _safe_path_segment("..")

--- a/tests/unit/test_redis_backend.py
+++ b/tests/unit/test_redis_backend.py
@@ -334,11 +334,11 @@ class TestRedisCacheClear:
         assert client.scan_calls == [(0, "fmp:*", 100), (17, "fmp:*", 100)]
         assert client.delete_calls == [("fmp:a", "fmp:b"), ("fmp:c",)]
 
-    def test_glob_metacharacters_in_prefix_are_not_escaped(
+    def test_glob_metacharacters_in_prefix_are_escaped(
         self, redis_stub: FakeRedisModule
     ) -> None:
-        """Current behaviour: the prefix is concatenated into the SCAN
-        pattern verbatim, so glob metacharacters change what is matched.
+        """SCAN MATCH is a glob; a literal ``[`` in the prefix must not
+        become a character class.
         """
         cache = RedisCache(key_prefix="fmp[1]:")
         client = redis_stub.client
@@ -348,7 +348,7 @@ class TestRedisCacheClear:
         cache.clear()
 
         assert client.setex_calls[0][0] == "fmp[1]:quote"
-        assert client.scan_calls == [(0, "fmp[1]:*", 100)]
+        assert client.scan_calls == [(0, r"fmp\[1\]:*", 100)]
 
     def test_empty_page_does_not_call_delete(self, redis_stub: FakeRedisModule) -> None:
         cache = RedisCache()

--- a/tests/unit/test_release_tag_push.py
+++ b/tests/unit/test_release_tag_push.py
@@ -70,17 +70,20 @@ def test_only_the_steps_that_need_it_receive_a_token() -> None:
         str(s.get("name")) for s in _build_steps() if "GH_TOKEN" in (s.get("env") or {})
     }
     assert len(holders) == 2, f"unexpected GH_TOKEN holders: {holders}"
-    assert any("tag" in h for h in holders)
+    assert any("Push tag" in h for h in holders)
     assert any("Release" in h for h in holders)
 
     build = _step("Build distribution")
     assert "GH_TOKEN" not in (build.get("env") or {})
+    assert "GH_TOKEN" not in (_step("Create local tag").get("env") or {})
 
 
 def test_tag_is_created_locally_before_the_build() -> None:
     """hatch-vcs reads the *local* tag; a remote-only tag yields `.devN`."""
-    assert _index("Create and push tag") < _index("Build distribution")
-    assert "git tag -a" in _step("Create and push tag")["run"]
+    assert _index("Create local tag") < _index("Build distribution")
+    assert _index("Build distribution") < _index("Push tag")
+    assert "git tag -a" in _step("Create local tag")["run"]
+    assert "git/tags" not in _step("Create local tag")["run"]
 
 
 def _code_lines(run: str) -> str:
@@ -91,7 +94,7 @@ def _code_lines(run: str) -> str:
 
 
 def test_tag_is_pushed_through_the_api_as_an_annotated_tag() -> None:
-    run = _step("Create and push tag")["run"]
+    run = _step("Push tag")["run"]
 
     # No git remote auth exists any more, so this must not come back.
     assert "git push" not in _code_lines(run)
@@ -104,10 +107,10 @@ def test_tag_is_pushed_through_the_api_as_an_annotated_tag() -> None:
 
 
 def test_the_push_is_verified_before_downstream_steps_rely_on_it() -> None:
-    assert "git/ref/tags/" in _step("Create and push tag")["run"]
+    assert "git/ref/tags/" in _step("Push tag")["run"]
 
 
-@pytest.mark.parametrize("fragment", ["Create and push tag", "Create GitHub Release"])
+@pytest.mark.parametrize("fragment", ["Push tag", "Create GitHub Release"])
 def test_token_scoped_steps_still_fail_closed(fragment: str) -> None:
     run = _step(fragment)["run"]
     assert "set -euo pipefail" in run

--- a/tests/unit/test_workflow_permission_isolation.py
+++ b/tests/unit/test_workflow_permission_isolation.py
@@ -34,12 +34,36 @@ WORKFLOWS = sorted((REPO_ROOT / ".github" / "workflows").glob("*.yml"))
 PAGES_DEPLOY_ENVIRONMENT = "github-pages"
 
 
-def _jobs(path: Path) -> dict[str, Any]:
+def _loaded(path: Path) -> dict[str, Any]:
     loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
     assert isinstance(loaded, dict), f"{path.name} is not a mapping"
-    jobs = loaded.get("jobs") or {}
+    return loaded
+
+
+def _jobs(path: Path) -> dict[str, Any]:
+    jobs = _loaded(path).get("jobs") or {}
     assert isinstance(jobs, dict)
     return jobs
+
+
+def _effective_permissions(loaded: dict[str, Any], job: dict[str, Any]) -> Any:
+    """Job-level permissions replace workflow-level ones; they do not merge."""
+    if "permissions" in job:
+        return job["permissions"]
+    return loaded.get("permissions")
+
+
+def _effective_env(
+    loaded: dict[str, Any],
+    job: dict[str, Any],
+    step: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Workflow, then job, then step — later mappings win."""
+    env: dict[str, Any] = {}
+    for mapping in (loaded.get("env"), job.get("env"), (step or {}).get("env")):
+        if isinstance(mapping, dict):
+            env.update(mapping)
+    return env
 
 
 def _write_scopes(permissions: Any) -> set[str]:
@@ -67,8 +91,9 @@ def _environment_name(job: dict[str, Any]) -> str | None:
 @pytest.mark.parametrize("path", WORKFLOWS, ids=lambda p: p.name)
 def test_no_job_mixes_oidc_with_repo_write(path: Path) -> None:
     offenders = []
+    loaded = _loaded(path)
     for name, job in _jobs(path).items():
-        scopes = _write_scopes(job.get("permissions"))
+        scopes = _write_scopes(_effective_permissions(loaded, job))
         if "id-token" not in scopes:
             continue
         allowed = {"id-token"}
@@ -119,22 +144,38 @@ def test_codecov_token_is_not_in_a_job_that_runs_pr_code() -> None:
     publish: produce an artifact with no secrets, upload it from a job that
     only downloads.
     """
-    jobs = _jobs(REPO_ROOT / ".github" / "workflows" / "ci.yml")
+    path = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+    loaded = _loaded(path)
+    jobs = _jobs(path)
 
-    coverage = yaml.dump(jobs["coverage"])
-    assert "CODECOV_TOKEN" not in coverage, (
+    coverage = jobs["coverage"]
+    coverage_env = _effective_env(loaded, coverage)
+    for step in coverage.get("steps") or []:
+        if isinstance(step, dict):
+            coverage_env = {**coverage_env, **_effective_env(loaded, coverage, step)}
+    assert "CODECOV_TOKEN" not in coverage_env, (
         "the coverage job executes PR-supplied test code; it must not hold "
         "the upload token"
     )
-    assert "nox" in coverage, "guard is vacuous if this job stops running tests"
+    assert "CODECOV_TOKEN" not in yaml.dump(coverage), (
+        "the coverage job executes PR-supplied test code; it must not hold "
+        "the upload token"
+    )
+    assert "nox" in yaml.dump(coverage), (
+        "guard is vacuous if this job stops running tests"
+    )
 
     upload = jobs["coverage-upload"]
-    assert "CODECOV_TOKEN" in yaml.dump(upload)
+    upload_env = _effective_env(loaded, upload)
+    for step in upload.get("steps") or []:
+        if isinstance(step, dict):
+            upload_env = {**upload_env, **_effective_env(loaded, upload, step)}
+    assert "CODECOV_TOKEN" in upload_env or "CODECOV_TOKEN" in yaml.dump(upload)
     assert "nox" not in yaml.dump(upload), (
         "the upload job must not execute repository code"
     )
     assert upload["needs"] == "coverage" or "coverage" in upload["needs"]
-    assert _write_scopes(upload.get("permissions")) == set()
+    assert _write_scopes(_effective_permissions(loaded, upload)) == set()
 
 
 PUBLISH_WORKFLOWS = ("release.yml", "dev-release.yml", "publish-testpypi.yml")


### PR DESCRIPTION
## Summary

Addresses the unresolved review threads on release PR #304.

| Thread | Change |
|---|---|
| `127.` loopback prefix | `_is_loopback_host` uses `ipaddress.is_loopback` |
| Log extras | string leaves + `Authorization` keys are redacted |
| MCP `TOOLS: list[str] =` | accepted as data-only `AnnAssign` |
| Redis SCAN | glob metacharacters in `key_prefix` are escaped |
| Release tag | remote tag created only after the sdist version check |
| `.env` comments | dotenv-style `\\s+#` stripped from unquoted values |
| `handle_response` | catch `UnicodeDecodeError` / `ValueError` like `_get_error_details` |
| TOML docs | top-level `tools` key, not a `[tools]` table |
| README market example | import `date` |
| Tests | encoded path separators, unpinned `uses:`, workflow-level permissions/env |

**Not changed:** Claude Code Review `plugin_marketplaces` stays. The action is SHA-pinned, the job is advisory (no checkout credentials, comment-only writes), and the gap is already documented in-file as accepted (#252). Vendoring or disabling the review job is a separate decision.

## Test plan

- [x] Targeted unit tests for the files above
- [ ] Test-Matrix on this PR
- [ ] After merge, reply on each #304 thread