### PR TITLE
fix(mcp): treat status-less Invalid API KEY as invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   client and calls `company.get_quote("AAPL")`; 401 and 403 map to
   `invalid`. Rate-limit / other HTTP errors still count as `valid`.
 
+- **`validate_api_key` treats a status-less `Invalid API KEY` body as
+  invalid (#329).** Live `/stable/quote` (and `/api/v3/quote`) now
+  return HTTP 401 for a junk key (probed 2026-08-15), which already
+  maps to `AuthenticationError`. `_check_error_response` still raises
+  a bare `FMPError` with no `status_code` if a 2xx JSON body is
+  `{"Error Message": "Invalid API KEY..."}`; that copy now classifies
+  as `invalid`. Unrelated status-less `FMPError`s still count as
+  `valid`.
+
 - **Setup wizard offers the example MCP profiles again (#320).**
   `get_manifest_choices` looks in `examples/mcp/configurations/` (the
   real directory). The example Claude Desktop script, JSON profiles,

--- a/fmp_data/mcp/utils.py
+++ b/fmp_data/mcp/utils.py
@@ -262,11 +262,8 @@ ApiKeyCheckReason = Literal["valid", "invalid", "timeout", "unavailable"]
 # works; AAPL is on every FMP plan that can call ``quote``.
 _PROBE_SYMBOL = "AAPL"
 
-# ``base._check_error_response`` raises a status-less ``FMPError`` when a
-# 2xx JSON body is ``{"Error Message": "Invalid API KEY..."}``. Live
-# ``/stable/quote`` now returns HTTP 401 for a junk key (probed 2026-08-15),
-# which already maps to ``AuthenticationError``. Keep matching the known
-# copy so a 200-body regression cannot report the key as valid (#329).
+# 2xx invalid-key bodies raise a status-less FMPError and must not
+# count as valid (#329).
 _INVALID_API_KEY_MESSAGE = re.compile(r"^invalid api key\b", re.IGNORECASE)
 
 
@@ -354,7 +351,6 @@ def validate_api_key(api_key: str) -> tuple[bool, ApiKeyCheckReason]:
         # 5xx mean the key was accepted.
         if exc.status_code in {401, 403}:
             return False, "invalid"
-        # 2xx bodies with the known invalid-key copy have no status_code.
         if exc.status_code is None and _INVALID_API_KEY_MESSAGE.match(
             (exc.message or "").strip()
         ):

--- a/fmp_data/mcp/utils.py
+++ b/fmp_data/mcp/utils.py
@@ -12,6 +12,7 @@ import json
 import os
 from pathlib import Path
 import platform
+import re
 import shutil
 import subprocess  # nosec B404
 import sys
@@ -261,6 +262,13 @@ ApiKeyCheckReason = Literal["valid", "invalid", "timeout", "unavailable"]
 # works; AAPL is on every FMP plan that can call ``quote``.
 _PROBE_SYMBOL = "AAPL"
 
+# ``base._check_error_response`` raises a status-less ``FMPError`` when a
+# 2xx JSON body is ``{"Error Message": "Invalid API KEY..."}``. Live
+# ``/stable/quote`` now returns HTTP 401 for a junk key (probed 2026-08-15),
+# which already maps to ``AuthenticationError``. Keep matching the known
+# copy so a 200-body regression cannot report the key as valid (#329).
+_INVALID_API_KEY_MESSAGE = re.compile(r"^invalid api key\b", re.IGNORECASE)
+
 
 def test_mcp_server(
     api_key: str, manifest_path: str | None = None
@@ -345,6 +353,11 @@ def validate_api_key(api_key: str) -> tuple[bool, ApiKeyCheckReason]:
         # FMPError. The previous helper treated both as invalid. 429 /
         # 5xx mean the key was accepted.
         if exc.status_code in {401, 403}:
+            return False, "invalid"
+        # 2xx bodies with the known invalid-key copy have no status_code.
+        if exc.status_code is None and _INVALID_API_KEY_MESSAGE.match(
+            (exc.message or "").strip()
+        ):
             return False, "invalid"
         return True, "valid"
     except Exception:

--- a/tests/unit/test_mcp_utils.py
+++ b/tests/unit/test_mcp_utils.py
@@ -817,6 +817,37 @@ class TestValidateApiKey:
 
         assert mcp_utils.validate_api_key("KEY123") == (True, "valid")
 
+    def test_statusless_invalid_api_key_copy_is_invalid(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A 200-body ``Error Message`` has no status_code (#329)."""
+        from fmp_data.exceptions import FMPError
+
+        class BodyClient(_FakeFmpClient):
+            def __init__(self, **kwargs: Any) -> None:
+                super().__init__(**kwargs)
+                self.company = _FakeCompany(raises=FMPError("Invalid API KEY"))
+
+        monkeypatch.setattr("fmp_data.client.FMPDataClient", BodyClient)
+
+        assert mcp_utils.validate_api_key("BAD") == (False, "invalid")
+        assert BodyClient.instances[-1].closed is True
+
+    def test_statusless_unrelated_fmp_error_is_still_valid(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Do not over-match every status-less 200 error body as invalid."""
+        from fmp_data.exceptions import FMPError
+
+        class OtherClient(_FakeFmpClient):
+            def __init__(self, **kwargs: Any) -> None:
+                super().__init__(**kwargs)
+                self.company = _FakeCompany(raises=FMPError("Legacy endpoint retired"))
+
+        monkeypatch.setattr("fmp_data.client.FMPDataClient", OtherClient)
+
+        assert mcp_utils.validate_api_key("KEY123") == (True, "valid")
+
     def test_http_403_is_invalid(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from fmp_data.exceptions import FMPError
 

--- a/tests/unit/test_mcp_utils.py
+++ b/tests/unit/test_mcp_utils.py
@@ -817,8 +817,15 @@ class TestValidateApiKey:
 
         assert mcp_utils.validate_api_key("KEY123") == (True, "valid")
 
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Invalid API KEY",
+            "Invalid API KEY. Feel free to create a Free API Key...",
+        ],
+    )
     def test_statusless_invalid_api_key_copy_is_invalid(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, monkeypatch: pytest.MonkeyPatch, message: str
     ) -> None:
         """A 200-body ``Error Message`` has no status_code (#329)."""
         from fmp_data.exceptions import FMPError
@@ -826,7 +833,7 @@ class TestValidateApiKey:
         class BodyClient(_FakeFmpClient):
             def __init__(self, **kwargs: Any) -> None:
                 super().__init__(**kwargs)
-                self.company = _FakeCompany(raises=FMPError("Invalid API KEY"))
+                self.company = _FakeCompany(raises=FMPError(message))
 
         monkeypatch.setattr("fmp_data.client.FMPDataClient", BodyClient)
 


### PR DESCRIPTION
Closes #329.

## Probe (2026-08-15)

The issue described a **200** body `{"Error Message": "Invalid API KEY"}` being treated as a valid key because `status_code is None`.

Live FMP no longer does that on the probe path `validate_api_key` uses:

| Request | Status | Body |
|---|---|---|
| `GET /stable/quote?symbol=AAPL&apikey=junk` | **401** | `{"Error Message": "Invalid API KEY. Feel free to create a Free API Key..."}` |
| `GET /api/v3/quote/AAPL?apikey=junk` | **401** | same |

HTTP 401 already becomes `AuthenticationError` in `handle_response` → `invalid`. The 200-body hole is not live on `/quote` today.

## What this PR still changes

`base._check_error_response` still raises a bare `FMPError(message)` with **no** `status_code` if a 2xx JSON body is that copy (other endpoints, or a FMP regression). `validate_api_key` now treats that known copy as `invalid`.

Unrelated status-less `FMPError`s (e.g. `"Legacy endpoint retired"`) still count as `valid`. 429 / 5xx still count as `valid`.

## Tests

- `FMPError("Invalid API KEY")` (no status) → `(False, "invalid")`
- status-less unrelated `FMPError` stays `(True, "valid")`

## Out of scope

Did not change `_check_error_response` globally (user picked isolated, wizard-local fix after the probe).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API-key validation for responses without a status code.
  * Errors containing “Invalid API KEY” are now correctly classified as invalid.
  * Other status-less errors continue to be treated as valid.

* **Documentation**
  * Added a changelog entry describing the updated API-key validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->