### PR TITLE
fix(sec): redact FMP_API_KEY= assignments on error bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (#330).** The #316 lookbehind skipped every `*_API_KEY=` assignment
   so wizard copy `export FMP_API_KEY="[YOUR_API_KEY]"` survived — and
   so did a real token in an HTTP error body. Prefixed names now match;
-  placeholder values (`[YOUR_API_KEY]`, `your_*key*`) are left alone.
+  only the wizard placeholder `[YOUR_API_KEY]` is left alone.
   Wizard 32-char / hex-40 heuristics stay off this path.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (sk-/32-char heuristics); those stay off HTTP error bodies so request
   ids are not blanked.
 
+- **`redact_credential_patterns` redacts `FMP_API_KEY=` assignments
+  (#330).** The #316 lookbehind skipped every `*_API_KEY=` assignment
+  so wizard copy `export FMP_API_KEY="[YOUR_API_KEY]"` survived — and
+  so did a real token in an HTTP error body. Prefixed names now match;
+  placeholder values (`[YOUR_API_KEY]`, `your_*key*`) are left alone.
+  Wizard 32-char / hex-40 heuristics stay off this path.
+
 ### Fixed
 
 - **MCP setup helpers no longer echo subprocess stderr (#319).**

--- a/fmp_data/_redaction.py
+++ b/fmp_data/_redaction.py
@@ -126,19 +126,16 @@ _URL_CREDENTIAL_RE = re.compile(
     re.IGNORECASE,
 )
 _URL_APIKEY_RE = re.compile(r"([?&]apikey=)[^&\s]+", re.IGNORECASE)
-# Matches ``apikey=``, ``api_key=``, ``FMP_API_KEY=``, ``my_api_key=``,
-# and ``"api_key":``. The previous ``(?<![A-Za-z0-9_])`` lookbehind
-# skipped every ``*_API_KEY=`` assignment so wizard copy
-# ``export FMP_API_KEY="[YOUR_API_KEY]"`` survived — and so did a real
-# token in an error body (#330). Placeholders are skipped in
-# ``_redact_assignment``.
+# Prefixed ``*_API_KEY=`` must match; only the wizard's instruction
+# value is skipped so ``export FMP_API_KEY="[YOUR_API_KEY]"`` stays
+# readable (#330).
 _ASSIGNMENT_RE = re.compile(
     r"([\"']?(?<![A-Za-z0-9])(?:[A-Za-z0-9]+_)*api_?key[\"']?\s*[=:]\s*[\"']?)"
     r"([^&\s\"'<>]+)([\"']?)",
     re.IGNORECASE,
 )
 _PLACEHOLDER_ASSIGNMENT_VALUE = re.compile(
-    r"^(\[[^\]]+\]|your[_-].*key(?:[_-].*)?|<your[_-].*>)$",
+    r"^\[YOUR_API_KEY\]$",
     re.IGNORECASE,
 )
 _ENCODED_RE = re.compile(r"(apikey%3[Dd])([^&\s\"'<>]+)", re.IGNORECASE)
@@ -154,7 +151,7 @@ _TEXT_MASK = "[REDACTED]"
 
 
 def _redact_assignment(match: re.Match[str]) -> str:
-    """Redact an assignment unless the value is wizard placeholder copy."""
+    """Redact an assignment unless the value is ``[YOUR_API_KEY]``."""
     value = match.group(2)
     if _PLACEHOLDER_ASSIGNMENT_VALUE.match(value):
         return match.group(0)

--- a/fmp_data/_redaction.py
+++ b/fmp_data/_redaction.py
@@ -126,12 +126,19 @@ _URL_CREDENTIAL_RE = re.compile(
     re.IGNORECASE,
 )
 _URL_APIKEY_RE = re.compile(r"([?&]apikey=)[^&\s]+", re.IGNORECASE)
-# Lookbehind keeps ``FMP_API_KEY="[YOUR_API_KEY]"`` (the wizard's
-# placeholder instruction) from matching as an assignment. Error bodies
-# use bare ``apikey=`` / ``api_key=`` / ``"api_key":``.
+# Matches ``apikey=``, ``api_key=``, ``FMP_API_KEY=``, ``my_api_key=``,
+# and ``"api_key":``. The previous ``(?<![A-Za-z0-9_])`` lookbehind
+# skipped every ``*_API_KEY=`` assignment so wizard copy
+# ``export FMP_API_KEY="[YOUR_API_KEY]"`` survived — and so did a real
+# token in an error body (#330). Placeholders are skipped in
+# ``_redact_assignment``.
 _ASSIGNMENT_RE = re.compile(
-    r"([\"']?(?<![A-Za-z0-9_])api_?key[\"']?\s*[=:]\s*[\"']?)"
+    r"([\"']?(?<![A-Za-z0-9])(?:[A-Za-z0-9]+_)*api_?key[\"']?\s*[=:]\s*[\"']?)"
     r"([^&\s\"'<>]+)([\"']?)",
+    re.IGNORECASE,
+)
+_PLACEHOLDER_ASSIGNMENT_VALUE = re.compile(
+    r"^(\[[^\]]+\]|your[_-].*key(?:[_-].*)?|<your[_-].*>)$",
     re.IGNORECASE,
 )
 _ENCODED_RE = re.compile(r"(apikey%3[Dd])([^&\s\"'<>]+)", re.IGNORECASE)
@@ -146,6 +153,14 @@ _KEY_SHAPED_RES = (
 _TEXT_MASK = "[REDACTED]"
 
 
+def _redact_assignment(match: re.Match[str]) -> str:
+    """Redact an assignment unless the value is wizard placeholder copy."""
+    value = match.group(2)
+    if _PLACEHOLDER_ASSIGNMENT_VALUE.match(value):
+        return match.group(0)
+    return f"{match.group(1)}{_TEXT_MASK}{match.group(3)}"
+
+
 def redact_credential_patterns(text: str) -> str:
     """Redact query/assignment/encoded credentials without the live secret.
 
@@ -155,7 +170,7 @@ def redact_credential_patterns(text: str) -> str:
     """
     result = _URL_CREDENTIAL_RE.sub(rf"\1{_TEXT_MASK}", text)
     result = _URL_APIKEY_RE.sub(rf"\1{_TEXT_MASK}", result)
-    result = _ASSIGNMENT_RE.sub(rf"\1{_TEXT_MASK}\3", result)
+    result = _ASSIGNMENT_RE.sub(_redact_assignment, result)
     return _ENCODED_RE.sub(rf"\1{_TEXT_MASK}", result)
 
 

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -388,6 +388,18 @@ def test_handle_response_does_not_blank_32_char_request_ids(client_config):
     assert token in repr(error.response)
 
 
+def test_handle_response_redacts_fmp_api_key_assignment(client_config):
+    """``FMP_API_KEY=`` on an error body must redact; request ids stay (#330)."""
+    planted = "PLANTED_error_body_fmp_key"
+    request_id = "A1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6"
+    body = f"<html>denied FMP_API_KEY={planted} request-id={request_id}</html>".encode()
+    error = _handle_body(client_config, 500, body)
+    rendered = repr(error.response)
+    assert planted not in rendered
+    assert "[REDACTED]" in rendered
+    assert request_id in rendered
+
+
 def test_get_error_details_handles_non_utf8_body():
     """Non-UTF-8 error bodies should not raise while extracting details."""
     request = httpx.Request("GET", "https://example.com")

--- a/tests/unit/test_redaction_rules.py
+++ b/tests/unit/test_redaction_rules.py
@@ -122,12 +122,16 @@ def test_pattern_api_redacts_query_assignment_and_encoded() -> None:
     encoded = "path?apikey%3Dnot-a-real-key-value"  # pragma: allowlist secret
     assert "not-a-real-key-value" not in redact_credential_patterns(encoded)
     assert "[REDACTED]" in redact_credential_patterns(encoded)
-    # Wizard instruction copy must survive: FMP_API_KEY is an env var name,
-    # not a bare apikey= assignment.
+    # Wizard instruction copy must survive: the value is a placeholder,
+    # not a live token (#316, #330).
     assert (
         redact_credential_patterns('export FMP_API_KEY="[YOUR_API_KEY]"')
         == 'export FMP_API_KEY="[YOUR_API_KEY]"'
     )
+    planted = "PLANTED_fmp_api_key_token"
+    assert planted not in redact_credential_patterns(f"FMP_API_KEY={planted}")
+    assert "[REDACTED]" in redact_credential_patterns(f"FMP_API_KEY={planted}")
+    assert planted not in redact_credential_patterns(f"my_api_key={planted}")
 
 
 def test_pattern_api_leaves_32_char_identifiers() -> None:

--- a/tests/unit/test_redaction_rules.py
+++ b/tests/unit/test_redaction_rules.py
@@ -122,16 +122,22 @@ def test_pattern_api_redacts_query_assignment_and_encoded() -> None:
     encoded = "path?apikey%3Dnot-a-real-key-value"  # pragma: allowlist secret
     assert "not-a-real-key-value" not in redact_credential_patterns(encoded)
     assert "[REDACTED]" in redact_credential_patterns(encoded)
-    # Wizard instruction copy must survive: the value is a placeholder,
-    # not a live token (#316, #330).
+    # Wizard instruction copy must survive: the value is the exact
+    # placeholder the setup wizard prints (#316, #330).
     assert (
         redact_credential_patterns('export FMP_API_KEY="[YOUR_API_KEY]"')
         == 'export FMP_API_KEY="[YOUR_API_KEY]"'
     )
     planted = "PLANTED_fmp_api_key_token"
+    quoted = 'export FMP_API_KEY="PLANTED_quoted_token"'  # pragma: allowlist secret
+    bracketed = "FMP_API_KEY=[PLANTED_BRACKETED]"  # pragma: allowlist secret
+    your_shaped = "FMP_API_KEY=your_actual_secret_key"  # pragma: allowlist secret
     assert planted not in redact_credential_patterns(f"FMP_API_KEY={planted}")
     assert "[REDACTED]" in redact_credential_patterns(f"FMP_API_KEY={planted}")
     assert planted not in redact_credential_patterns(f"my_api_key={planted}")
+    assert "PLANTED" not in redact_credential_patterns(quoted)
+    assert "[PLANTED_BRACKETED]" not in redact_credential_patterns(bracketed)
+    assert "your_actual_secret_key" not in redact_credential_patterns(your_shaped)
 
 
 def test_pattern_api_leaves_32_char_identifiers() -> None:


### PR DESCRIPTION
Closes #330.

## Why

`#316` / `#328` added a lookbehind so wizard copy `export FMP_API_KEY=\"[YOUR_API_KEY]\"` is not treated as an `apikey=` assignment. That lookbehind also meant HTTP error bodies containing `FMP_API_KEY=secret` or `my_api_key=secret` were **not** redacted by `redact_credential_patterns` / `base._redact_api_keys`.

Wizard prompts still exact-replace the held secret via `redact_held_secret`. The error-body path does not have the held secret.

## Fix

- Assignment pattern now matches prefixed names (`FMP_API_KEY=`, `my_api_key=`).
- Placeholder values (`[YOUR_API_KEY]`, `your_*key*`) are left alone so wizard instruction copy still survives.
- Wizard 32-char / hex-40 heuristics stay off the error-body path.

## Tests

- `test_redaction_rules.py`: planted `FMP_API_KEY=` / `my_api_key=` redact; `export FMP_API_KEY=\"[YOUR_API_KEY]\"` unchanged.
- `test_base.py`: pin next to `test_handle_response_does_not_blank_32_char_request_ids` — assignment redacts, request id stays.