### PR TITLE
chore(review): enable CodeRabbit auto-review on PRs targeting dev

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -14,6 +14,10 @@ reviews:
   auto_review:
     enabled: true
     drafts: false  # Skip draft PRs
+    # Default branch (`main`) is always included. Most work lands on `dev`
+    # first (#318); without this, CodeRabbit skips those PRs.
+    base_branches:
+      - "^dev$"
 
   # Path-specific review instructions
   path_instructions:


### PR DESCRIPTION
## Why

PRs that target `dev` (including #315) get:

> Review skipped. Auto reviews are disabled on base/target branches other than the default branch.

Default branch is `main`. Most work lands on `dev` first, so CodeRabbit is a no-op on the branch we actually review.

Closes #318

## Change

Add `reviews.auto_review.base_branches: ["^dev$"]` to `.coderabbit.yaml`. Draft skipping stays off. `main` remains included by default.

`closes #N` is inert on `dev`-base PRs; close #318 by hand after merge if the link does not fire.
