### PR TITLE
fix(mcp): classify helper failures, probe FMP, and fix example-profile path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (sk-/32-char heuristics); those stay off HTTP error bodies so request
   ids are not blanked.
 
+### Fixed
+
+- **MCP setup helpers no longer echo subprocess stderr (#319).**
+  `validate_api_key` and `test_mcp_server` return classified reasons
+  (`valid` / `invalid` / `timeout` / `unavailable` and
+  `passed` / `started` / `failed` / `unavailable`). `fmp-mcp status`
+  and `fmp-mcp test` print sink-local literals so a key quoted in
+  child stderr cannot reach the terminal.
+
+- **`validate_api_key` now probes FMP (#317).**
+  A typed junk key no longer reports success. The helper constructs a
+  client and calls `company.get_quote("AAPL")`; 401 maps to `invalid`.
+
+- **Setup wizard offers the example MCP profiles again (#320).**
+  `get_manifest_choices` looks in `examples/mcp/configurations/` (the
+  real directory). The example Claude Desktop script and its
+  README / troubleshooting copies use the same path.
+
 ## [2.7.0] - 2026-08-14
 
 Released from `dev`. A security-and-contracts minor in the same shape as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,12 +28,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`validate_api_key` now probes FMP (#317).**
   A typed junk key no longer reports success. The helper constructs a
-  client and calls `company.get_quote("AAPL")`; 401 maps to `invalid`.
+  client and calls `company.get_quote("AAPL")`; 401 and 403 map to
+  `invalid`. Rate-limit / other HTTP errors still count as `valid`.
 
 - **Setup wizard offers the example MCP profiles again (#320).**
   `get_manifest_choices` looks in `examples/mcp/configurations/` (the
-  real directory). The example Claude Desktop script and its
-  README / troubleshooting copies use the same path.
+  real directory). The example Claude Desktop script, JSON profiles,
+  and README / troubleshooting copies use the same path.
 
 ## [2.7.0] - 2026-08-14
 

--- a/examples/mcp/claude_desktop/README.md
+++ b/examples/mcp/claude_desktop/README.md
@@ -188,7 +188,7 @@ We provide pre-configured tool sets for different use cases:
       "args": ["-m", "fmp_data.mcp"],
       "env": {
         "FMP_API_KEY": "your_api_key_here"  # pragma: allowlist secret,
-        "FMP_MCP_MANIFEST": "examples/mcp_configurations/trading_manifest.py"
+        "FMP_MCP_MANIFEST": "examples/mcp/configurations/trading_manifest.py"
       }
     }
   }
@@ -204,7 +204,7 @@ We provide pre-configured tool sets for different use cases:
       "args": ["-m", "fmp_data.mcp"],
       "env": {
         "FMP_API_KEY": "your_api_key_here"  # pragma: allowlist secret,
-        "FMP_MCP_MANIFEST": "examples/mcp_configurations/research_manifest.py"
+        "FMP_MCP_MANIFEST": "examples/mcp/configurations/research_manifest.py"
       }
     }
   }
@@ -220,7 +220,7 @@ We provide pre-configured tool sets for different use cases:
       "args": ["-m", "fmp_data.mcp"],
       "env": {
         "FMP_API_KEY": "your_api_key_here"  # pragma: allowlist secret,
-        "FMP_MCP_MANIFEST": "examples/mcp_configurations/crypto_manifest.py"
+        "FMP_MCP_MANIFEST": "examples/mcp/configurations/crypto_manifest.py"
       }
     }
   }

--- a/examples/mcp/claude_desktop/claude_desktop_config_advanced.json
+++ b/examples/mcp/claude_desktop/claude_desktop_config_advanced.json
@@ -13,7 +13,7 @@
       "args": ["-m", "fmp_data.mcp"],
       "env": {
         "FMP_API_KEY": "your_api_key_here",
-        "FMP_MCP_MANIFEST": "examples/mcp_configurations/trading_manifest.py"
+        "FMP_MCP_MANIFEST": "examples/mcp/configurations/trading_manifest.py"
       }
     },
     "fmp-research": {
@@ -21,7 +21,7 @@
       "args": ["-m", "fmp_data.mcp"],
       "env": {
         "FMP_API_KEY": "your_api_key_here",
-        "FMP_MCP_MANIFEST": "examples/mcp_configurations/research_manifest.py"
+        "FMP_MCP_MANIFEST": "examples/mcp/configurations/research_manifest.py"
       }
     }
   }

--- a/examples/mcp/claude_desktop/setup_claude_desktop.py
+++ b/examples/mcp/claude_desktop/setup_claude_desktop.py
@@ -185,15 +185,13 @@ def test_mcp_server(api_key):
         if result.returncode == 0:
             print("✅ MCP server test passed")
             return True
-        else:
-            print("❌ MCP server test failed")
-            print(f"   Error: {result.stderr}")
-            return False
+        print("❌ MCP server test failed")
+        return False
     except subprocess.TimeoutExpired:
         print("✅ MCP server test passed (server started)")
         return True
-    except Exception as e:
-        print(f"❌ MCP server test failed: {e}")
+    except Exception:
+        print("❌ MCP server test failed")
         return False
 
 
@@ -210,10 +208,10 @@ def choose_configuration():
 
     manifest_map = {
         "1": None,  # Default
-        "2": "examples/mcp_configurations/minimal_manifest.py",
-        "3": "examples/mcp_configurations/trading_manifest.py",
-        "4": "examples/mcp_configurations/research_manifest.py",
-        "5": "examples/mcp_configurations/crypto_manifest.py",
+        "2": "examples/mcp/configurations/minimal_manifest.py",
+        "3": "examples/mcp/configurations/trading_manifest.py",
+        "4": "examples/mcp/configurations/research_manifest.py",
+        "5": "examples/mcp/configurations/crypto_manifest.py",
     }
 
     return manifest_map.get(choice)

--- a/examples/mcp/claude_desktop/troubleshooting.md
+++ b/examples/mcp/claude_desktop/troubleshooting.md
@@ -140,7 +140,7 @@ Use a minimal configuration to reduce API calls:
       "args": ["-m", "fmp_data.mcp"],
       "env": {
         "FMP_API_KEY": "your_key",
-        "FMP_MCP_MANIFEST": "examples/mcp_configurations/minimal_manifest.py"
+        "FMP_MCP_MANIFEST": "examples/mcp/configurations/minimal_manifest.py"
       }
     }
   }

--- a/fmp_data/mcp/cli.py
+++ b/fmp_data/mcp/cli.py
@@ -1106,6 +1106,22 @@ def setup_command(args: argparse.Namespace) -> int:
     return run_setup(quiet=getattr(args, "quiet", False))
 
 
+def _print_server_check(success: bool, reason: str) -> None:
+    """Print a classified MCP server check using sink-local literals.
+
+    Do not interpolate ``reason`` into the printed string. CodeQL treats
+    stdout as a logging sink; a helper return that once held stderr is
+    still tainted even after an allowlist (#319, #321).
+    """
+    if success:
+        if reason == "started":
+            print("✅ MCP server test passed (server started)")
+        else:
+            print("✅ MCP server test passed")
+        return
+    print("❌ MCP server test failed")
+
+
 def status_command(args: argparse.Namespace) -> int:
     """Check MCP server status."""
     from fmp_data.mcp.utils import (
@@ -1139,11 +1155,8 @@ def status_command(args: argparse.Namespace) -> int:
             )
             if api_key:
                 print("🧪 Testing server connection...")
-                success, message = test_mcp_server(api_key)
-                if success:
-                    print(f"✅ {message}")
-                else:
-                    print(f"❌ {message}")
+                success, reason = test_mcp_server(api_key)
+                _print_server_check(success, reason)
             else:
                 print("⚠️  No API key configured")
         else:
@@ -1171,25 +1184,24 @@ def test_command(args: argparse.Namespace) -> int:
         return 1
 
     # Test server
-    success, message = test_mcp_server(api_key)
-    if success:
-        print(f"✅ {message}")
-
-        # Try to get tool count
-        try:
-            from fmp_data.mcp.server import create_app
-
-            app = create_app()
-            tool_manager = getattr(app, "_tool_manager", None)
-            tool_count = len(tool_manager._tools) if tool_manager else 0
-            print(f"✅ {tool_count} tools registered")
-        except Exception as e:
-            print(f"⚠️  Could not count tools: {e}")
-
-        return 0
-    else:
-        print(f"❌ {message}")
+    success, reason = test_mcp_server(api_key)
+    _print_server_check(success, reason)
+    if not success:
         return 1
+
+    # Try to get tool count
+    try:
+        from fmp_data.mcp.server import create_app
+
+        app = create_app()
+        tool_manager = getattr(app, "_tool_manager", None)
+        tool_count = len(tool_manager._tools) if tool_manager else 0
+        print(f"✅ {tool_count} tools registered")
+    except Exception:
+        # create_app can reflect the key in an exception message.
+        print("⚠️  Could not count tools")
+
+    return 0
 
 
 # CLI entry points for potential future integration with click/argparse

--- a/fmp_data/mcp/utils.py
+++ b/fmp_data/mcp/utils.py
@@ -16,7 +16,7 @@ import shutil
 import subprocess  # nosec B404
 import sys
 import tempfile
-from typing import Any
+from typing import Any, Literal
 
 
 def get_claude_config_path() -> Path:
@@ -250,21 +250,26 @@ def add_mcp_server_to_config(
     return config
 
 
-def test_mcp_server(api_key: str, manifest_path: str | None = None) -> tuple[bool, str]:
-    """
-    Test if the MCP server can start successfully.
+# Classified reasons only. Never embed stderr / exception text — those
+# strings can quote the API key, and stdout is a CodeQL logging sink
+# (py/clear-text-logging-sensitive-data). Callers must map the reason
+# onto a string literal at the print site (#319, #321).
+McpServerCheckReason = Literal["passed", "started", "failed", "unavailable"]
+ApiKeyCheckReason = Literal["valid", "invalid", "timeout", "unavailable"]
 
-    Parameters
-    ----------
-    api_key
-        FMP API key to test
-    manifest_path
-        Optional path to custom manifest
+# Cheap authenticated probe used by ``validate_api_key``. Any live symbol
+# works; AAPL is on every FMP plan that can call ``quote``.
+_PROBE_SYMBOL = "AAPL"
 
-    Returns
-    -------
-    tuple[bool, str]
-        Success status and message
+
+def test_mcp_server(
+    api_key: str, manifest_path: str | None = None
+) -> tuple[bool, McpServerCheckReason]:
+    """Test whether the MCP server process can start.
+
+    Returns a classified reason, never subprocess stderr or exception
+    text. ``fmp-mcp status`` / ``test`` must print a sink-local literal
+    derived from the reason, not this return value interpolated (#319).
     """
     env = os.environ.copy()
     env["FMP_API_KEY"] = api_key
@@ -289,16 +294,14 @@ def test_mcp_server(api_key: str, manifest_path: str | None = None) -> tuple[boo
         )
 
         if result.returncode == 0:
-            return True, "MCP server test passed"
-        else:
-            error_msg = result.stderr.strip() if result.stderr else "Unknown error"
-            return False, f"MCP server test failed: {error_msg}"
+            return True, "passed"
+        return False, "failed"
 
     except subprocess.TimeoutExpired:
         # Timeout actually means the server started and is waiting for input
-        return True, "MCP server test passed (server started)"
-    except Exception as e:
-        return False, f"MCP server test failed: {e}"
+        return True, "started"
+    except Exception:
+        return False, "unavailable"
 
 
 def get_api_key_from_env() -> str | None:
@@ -313,53 +316,40 @@ def get_api_key_from_env() -> str | None:
     return os.environ.get("FMP_API_KEY")
 
 
-def validate_api_key(api_key: str) -> tuple[bool, str]:
-    """
-    Validate an FMP API key by making a test request.
+def validate_api_key(api_key: str) -> tuple[bool, ApiKeyCheckReason]:
+    """Validate an FMP API key with a cheap authenticated request.
 
-    Parameters
-    ----------
-    api_key
-        API key to validate
-
-    Returns
-    -------
-    tuple[bool, str]
-        Success status and message
+    Constructs a client and calls ``company.get_quote`` so a typed junk
+    key cannot report success (#317). Returns a classified reason, never
+    exception text or stderr — those can quote the key (#319).
     """
+    import httpx
+
+    from fmp_data.client import FMPDataClient
+    from fmp_data.exceptions import AuthenticationError, ConfigError, FMPError
+
+    client: FMPDataClient | None = None
     try:
-        # Try to create a client with the API key
-        env = os.environ.copy()
-        env["FMP_API_KEY"] = api_key
-
-        result = subprocess.run(  # nosec B603
-            [
-                sys.executable,
-                "-c",
-                "import os; "
-                "from fmp_data import FMPDataClient; "
-                "client = FMPDataClient.from_env(); "
-                "client.close(); "
-                "print('API key is valid')",
-            ],
-            env=env,
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-
-        if result.returncode == 0:
-            return True, "API key is valid"
-        else:
-            error_msg = result.stderr.strip() if result.stderr else "Invalid API key"
-            if "401" in error_msg or "403" in error_msg:
-                return False, "API key is invalid or expired"
-            return False, f"API key validation failed: {error_msg}"
-
-    except subprocess.TimeoutExpired:
-        return False, "API key validation timed out"
-    except Exception as e:
-        return False, f"API key validation failed: {e}"
+        # One attempt: 401 is not retried, and a 4-10s backoff would make
+        # the wizard feel hung on a network blip.
+        client = FMPDataClient(api_key=api_key, timeout=10, max_retries=1)
+        client.company.get_quote(_PROBE_SYMBOL)
+    except AuthenticationError:
+        return False, "invalid"
+    except ConfigError:
+        return False, "invalid"
+    except (TimeoutError, httpx.TimeoutException):
+        return False, "timeout"
+    except FMPError:
+        # The key was accepted; the probe endpoint failed for another
+        # reason (rate limit, empty quote, …).
+        return True, "valid"
+    except Exception:
+        return False, "unavailable"
+    finally:
+        if client is not None:
+            client.close()
+    return True, "valid"
 
 
 def get_manifest_choices() -> dict[str, str | None]:
@@ -371,7 +361,12 @@ def get_manifest_choices() -> dict[str, str | None]:
     dict[str, str | None]
         Mapping of choice names to manifest paths (None for default)
     """
-    base_path = Path(__file__).parent.parent.parent / "examples" / "mcp_configurations"
+    base_path = (
+        Path(__file__).resolve().parent.parent.parent
+        / "examples"
+        / "mcp"
+        / "configurations"
+    )
 
     choices: dict[str, str | None] = {
         "default": None,  # Use default manifest

--- a/fmp_data/mcp/utils.py
+++ b/fmp_data/mcp/utils.py
@@ -340,9 +340,12 @@ def validate_api_key(api_key: str) -> tuple[bool, ApiKeyCheckReason]:
         return False, "invalid"
     except (TimeoutError, httpx.TimeoutException):
         return False, "timeout"
-    except FMPError:
-        # The key was accepted; the probe endpoint failed for another
-        # reason (rate limit, empty quote, …).
+    except FMPError as exc:
+        # base.py maps only 401 → AuthenticationError; 403 is a generic
+        # FMPError. The previous helper treated both as invalid. 429 /
+        # 5xx mean the key was accepted.
+        if exc.status_code in {401, 403}:
+            return False, "invalid"
         return True, "valid"
     except Exception:
         return False, "unavailable"

--- a/tests/unit/test_mcp_cli.py
+++ b/tests/unit/test_mcp_cli.py
@@ -1176,3 +1176,53 @@ class TestListLabelsAllThreeRetirementConcepts:
         assert DEPRECATED_TOOLS, "floor: no renames to check"
         for spec, replacement in sorted(DEPRECATED_TOOLS.items()):
             assert f"{spec} [DEPRECATED -> {replacement}]" in rendered
+
+
+class TestServerCheckPrinting:
+    """``fmp-mcp status`` / ``test`` must print sink-local literals (#319)."""
+
+    def test_failed_reason_does_not_flow_into_stdout(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from fmp_data.mcp.cli import _print_server_check
+
+        planted = "PLANTED_apikey_should_not_print"
+        _print_server_check(False, f"failed: apikey={planted}")
+
+        out = capsys.readouterr().out
+        assert planted not in out
+        assert out == "❌ MCP server test failed\n"
+
+    def test_started_and_passed_use_distinct_literals(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from fmp_data.mcp.cli import _print_server_check
+
+        _print_server_check(True, "started")
+        _print_server_check(True, "passed")
+
+        assert capsys.readouterr().out == (
+            "✅ MCP server test passed (server started)\n✅ MCP server test passed\n"
+        )
+
+    def test_test_command_does_not_echo_a_leaky_helper(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        import argparse
+
+        from fmp_data.mcp import cli as cli_mod
+        from fmp_data.mcp import utils as mcp_utils
+
+        planted = "PLANTED_cli_key"
+        monkeypatch.setenv("FMP_API_KEY", planted)
+
+        def leaky(api_key: str, manifest_path: str | None = None) -> tuple[bool, str]:
+            return False, f"MCP server test failed: stderr quoted {api_key}"
+
+        monkeypatch.setattr(mcp_utils, "test_mcp_server", leaky)
+
+        assert cli_mod.test_command(argparse.Namespace()) == 1
+        out = capsys.readouterr().out
+        assert planted not in out
+        assert "MCP server test failed: stderr" not in out
+        assert "❌ MCP server test failed" in out

--- a/tests/unit/test_mcp_cli.py
+++ b/tests/unit/test_mcp_cli.py
@@ -1226,3 +1226,33 @@ class TestServerCheckPrinting:
         assert planted not in out
         assert "MCP server test failed: stderr" not in out
         assert "❌ MCP server test failed" in out
+
+    def test_test_command_does_not_echo_create_app_exception(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        import argparse
+        import sys
+        import types
+
+        from fmp_data.mcp import cli as cli_mod
+        from fmp_data.mcp import utils as mcp_utils
+
+        planted = "PLANTED_create_app_key"
+        monkeypatch.setenv("FMP_API_KEY", planted)
+        monkeypatch.setattr(
+            mcp_utils,
+            "test_mcp_server",
+            lambda api_key, manifest_path=None: (True, "passed"),
+        )
+
+        def boom() -> None:
+            raise RuntimeError(f"create_app failed apikey={planted}")
+
+        fake_server = types.ModuleType("fmp_data.mcp.server")
+        fake_server.create_app = boom  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "fmp_data.mcp.server", fake_server)
+
+        assert cli_mod.test_command(argparse.Namespace()) == 0
+        out = capsys.readouterr().out
+        assert planted not in out
+        assert "Could not count tools" in out

--- a/tests/unit/test_mcp_utils.py
+++ b/tests/unit/test_mcp_utils.py
@@ -817,6 +817,21 @@ class TestValidateApiKey:
 
         assert mcp_utils.validate_api_key("KEY123") == (True, "valid")
 
+    def test_http_403_is_invalid(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from fmp_data.exceptions import FMPError
+
+        class ForbiddenClient(_FakeFmpClient):
+            def __init__(self, **kwargs: Any) -> None:
+                super().__init__(**kwargs)
+                self.company = _FakeCompany(
+                    raises=FMPError("unauthorized", status_code=403)
+                )
+
+        monkeypatch.setattr("fmp_data.client.FMPDataClient", ForbiddenClient)
+
+        assert mcp_utils.validate_api_key("BAD") == (False, "invalid")
+        assert ForbiddenClient.instances[-1].closed is True
+
     def test_unexpected_exception_is_unavailable_not_raised(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -934,7 +949,7 @@ def test_example_claude_desktop_copies_use_the_real_manifest_path() -> None:
     stale = "examples/mcp_configurations/"
     offenders: list[str] = []
     for path in sorted(root.rglob("*")):
-        if not path.is_file() or path.suffix not in {".py", ".md"}:
+        if not path.is_file() or path.suffix not in {".py", ".md", ".json"}:
             continue
         if stale in path.read_text(encoding="utf-8"):
             offenders.append(str(path.relative_to(root)))

--- a/tests/unit/test_mcp_utils.py
+++ b/tests/unit/test_mcp_utils.py
@@ -13,11 +13,12 @@ of these shapes while silently running their payload -- the marker file is
 what makes that distinguishable from a genuine refusal.
 
 The second is the setup helper surface (config path, config load/save,
-interpreter discovery, subprocess-backed checks). Those functions decide
-where the tool writes and what it reports back to the user, so they are
-tested through fakes for the OS-facing collaborators only -- ``platform``,
-``os.environ``, ``subprocess.run``, ``Path.exists`` -- never by faking the
-function under test.
+interpreter discovery, subprocess-backed server start, in-process API-key
+probe). Those functions decide where the tool writes and what it reports
+back to the user, so they are tested through fakes for the OS-facing
+collaborators only -- ``platform``, ``os.environ``, ``subprocess.run``,
+``FMPDataClient``, ``Path.exists`` -- never by faking the function under
+test. Helper return values are classified reasons, never stderr.
 """
 
 from __future__ import annotations
@@ -28,7 +29,7 @@ from pathlib import Path
 import platform
 import subprocess
 import sys
-from typing import Any
+from typing import Any, ClassVar
 
 import pytest
 
@@ -622,7 +623,7 @@ class TestRunMcpServerCheck:
         fake = _FakeRun(returncode=0, stdout="Server initialized successfully\n")
         monkeypatch.setattr(subprocess, "run", fake)
 
-        assert run_mcp_server_check("KEY123") == (True, "MCP server test passed")
+        assert run_mcp_server_check("KEY123") == (True, "passed")
 
         cmd, kwargs = fake.calls[0]
         assert cmd[0] == sys.executable
@@ -634,8 +635,8 @@ class TestRunMcpServerCheck:
         assert kwargs["env"]["FMP_API_KEY"] == "KEY123"  # pragma: allowlist secret
         assert "FMP_MCP_MANIFEST" not in kwargs["env"]
         assert kwargs["timeout"] == 5
-        # stderr is reported verbatim on failure, so decoded output is part
-        # of the contract, not an incidental kwarg.
+        # Output is captured so a key quoted on stderr never reaches the
+        # caller; the return is a classified reason, not that text (#319).
         assert kwargs["capture_output"] is True
         assert kwargs["text"] is True
         assert "FMP_API_KEY" not in os.environ
@@ -650,7 +651,7 @@ class TestRunMcpServerCheck:
 
         assert run_mcp_server_check("KEY123", manifest_path=manifest) == (
             True,
-            "MCP server test passed",
+            "passed",
         )
 
         env = fake.calls[0][1]["env"]
@@ -658,25 +659,23 @@ class TestRunMcpServerCheck:
         assert env["FMP_API_KEY"] == "KEY123"  # pragma: allowlist secret
         assert "FMP_MCP_MANIFEST" not in os.environ
 
-    def test_reports_stderr_on_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_nonzero_exit_is_failed_without_stderr(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.setattr(
-            subprocess, "run", _FakeRun(returncode=1, stderr="  ImportError: mcp  ")
+            subprocess,
+            "run",
+            _FakeRun(returncode=1, stderr="  ImportError: mcp apikey=KEY123  "),
         )
 
-        assert run_mcp_server_check("KEY123") == (
-            False,
-            "MCP server test failed: ImportError: mcp",
-        )
+        assert run_mcp_server_check("KEY123") == (False, "failed")
 
     def test_reports_unknown_error_when_stderr_is_empty(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setattr(subprocess, "run", _FakeRun(returncode=2, stderr=""))
 
-        assert run_mcp_server_check("KEY123") == (
-            False,
-            "MCP server test failed: Unknown error",
-        )
+        assert run_mcp_server_check("KEY123") == (False, "failed")
 
     def test_timeout_counts_as_a_started_server(
         self, monkeypatch: pytest.MonkeyPatch
@@ -687,10 +686,7 @@ class TestRunMcpServerCheck:
             _FakeRun(raises=subprocess.TimeoutExpired(cmd="py", timeout=5)),
         )
 
-        assert run_mcp_server_check("KEY123") == (
-            True,
-            "MCP server test passed (server started)",
-        )
+        assert run_mcp_server_check("KEY123") == (True, "started")
 
     def test_unexpected_exception_is_reported_not_raised(
         self, monkeypatch: pytest.MonkeyPatch
@@ -699,10 +695,7 @@ class TestRunMcpServerCheck:
             subprocess, "run", _FakeRun(raises=OSError("no such executable"))
         )
 
-        assert run_mcp_server_check("KEY123") == (
-            False,
-            "MCP server test failed: no such executable",
-        )
+        assert run_mcp_server_check("KEY123") == (False, "unavailable")
 
 
 # ---------------------------------------------------------------------------
@@ -724,91 +717,134 @@ class TestGetApiKeyFromEnv:
         assert mcp_utils.get_api_key_from_env() is None
 
 
+class _FakeCompany:
+    def __init__(self, quote: Any = None, raises: BaseException | None = None) -> None:
+        self.quote = quote
+        self.raises = raises
+        self.symbols: list[str] = []
+
+    def get_quote(self, symbol: str) -> Any:
+        self.symbols.append(symbol)
+        if self.raises is not None:
+            raise self.raises
+        return self.quote
+
+
+class _FakeFmpClient:
+    """Stand-in for ``FMPDataClient`` that records construction and close."""
+
+    instances: ClassVar[list[_FakeFmpClient]] = []
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self.closed = False
+        self.company = _FakeCompany()
+        type(self).instances.append(self)
+
+    def close(self) -> None:
+        self.closed = True
+
+
 class TestValidateApiKey:
-    def test_valid_key_reports_success_and_never_leaks_into_os_environ(
+    def test_valid_key_makes_an_authenticated_quote_probe(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.delenv("FMP_API_KEY", raising=False)
-        fake = _FakeRun(returncode=0, stdout="API key is valid\n")
-        monkeypatch.setattr(subprocess, "run", fake)
+        _FakeFmpClient.instances = []
+        monkeypatch.setattr("fmp_data.client.FMPDataClient", _FakeFmpClient)
 
-        assert mcp_utils.validate_api_key("KEY123") == (True, "API key is valid")
+        assert mcp_utils.validate_api_key("KEY123") == (True, "valid")
 
-        cmd, kwargs = fake.calls[0]
-        assert cmd[0] == sys.executable
-        # The probe must build a client from the environment -- otherwise a
-        # key that never reaches FMP would still be reported "valid".
-        assert cmd[1] == "-c"
-        assert "from fmp_data import FMPDataClient" in cmd[2]
-        assert "FMPDataClient.from_env()" in cmd[2]
-        assert kwargs["env"]["FMP_API_KEY"] == "KEY123"  # pragma: allowlist secret
-        assert kwargs["timeout"] == 10
-        assert kwargs["capture_output"] is True
-        assert kwargs["text"] is True
+        assert len(_FakeFmpClient.instances) == 1
+        client = _FakeFmpClient.instances[0]
+        assert client.kwargs["api_key"] == "KEY123"  # pragma: allowlist secret
+        assert client.kwargs["timeout"] == 10
+        assert client.kwargs["max_retries"] == 1
+        assert client.company.symbols == [mcp_utils._PROBE_SYMBOL]
+        assert client.closed is True
         assert "FMP_API_KEY" not in os.environ
 
-    @pytest.mark.parametrize("status", ["401", "403"])
-    def test_auth_status_codes_map_to_an_invalid_key_message(
-        self, monkeypatch: pytest.MonkeyPatch, status: str
-    ) -> None:
-        monkeypatch.setattr(
-            subprocess,
-            "run",
-            _FakeRun(returncode=1, stderr=f"AuthenticationError: {status} for url"),
-        )
-
-        assert mcp_utils.validate_api_key("BAD") == (
-            False,
-            "API key is invalid or expired",
-        )
-
-    def test_other_failures_surface_stderr(
+    def test_authentication_error_is_invalid(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr(
-            subprocess, "run", _FakeRun(returncode=1, stderr="ConnectionError: dns\n")
-        )
+        from fmp_data.exceptions import AuthenticationError
 
-        assert mcp_utils.validate_api_key("KEY123") == (
-            False,
-            "API key validation failed: ConnectionError: dns",
-        )
+        class AuthClient(_FakeFmpClient):
+            def __init__(self, **kwargs: Any) -> None:
+                super().__init__(**kwargs)
+                self.company = _FakeCompany(
+                    raises=AuthenticationError("nope", status_code=401)
+                )
 
-    def test_empty_stderr_falls_back_to_invalid_key_text(
+        monkeypatch.setattr("fmp_data.client.FMPDataClient", AuthClient)
+
+        assert mcp_utils.validate_api_key("BAD") == (False, "invalid")
+        assert AuthClient.instances[-1].closed is True
+
+    def test_config_error_is_invalid(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from fmp_data.exceptions import ConfigError
+
+        def boom(**kwargs: Any) -> None:
+            raise ConfigError("Invalid client configuration")
+
+        monkeypatch.setattr("fmp_data.client.FMPDataClient", boom)
+
+        assert mcp_utils.validate_api_key("") == (False, "invalid")
+
+    def test_timeout_is_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import httpx
+
+        class TimeoutClient(_FakeFmpClient):
+            def __init__(self, **kwargs: Any) -> None:
+                super().__init__(**kwargs)
+                self.company = _FakeCompany(raises=httpx.TimeoutException("slow"))
+
+        monkeypatch.setattr("fmp_data.client.FMPDataClient", TimeoutClient)
+
+        assert mcp_utils.validate_api_key("KEY123") == (False, "timeout")
+
+    def test_non_auth_fmp_error_still_counts_as_valid(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr(subprocess, "run", _FakeRun(returncode=1, stderr=""))
+        from fmp_data.exceptions import FMPError
 
-        assert mcp_utils.validate_api_key("KEY123") == (
-            False,
-            "API key validation failed: Invalid API key",
-        )
+        class BusyClient(_FakeFmpClient):
+            def __init__(self, **kwargs: Any) -> None:
+                super().__init__(**kwargs)
+                self.company = _FakeCompany(raises=FMPError("rate limited", 429))
 
-    def test_timeout_is_reported_as_a_timeout(
+        monkeypatch.setattr("fmp_data.client.FMPDataClient", BusyClient)
+
+        assert mcp_utils.validate_api_key("KEY123") == (True, "valid")
+
+    def test_unexpected_exception_is_unavailable_not_raised(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr(
-            subprocess,
-            "run",
-            _FakeRun(raises=subprocess.TimeoutExpired(cmd="py", timeout=10)),
-        )
+        class BrokenClient(_FakeFmpClient):
+            def __init__(self, **kwargs: Any) -> None:
+                super().__init__(**kwargs)
+                self.company = _FakeCompany(raises=OSError("network down"))
 
-        assert mcp_utils.validate_api_key("KEY123") == (
-            False,
-            "API key validation timed out",
-        )
+        monkeypatch.setattr("fmp_data.client.FMPDataClient", BrokenClient)
 
-    def test_unexpected_exception_is_reported_not_raised(
+        assert mcp_utils.validate_api_key("KEY123") == (False, "unavailable")
+
+    def test_return_never_embeds_exception_text(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr(
-            subprocess, "run", _FakeRun(raises=OSError("exec format error"))
-        )
+        planted = "PLANTED_key_xyzzy"
 
-        assert mcp_utils.validate_api_key("KEY123") == (
-            False,
-            "API key validation failed: exec format error",
-        )
+        class LeakyClient(_FakeFmpClient):
+            def __init__(self, **kwargs: Any) -> None:
+                super().__init__(**kwargs)
+                self.company = _FakeCompany(raises=OSError(f"refused apikey={planted}"))
+
+        monkeypatch.setattr("fmp_data.client.FMPDataClient", LeakyClient)
+
+        ok, reason = mcp_utils.validate_api_key(planted)
+        assert ok is False
+        assert reason == "unavailable"
+        assert planted not in reason
 
 
 # ---------------------------------------------------------------------------
@@ -835,7 +871,7 @@ class TestGetManifestChoices:
         monkeypatch.setattr(
             mcp_utils, "__file__", str(tmp_path / "fmp_data" / "mcp" / "utils.py")
         )
-        return tmp_path / "examples" / "mcp_configurations"
+        return tmp_path / "examples" / "mcp" / "configurations"
 
     @pytest.mark.parametrize("name", sorted(EXAMPLE_MANIFESTS))
     def test_each_choice_maps_to_its_own_file_and_only_when_present(
@@ -873,6 +909,36 @@ class TestGetManifestChoices:
         self._redirect_examples_root(monkeypatch, tmp_path)
 
         assert mcp_utils.get_manifest_choices() == {"default": None}
+
+    def test_repo_example_profiles_are_offered_when_present(self) -> None:
+        """The real checkout path, not a redirected fake tree (#320)."""
+        repo_examples = (
+            Path(__file__).resolve().parents[2] / "examples" / "mcp" / "configurations"
+        )
+        if not repo_examples.is_dir():
+            pytest.skip("example manifests are not shipped in this install")
+
+        choices = mcp_utils.get_manifest_choices()
+
+        assert "default" in choices
+        for name, filename in EXAMPLE_MANIFESTS.items():
+            expected = repo_examples / filename
+            if not expected.is_file():
+                pytest.fail(f"advertised example {filename} is missing")
+            assert choices[name] == str(expected)
+
+
+def test_example_claude_desktop_copies_use_the_real_manifest_path() -> None:
+    """The same stale path #320 fixed in the helper also lived in examples."""
+    root = Path(__file__).resolve().parents[2] / "examples" / "mcp" / "claude_desktop"
+    stale = "examples/mcp_configurations/"
+    offenders: list[str] = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.suffix not in {".py", ".md"}:
+            continue
+        if stale in path.read_text(encoding="utf-8"):
+            offenders.append(str(path.relative_to(root)))
+    assert not offenders, f"stale examples/mcp_configurations/ in {offenders}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Follow-up from #315 / #321. Three adjacent setup bugs:

- **#319** — `fmp-mcp status` / `test` still printed `test_mcp_server`'s return string. That string embedded subprocess stderr, which can quote the API key. Allowlisting the helper string is not enough (CodeQL still treats it as dataflow from getpass).
- **#317** — `validate_api_key` only constructed `FMPDataClient.from_env()` and closed it. A typed junk key reported success and the wizard would persist it.
- **#320** — `get_manifest_choices` looked in `examples/mcp_configurations/`. The real directory is `examples/mcp/configurations/`, so the wizard never offered trading / minimal / research / crypto.

Closes #319
Closes #317
Closes #320

## What changed

### Classified reasons (#319)
`validate_api_key` returns `valid | invalid | timeout | unavailable`.
`test_mcp_server` returns `passed | started | failed | unavailable`.
Neither embeds stderr or exception text.
`fmp-mcp status` / `test` map those reasons onto **sink-local string literals**. A helper return that still contained a key cannot reach stdout. `create_app` exceptions on the tool-count path are also not interpolated.

### Live probe (#317)
`validate_api_key` constructs `FMPDataClient(api_key=..., timeout=10, max_retries=1)` and calls `company.get_quote("AAPL")`. `AuthenticationError` / `ConfigError` / HTTP 401 or 403 → `invalid`. Non-auth `FMPError` (rate limit, empty quote) still counts as `valid` because the key was accepted.

### Example profiles (#320)
Runtime path is `examples/mcp/configurations/`. Tests redirect to that tree, assert the real checkout offers all four shipped manifests, and scan `.py` / `.md` / `.json` example copies for the stale path.

## Out of scope

- #316 (unify redaction implementations) — #328, merged
- #318 (CodeRabbit on `dev`) — #326, merged
- #329 (P3): 200-body `{"Error Message": "Invalid API KEY"}` with no `status_code` still classifies as `valid`

`closes #N` is inert on `dev`-base PRs; close the three issues by hand after merge if the links do not fire.
