### PR TITLE
fix(mcp): keep setup-wizard console copy fully static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -250,8 +250,8 @@ None. No FMP path we ship was newly retired by this changelog window.
   is now read in full before the version line is parsed.
 
 - **MCP setup wizard no longer prints validator stderr or the key
-  (#315).** Failed validation and the MCP smoke-test print static or
-  classified key-free copy. Console output is pattern-redacted and
+  (#315).** Failed validation, the MCP smoke-test, and unexpected
+  crashes print static copy. Console output is pattern-redacted and
   never interpolates the getpass-held key or exception text (CodeQL
   ``py/clear-text-logging-sensitive-data``). Persistence hints use
   ``[YOUR_API_KEY]``, not a prefix/suffix of the secret.

--- a/fmp_data/mcp/setup.py
+++ b/fmp_data/mcp/setup.py
@@ -38,14 +38,6 @@ _KEY_SHAPED_PATTERNS = (
     r"\b[a-zA-Z0-9]{32,}\b",
     r"[a-fA-F0-9]{40,}",
 )
-# validate_api_key strings that never embed subprocess stderr or the key.
-_SAFE_API_KEY_FAILURES = frozenset(
-    {
-        "API key is invalid or expired",
-        "API key validation timed out",
-        "API key validation failed: Invalid API key",
-    }
-)
 
 
 def _redact_key_patterns(message: str) -> str:
@@ -278,7 +270,7 @@ class SetupWizard:
 
             # Validate API key
             self.print("Validating API key...", "info")
-            valid, status = validate_api_key(api_key)
+            valid, _status = validate_api_key(api_key)
 
             if valid:
                 self.print("API key validated successfully.", "success")
@@ -292,14 +284,9 @@ class SetupWizard:
 
                 return True
             else:
-                # Echo only classified, key-free statuses. Raw helper text
-                # can include subprocess stderr that repeats the key.
-                failure = (
-                    status
-                    if status in _SAFE_API_KEY_FAILURES
-                    else "API key validation failed."
-                )
-                self.print(failure, "error")
+                # Static copy only. The helper string is dataflow from the
+                # getpass-held key; stdout is a CodeQL logging sink.
+                self.print("API key validation failed.", "error")
                 retry = self.prompt("Try another key? (y/n)", "y")
                 if retry.lower() != "y":
                     # Clear invalid API key
@@ -574,9 +561,10 @@ def run_setup(quiet: bool = False) -> int:
     except KeyboardInterrupt:
         wizard.print("\n\nSetup cancelled by user", "warning")
         return 1
-    except Exception as e:
-        # Exception text can quote the key. Type name is enough to debug.
-        detail = f"Setup failed: {type(e).__name__}"
+    except Exception:
+        # Do not interpolate the exception: stdout is a logging sink and
+        # the message can quote the key.
+        detail = "Setup failed."
         reporter = wizard if not wizard.quiet else SetupWizard(quiet=False)
         try:
             reporter.print(detail, "error")

--- a/tests/unit/test_mcp.py
+++ b/tests/unit/test_mcp.py
@@ -1415,7 +1415,7 @@ class TestMCPSetupSecurity:
         output = captured_output.getvalue()
         assert "secret123" not in output
         assert "api_key=" not in output
-        assert "Setup failed: Exception" in output
+        assert "Setup failed." in output
         assert result == 1
 
 

--- a/tests/unit/test_mcp_setup.py
+++ b/tests/unit/test_mcp_setup.py
@@ -498,29 +498,6 @@ class TestSetupApiKey:
         assert "❌ API key validation failed." in out
         assert prompts == ["Try another key? (y/n) [y]: "]
 
-    @pytest.mark.parametrize(
-        "status",
-        [
-            "API key is invalid or expired",
-            "API key validation timed out",
-            "API key validation failed: Invalid API key",
-        ],
-    )
-    def test_classified_validation_failures_are_shown(
-        self,
-        status: str,
-        monkeypatch: pytest.MonkeyPatch,
-        capsys: pytest.CaptureFixture[str],
-    ) -> None:
-        """Key-free helper statuses are safe to echo; raw stderr is not."""
-        monkeypatch.setattr(setup_mod, "get_api_key_from_env", lambda: None)
-        monkeypatch.setattr(setup_mod, "validate_api_key", lambda key: (False, status))
-        feed_secrets(monkeypatch, ["TYPED-KEY"])
-        feed_input(monkeypatch, ["n"])
-
-        assert SetupWizard().setup_api_key() is False
-        assert f"❌ {status}" in capsys.readouterr().out
-
     def test_retrying_after_a_rejection_keeps_the_second_key(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1152,7 +1129,7 @@ class TestRunSetup:
         assert run_setup() == 1
 
         out = capsys.readouterr().out
-        assert "❌ Setup failed: RuntimeError" in out
+        assert "❌ Setup failed." in out
         assert "sk-abcdefgh12345678" not in out
         assert "probe hit" not in out
 
@@ -1170,7 +1147,7 @@ class TestRunSetup:
         assert run_setup(quiet=True) == 1
 
         out = capsys.readouterr().out
-        assert "❌ Setup failed: RuntimeError" in out
+        assert "❌ Setup failed." in out
         assert "sk-abcdefgh12345678" not in out
 
     def test_when_the_error_report_itself_fails_the_type_is_still_shown(
@@ -1192,7 +1169,7 @@ class TestRunSetup:
 
         out = capsys.readouterr().out
         assert failed_once, "the first error report never happened"
-        assert "Setup failed: RuntimeError" in out
+        assert "Setup failed." in out
         assert "sk-abcdefgh12345678" not in out
         assert "manifest scan" not in out
 
@@ -1214,5 +1191,5 @@ class TestRunSetup:
 
         out = capsys.readouterr().out
         assert failed_once, "the first error report never happened"
-        assert "❌ Setup failed: RuntimeError" in out
+        assert "❌ Setup failed." in out
         assert "claude probe died" not in out


### PR DESCRIPTION
## Why
#315 squash-merged (`b2e37fa`) while a follow-up commit was still in flight. The merged tree echoes allowlisted `validate_api_key` statuses and interpolates `type(e).__name__` on crashes.

CodeQL treats those helper strings as dataflow from `getpass` and re-flags `stdout.write` (`py/clear-text-logging-sensitive-data`, alerts 29–34 on #315). That is the same class of alert #315 was meant to clear on release PR #304.

## What
Cherry-pick of `e8cda93` onto current `dev`:

- Validation failure and unexpected crashes print **static literals only**.
- No dataflow from the helper return string or exception object into stdout.
- Tests updated to match.

Classified, key-free reasons still belong in #319 (construct literals at the sink / typed enum — do not pass the helper string through).

## Test plan
- [x] `tests/unit/test_mcp_setup.py` + `TestMCPSetupSecurity` (88 passed on the source commit)
- [ ] CI CodeQL / Analyze Python green
