### PR TITLE
feat(intelligence): add Senate and House trades-by-id lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- **Senate and House trades by member id (#323).**
+  `get_senate_trades_by_id` / `get_house_trades_by_id` (sync + async)
+  call `/stable/senate-trades-by-id` and `/stable/house-trades-by-id`
+  with query param `senateID`. Reuses `SenateTrade` / `HouseDisclosure`.
+  The docs example `S000033` currently returns an empty list; Whitehouse
+  `W000802` and Pelosi `P000197` return rows (probed 2026-08-15).
+
 ### Changed
 
 - **One module now owns credential display redaction (#316).**

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -10,7 +10,7 @@ All endpoints use the `/stable` prefix unless explicitly marked as `DIRECT` or `
 - [Market (36 endpoints)](#market)
 - [Fundamental (14 endpoints)](#fundamental)
 - [Technical (9 endpoints)](#technical)
-- [Market Intelligence (46 endpoints)](#market-intelligence)
+- [Market Intelligence (48 endpoints)](#market-intelligence)
 - [Institutional (24 endpoints)](#institutional)
 - [Investment (14 endpoints)](#investment)
 - [Alternative Markets (15 endpoints)](#alternative-markets)
@@ -167,7 +167,7 @@ All endpoints use the `/stable` prefix unless explicitly marked as `DIRECT` or `
 
 ## Market Intelligence
 
-### 46 endpoints
+### 48 endpoints
 
 | Endpoint | Path | Description |
 |----------|------|-------------|
@@ -194,6 +194,7 @@ All endpoints use the `/stable` prefix unless explicitly marked as `DIRECT` or `
 | `historical_social_sentiment` | `/stable/historical/social-sentiment` | **Removed** — raises `RemovedEndpointError` |
 | `house_latest` | `/stable/house-latest` | Get latest House financial disclosures |
 | `house_disclosure` | `/stable/house-trades` | Get House trading data by symbol |
+| `house_trades_by_id` | `/stable/house-trades-by-id` | Get House trading data by member id |
 | `house_trades_by_name` | `/stable/house-trades-by-name` | Get House trading data by name |
 | `ipo_calendar` | `/stable/ipos-calendar` | Get IPO calendar |
 | `crypto_news_symbol` | `/stable/news/crypto` | Search crypto news articles by trading pair |
@@ -211,6 +212,7 @@ All endpoints use the `/stable` prefix unless explicitly marked as `DIRECT` or `
 | `ratings_snapshot` | `/stable/ratings-snapshot` | Get current analyst ratings snapshot |
 | `senate_latest` | `/stable/senate-latest` | Get latest Senate financial disclosures |
 | `senate_trading` | `/stable/senate-trades` | Get Senate trading data by symbol |
+| `senate_trades_by_id` | `/stable/senate-trades-by-id` | Get Senate trading data by member id |
 | `senate_trades_by_name` | `/stable/senate-trades-by-name` | Get Senate trading data by name |
 | `senate_trading_rss` | `/stable/senate-trading-rss-feed` | Get Senate trading RSS feed |
 | `social_sentiment_changes` | `/stable/social-sentiments/change` | Get changes in social sentiment data |

--- a/docs/mcp/hosted.md
+++ b/docs/mcp/hosted.md
@@ -106,7 +106,7 @@ Hosted `endpoint` values are FMP path slugs, not our `client.method` specs.
 | `analyst` | 8 | `intelligence.grades*`, `company.price_target_*`, `company.analyst_estimates` | |
 | `calendar` | 9 | `intelligence` earnings/dividends/splits/IPO calendars | |
 | `news` | 10 | `intelligence` news / press-release tools | |
-| `senate` | 6 | `intelligence` senate/house trade tools | |
+| `senate` | 6 | `intelligence` senate/house trade tools | This client also ships trades-by-id (#323) |
 | `directory` | 11 | `market` lists / `company.symbol_changes` | |
 | `discountedCashFlow` | 4 | `fundamental.discounted_cash_flow`, levered + custom DCF | |
 | `economics` | 4 | `economics.*` | |

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -9,7 +9,7 @@ For full FMP endpoint coverage, use the Python client. The MCP tool catalog incl
 (everything with MCP semantics, loadable via an explicit manifest), followed by
 how many of those are in `DEFAULT_TOOLS` (what a default server registers).
 The two differ where a tool is deprecated, redundant, or too heavy for the
-default set — `224` catalog tools, `138` default.
+default set — `226` catalog tools, `140` default.
 
 **Withdrawn endpoints:** 22 tools name an FMP endpoint that no longer exists.
 Probed against the live `stable` API, every one of those paths returns 404, so
@@ -37,7 +37,7 @@ always be written in full: `crypto_quotes` (`alternative.crypto_quotes` vs
 - [Fundamental (14 tools, 12 default)](#fundamental)
 - [Index (6 tools, 0 default)](#index)
 - [Institutional (12 tools, 8 default)](#institutional)
-- [Intelligence (45 tools, 38 default)](#intelligence)
+- [Intelligence (47 tools, 40 default)](#intelligence)
 - [Investment (14 tools, 9 default)](#investment)
 - [Market (23 tools, 21 default)](#market)
 - [SEC (12 tools, 0 default)](#sec)
@@ -213,7 +213,7 @@ via a manifest; these return large payloads and several are CSV).
 
 ## Intelligence
 
-**45 tools** for news, sentiment, market events, and analyst ratings/grades (38 default).
+**47 tools** for news, sentiment, market events, and analyst ratings/grades (40 default).
 
 | Tool Key | Description |
 |----------|-------------|
@@ -245,6 +245,7 @@ via a manifest; these return large payloads and several are CSV).
 | `historical_social_sentiment` | **Removed / not in DEFAULT_TOOLS** — raises `RemovedEndpointError` |
 | `house_disclosure` | Access House of Representatives trading disclosures including transaction details, filing information, and trade specifics |
 | `house_latest` | Get the latest House financial disclosures with transaction details |
+| `house_trades_by_id` | Get House trading data filtered by member id |
 | `house_trades_by_name` | Get House trading data filtered by representative name |
 | `ipo_calendar` | Retrieve upcoming and recent IPO events including pricing details, offering sizes, and listing dates |
 | `press_releases` | Retrieve corporate press releases and official company announcements with detailed content and publication information |
@@ -254,6 +255,7 @@ via a manifest; these return large payloads and several are CSV).
 | `ratings_historical` | Retrieve historical analyst ratings for a company to track how the rating and its component scores changed over time |
 | `ratings_snapshot` | Get the current analyst rating snapshot for a company, including the overall rating and component scores |
 | `senate_latest` | Get the latest Senate financial disclosures with transaction details |
+| `senate_trades_by_id` | Get Senate trading data filtered by member id |
 | `senate_trades_by_name` | Get Senate trading data filtered by senator name |
 | `senate_trading` | Access Senate trading activity and disclosures including stock trades, transaction details, and filing information |
 | `senate_trading_rss` | Get real-time RSS feed of Senate trading disclosures including new filings and transaction updates |

--- a/fmp_data/intelligence/async_client.py
+++ b/fmp_data/intelligence/async_client.py
@@ -32,6 +32,7 @@ from fmp_data.intelligence.endpoints import (
     HISTORICAL_EARNINGS,
     HOUSE_DISCLOSURE,
     HOUSE_LATEST,
+    HOUSE_TRADES_BY_ID,
     HOUSE_TRADES_BY_NAME,
     IPO_CALENDAR,
     PRESS_RELEASES_BY_SYMBOL_ENDPOINT,
@@ -41,6 +42,7 @@ from fmp_data.intelligence.endpoints import (
     RATINGS_HISTORICAL,
     RATINGS_SNAPSHOT,
     SENATE_LATEST,
+    SENATE_TRADES_BY_ID,
     SENATE_TRADES_BY_NAME,
     SENATE_TRADING,
     STOCK_NEWS_ENDPOINT,
@@ -566,6 +568,17 @@ class AsyncMarketIntelligenceClient(AsyncEndpointGroup):
             SenateTrade,
         )
 
+    async def get_senate_trades_by_id(
+        self, senate_id: str, page: int = 0, limit: int = 100
+    ) -> list[SenateTrade]:
+        """Get Senate trading data by member id"""
+        return self._unwrap_list(
+            await self.client.request_async(
+                SENATE_TRADES_BY_ID, senate_id=senate_id, page=page, limit=limit
+            ),
+            SenateTrade,
+        )
+
     @deprecated(
         "senate-trading-rss-feed is dead. The live path senate-latest is "
         "already shipped as get_senate_latest(); this method is a leftover "
@@ -603,6 +616,17 @@ class AsyncMarketIntelligenceClient(AsyncEndpointGroup):
         """Get House trading data by name"""
         return self._unwrap_list(
             await self.client.request_async(HOUSE_TRADES_BY_NAME, name=name),
+            HouseDisclosure,
+        )
+
+    async def get_house_trades_by_id(
+        self, senate_id: str, page: int = 0, limit: int = 100
+    ) -> list[HouseDisclosure]:
+        """Get House trading data by member id"""
+        return self._unwrap_list(
+            await self.client.request_async(
+                HOUSE_TRADES_BY_ID, senate_id=senate_id, page=page, limit=limit
+            ),
             HouseDisclosure,
         )
 

--- a/fmp_data/intelligence/client.py
+++ b/fmp_data/intelligence/client.py
@@ -30,6 +30,7 @@ from fmp_data.intelligence.endpoints import (
     HISTORICAL_EARNINGS,
     HOUSE_DISCLOSURE,
     HOUSE_LATEST,
+    HOUSE_TRADES_BY_ID,
     HOUSE_TRADES_BY_NAME,
     IPO_CALENDAR,
     PRESS_RELEASES_BY_SYMBOL_ENDPOINT,
@@ -39,6 +40,7 @@ from fmp_data.intelligence.endpoints import (
     RATINGS_HISTORICAL,
     RATINGS_SNAPSHOT,
     SENATE_LATEST,
+    SENATE_TRADES_BY_ID,
     SENATE_TRADES_BY_NAME,
     SENATE_TRADING,
     STOCK_NEWS_ENDPOINT,
@@ -544,6 +546,17 @@ class MarketIntelligenceClient(EndpointGroup):
             self.client.request(SENATE_TRADES_BY_NAME, name=name), SenateTrade
         )
 
+    def get_senate_trades_by_id(
+        self, senate_id: str, page: int = 0, limit: int = 100
+    ) -> list[SenateTrade]:
+        """Get Senate trading data by member id"""
+        return self._unwrap_list(
+            self.client.request(
+                SENATE_TRADES_BY_ID, senate_id=senate_id, page=page, limit=limit
+            ),
+            SenateTrade,
+        )
+
     @deprecated(
         "senate-trading-rss-feed is dead. The live path senate-latest is "
         "already shipped as get_senate_latest(); this method is a leftover "
@@ -579,6 +592,17 @@ class MarketIntelligenceClient(EndpointGroup):
         """Get House trading data by name"""
         return self._unwrap_list(
             self.client.request(HOUSE_TRADES_BY_NAME, name=name), HouseDisclosure
+        )
+
+    def get_house_trades_by_id(
+        self, senate_id: str, page: int = 0, limit: int = 100
+    ) -> list[HouseDisclosure]:
+        """Get House trading data by member id"""
+        return self._unwrap_list(
+            self.client.request(
+                HOUSE_TRADES_BY_ID, senate_id=senate_id, page=page, limit=limit
+            ),
+            HouseDisclosure,
         )
 
     # Fundraising methods

--- a/fmp_data/intelligence/endpoints.py
+++ b/fmp_data/intelligence/endpoints.py
@@ -842,6 +842,39 @@ SENATE_TRADES_BY_NAME: Endpoint[SenateTrade] = Endpoint(
     response_model=SenateTrade,
 )
 
+SENATE_TRADES_BY_ID: Endpoint[SenateTrade] = Endpoint(
+    name="senate_trades_by_id",
+    path="senate-trades-by-id",
+    version=APIVersion.STABLE,
+    description="Get Senate trading data by member id",
+    mandatory_params=[
+        EndpointParam(
+            name="senate_id",
+            location=ParamLocation.QUERY,
+            param_type=ParamType.STRING,
+            description="FMP senate member id (wire key senateID)",
+            alias="senateID",
+        )
+    ],
+    optional_params=[
+        EndpointParam(
+            name="page",
+            location=ParamLocation.QUERY,
+            param_type=ParamType.INTEGER,
+            description="Page number",
+            default=0,
+        ),
+        EndpointParam(
+            name="limit",
+            location=ParamLocation.QUERY,
+            param_type=ParamType.INTEGER,
+            description="Number of results (max 250)",
+            default=100,
+        ),
+    ],
+    response_model=SenateTrade,
+)
+
 SENATE_TRADING_RSS: Endpoint[SenateTrade] = Endpoint(
     name="senate_trading_rss",
     path="senate-trading-rss-feed",
@@ -920,6 +953,42 @@ HOUSE_TRADES_BY_NAME: Endpoint[HouseDisclosure] = Endpoint(
         )
     ],
     optional_params=[],
+    response_model=HouseDisclosure,
+)
+
+HOUSE_TRADES_BY_ID: Endpoint[HouseDisclosure] = Endpoint(
+    name="house_trades_by_id",
+    path="house-trades-by-id",
+    version=APIVersion.STABLE,
+    description="Get House trading data by member id",
+    mandatory_params=[
+        EndpointParam(
+            name="senate_id",
+            location=ParamLocation.QUERY,
+            param_type=ParamType.STRING,
+            description=(
+                "FMP member id. House rows use the wire key senateID "
+                "(e.g. Pelosi is P000197)"
+            ),
+            alias="senateID",
+        )
+    ],
+    optional_params=[
+        EndpointParam(
+            name="page",
+            location=ParamLocation.QUERY,
+            param_type=ParamType.INTEGER,
+            description="Page number",
+            default=0,
+        ),
+        EndpointParam(
+            name="limit",
+            location=ParamLocation.QUERY,
+            param_type=ParamType.INTEGER,
+            description="Number of results (max 250)",
+            default=100,
+        ),
+    ],
     response_model=HouseDisclosure,
 )
 

--- a/fmp_data/intelligence/mapping.py
+++ b/fmp_data/intelligence/mapping.py
@@ -31,6 +31,7 @@ from fmp_data.intelligence.endpoints import (
     HISTORICAL_SOCIAL_SENTIMENT_ENDPOINT,
     HOUSE_DISCLOSURE,
     HOUSE_LATEST,
+    HOUSE_TRADES_BY_ID,
     HOUSE_TRADES_BY_NAME,
     IPO_CALENDAR,
     PRESS_RELEASES_BY_SYMBOL_ENDPOINT,
@@ -40,6 +41,7 @@ from fmp_data.intelligence.endpoints import (
     RATINGS_HISTORICAL,
     RATINGS_SNAPSHOT,
     SENATE_LATEST,
+    SENATE_TRADES_BY_ID,
     SENATE_TRADES_BY_NAME,
     SENATE_TRADING,
     SENATE_TRADING_RSS,
@@ -54,6 +56,7 @@ from fmp_data.lc.hints import (
     DATE_HINTS,
     LIMIT_HINT,
     PAGE_HINT,
+    SENATE_ID_HINT,
     SYMBOL_HINT,
 )
 from fmp_data.lc.models import (
@@ -82,10 +85,12 @@ INTELLIGENCE_ENDPOINT_MAP: dict[str, Endpoint[Any]] = {
     "get_senate_latest": SENATE_LATEST,
     "get_senate_trading": SENATE_TRADING,
     "get_senate_trades_by_name": SENATE_TRADES_BY_NAME,
+    "get_senate_trades_by_id": SENATE_TRADES_BY_ID,
     "get_senate_trading_rss": SENATE_TRADING_RSS,
     "get_house_latest": HOUSE_LATEST,
     "get_house_disclosure": HOUSE_DISCLOSURE,
     "get_house_trades_by_name": HOUSE_TRADES_BY_NAME,
+    "get_house_trades_by_id": HOUSE_TRADES_BY_ID,
     # Fundraising endpoints
     "get_crowdfunding_rss": CROWDFUNDING_RSS,
     "search_crowdfunding": CROWDFUNDING_SEARCH,
@@ -881,6 +886,45 @@ INTELLIGENCE_ENDPOINTS_SEMANTICS = {
             "amount": ResponseFieldInfo(
                 description="Trade amount range",
                 examples=["$1,001 - $15,000", "$15,001 - $50,000"],
+                related_terms=["value", "transaction size"],
+            ),
+        },
+        use_cases=[
+            "Member trade review",
+            "Political trading analysis",
+            "Compliance checks",
+        ],
+    ),
+    "house_trades_by_id": EndpointSemantics(
+        client_name="intelligence",
+        method_name="get_house_trades_by_id",
+        natural_description="Get House trading data filtered by member id",
+        example_queries=[
+            "House trades by senate id",
+            "Trades for P000197",
+            "Look up House trades by member id",
+        ],
+        related_terms=[
+            "house trades by id",
+            "senateID",
+            "member id trades",
+        ],
+        category=SemanticCategory.INTELLIGENCE,
+        sub_category="Government Trading",
+        parameter_hints={
+            "senate_id": SENATE_ID_HINT,
+            "page": PAGE_HINT,
+            "limit": LIMIT_HINT,
+        },
+        response_hints={
+            "symbol": ResponseFieldInfo(
+                description="Stock symbol",
+                examples=["UBER", "INTC"],
+                related_terms=["ticker", "company symbol"],
+            ),
+            "amount": ResponseFieldInfo(
+                description="Trade amount range",
+                examples=["$500,001 - $1,000,000", "$1,001 - $15,000"],
                 related_terms=["value", "transaction size"],
             ),
         },
@@ -1699,6 +1743,45 @@ INTELLIGENCE_ENDPOINTS_SEMANTICS = {
             "symbol": ResponseFieldInfo(
                 description="Stock symbol",
                 examples=["AAPL", "BRK/B"],
+                related_terms=["ticker", "company symbol"],
+            ),
+            "amount": ResponseFieldInfo(
+                description="Trade amount range",
+                examples=["$1,001 - $15,000", "$15,001 - $50,000"],
+                related_terms=["value", "transaction size"],
+            ),
+        },
+        use_cases=[
+            "Member trade review",
+            "Political trading analysis",
+            "Compliance checks",
+        ],
+    ),
+    "senate_trades_by_id": EndpointSemantics(
+        client_name="intelligence",
+        method_name="get_senate_trades_by_id",
+        natural_description="Get Senate trading data filtered by member id",
+        example_queries=[
+            "Senate trades by senate id",
+            "Trades for W000802",
+            "Look up Senate trades by member id",
+        ],
+        related_terms=[
+            "senate trades by id",
+            "senateID",
+            "member id trades",
+        ],
+        category=SemanticCategory.INTELLIGENCE,
+        sub_category="Government Trading",
+        parameter_hints={
+            "senate_id": SENATE_ID_HINT,
+            "page": PAGE_HINT,
+            "limit": LIMIT_HINT,
+        },
+        response_hints={
+            "symbol": ResponseFieldInfo(
+                description="Stock symbol",
+                examples=["LOW", "AAPL"],
                 related_terms=["ticker", "company symbol"],
             ),
             "amount": ResponseFieldInfo(

--- a/fmp_data/lc/hints.py
+++ b/fmp_data/lc/hints.py
@@ -337,6 +337,18 @@ PAGE_HINT = ParameterHint(
     ],
 )
 
+# FMP member id. House rows use the same wire key ``senateID`` (Pelosi is
+# ``P000197``).
+SENATE_ID_HINT = ParameterHint(
+    natural_names=["senate id", "senateID", "member id", "bioguide"],
+    extraction_patterns=[
+        r"(?i)\bsenate[_ ]?id[:\s]+([A-Z]\d{6})",
+        r"\b([A-Z]\d{6})\b",
+    ],
+    examples=["S000033", "P000197", "W000802"],
+    context_clues=["senate id", "member id", "bioguide", "congress member"],
+)
+
 SECTOR_HINT = ParameterHint(
     natural_names=["sector", "market sector", "industry sector"],
     extraction_patterns=[

--- a/fmp_data/mcp/tools_manifest.py
+++ b/fmp_data/mcp/tools_manifest.py
@@ -172,7 +172,7 @@ DEFAULT_TOOLS: list[str] = [
     "institutional.insider_trades",
     "institutional.institutional_holdings",
     "institutional.transaction_types",
-    # Intelligence (38 tools) - news, events, grades/ratings (#116)
+    # Intelligence (40 tools) - news, events, grades/ratings (#116)
     # Dead FMP endpoints intentionally omitted from defaults, all in
     # WITHDRAWN_TOOLS: earnings_confirmed, earnings_surprises and
     # stock_news_sentiments 404 with no successor at all, and
@@ -205,6 +205,7 @@ DEFAULT_TOOLS: list[str] = [
     "intelligence.historical_earnings",
     "intelligence.house_disclosure",
     "intelligence.house_latest",
+    "intelligence.house_trades_by_id",
     "intelligence.house_trades_by_name",
     "intelligence.ipo_calendar",
     "intelligence.press_releases",
@@ -215,6 +216,7 @@ DEFAULT_TOOLS: list[str] = [
     "intelligence.ratings_snapshot",
     "intelligence.senate_trading",
     "intelligence.senate_latest",
+    "intelligence.senate_trades_by_id",
     "intelligence.senate_trades_by_name",
     "intelligence.stock_news",
     "intelligence.stock_splits_calendar",

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -64,6 +64,8 @@ ALLOW_EMPTY: frozenset[tuple[str, str]] = frozenset(
         ("institutional", "get_holder_industry_breakdown"),
         ("intelligence", "get_senate_trades_by_name"),
         ("intelligence", "get_house_trades_by_name"),
+        ("intelligence", "get_senate_trades_by_id"),
+        ("intelligence", "get_house_trades_by_id"),
         ("intelligence", "search_crowdfunding"),
         ("intelligence", "get_crowdfunding_by_cik"),
         ("intelligence", "search_equity_offering"),
@@ -270,6 +272,7 @@ _FIXED_SAMPLES: dict[str, Any] = {
     "sicCode": "3571",
     "part": 0,
     "part_number": 0,
+    "senate_id": "P000197",
 }
 
 
@@ -333,6 +336,7 @@ _ALWAYS_FILL = frozenset(
 # override of ``timeframe`` and would stop matching their 1day cassettes.
 _METHOD_OVERRIDES: dict[tuple[str, str], dict[str, Any]] = {
     ("company", "get_intraday_prices"): {"interval": "5min"},
+    ("intelligence", "get_senate_trades_by_id"): {"senate_id": "W000802"},
 }
 
 # Public methods that never perform HTTP. Calling them under VCR in replay

--- a/tests/integration/test_intelligence.py
+++ b/tests/integration/test_intelligence.py
@@ -540,6 +540,22 @@ class TestIntelligenceEndpoints(BaseTestCase):
                     assert trade.first_name
                     assert trade.last_name
 
+    def test_get_senate_trades_by_id(self, fmp_client: FMPDataClient, vcr_instance):
+        """Docs example S000033 is empty; W000802 has rows (probed 2026-08-15)."""
+        with vcr_instance.use_cassette("intelligence/senate_trades_by_id.yaml"):
+            trades = self._handle_rate_limit(
+                fmp_client.intelligence.get_senate_trades_by_id,
+                "W000802",
+                page=0,
+                limit=5,
+            )
+
+            assert isinstance(trades, list)
+            assert trades
+            for trade in trades:
+                assert isinstance(trade, SenateTrade)
+                assert trade.senate_id == "W000802"
+
     def test_get_senate_trading_rss(self, fmp_client: FMPDataClient, vcr_instance):
         """Test getting senate trading RSS feed"""
         with vcr_instance.use_cassette("intelligence/senate_trading_rss.yaml"):
@@ -609,6 +625,21 @@ class TestIntelligenceEndpoints(BaseTestCase):
                     assert isinstance(disclosure, HouseDisclosure)
                     assert disclosure.first_name
                     assert disclosure.last_name
+
+    def test_get_house_trades_by_id(self, fmp_client: FMPDataClient, vcr_instance):
+        with vcr_instance.use_cassette("intelligence/house_trades_by_id.yaml"):
+            disclosures = self._handle_rate_limit(
+                fmp_client.intelligence.get_house_trades_by_id,
+                "P000197",
+                page=0,
+                limit=5,
+            )
+
+            assert isinstance(disclosures, list)
+            assert disclosures
+            for disclosure in disclosures:
+                assert isinstance(disclosure, HouseDisclosure)
+                assert disclosure.senate_id == "P000197"
 
     def test_get_crowdfunding_rss(self, fmp_client: FMPDataClient, vcr_instance):
         """Test getting latest crowdfunding offerings"""

--- a/tests/unit/test_intelligence.py
+++ b/tests/unit/test_intelligence.py
@@ -944,6 +944,24 @@ class TestMarketIntelligenceClientGovernment:
         _args, kwargs = mock_client.request.call_args
         assert kwargs["name"] == "Jerry"
 
+    def test_get_senate_trades_by_id(self, fmp_client, mock_client):
+        """senate_id is forwarded as senate_id, not a name= leftover (#323)."""
+        mock_client.request.return_value = []
+
+        _ = fmp_client.intelligence.get_senate_trades_by_id(
+            "W000802", page=0, limit=100
+        )
+
+        mock_client.request.assert_called_once()
+        _args, kwargs = mock_client.request.call_args
+        assert kwargs["senate_id"] == "W000802"
+        assert "name" not in kwargs
+        assert "symbol" not in kwargs
+        assert kwargs["page"] == 0
+        assert kwargs["limit"] == 100
+        assert _args[0].name == "senate_trades_by_id"
+        assert _args[0].path == "senate-trades-by-id"
+
     def test_get_senate_trading_rss_is_deprecated(self, fmp_client, mock_client):
         """``senate-trading-rss-feed`` 404s; ``senate-latest`` is the live feed."""
         with pytest.warns(DeprecationWarning, match="get_senate_latest"):
@@ -1017,6 +1035,36 @@ class TestMarketIntelligenceClientGovernment:
         mock_client.request.assert_called_once()
         _args, kwargs = mock_client.request.call_args
         assert kwargs["name"] == "James"
+
+    def test_get_house_trades_by_id(self, fmp_client, mock_client):
+        """senate_id is forwarded as senate_id, not a name= leftover (#323)."""
+        mock_client.request.return_value = []
+
+        _ = fmp_client.intelligence.get_house_trades_by_id("P000197", page=0, limit=100)
+
+        mock_client.request.assert_called_once()
+        _args, kwargs = mock_client.request.call_args
+        assert kwargs["senate_id"] == "P000197"
+        assert "name" not in kwargs
+        assert "symbol" not in kwargs
+        assert kwargs["page"] == 0
+        assert kwargs["limit"] == 100
+        assert _args[0].name == "house_trades_by_id"
+        assert _args[0].path == "house-trades-by-id"
+
+    def test_trades_by_id_query_uses_senateID_alias(self):
+        """Client kwargs use senate_id; the wire query key is senateID (#323)."""
+        from fmp_data.intelligence.endpoints import (
+            HOUSE_TRADES_BY_ID,
+            SENATE_TRADES_BY_ID,
+        )
+
+        for endpoint in (SENATE_TRADES_BY_ID, HOUSE_TRADES_BY_ID):
+            wire = endpoint.validate_params({"senate_id": "P000197", "page": 0})
+            assert wire["senateID"] == "P000197"
+            assert "senate_id" not in wire
+            assert "name" not in wire
+            assert "symbol" not in wire
 
     def test_senate_trade_senate_id_alias_round_trip(self):
         """senateID is a first-class SenateTrade field (#229)."""


### PR DESCRIPTION
Closes #323.
Part of #322.

## Why

Callers can read `senate_id` on a trade row but could not look up that member's trades by id.

## Probe (2026-08-15)

| Path | Params | Result |
|---|---|---|
| `/stable/senate-trades-by-id` | `senateID=S000033` (docs example) | 200, **empty** |
| `/stable/senate-trades-by-id` | `senateID=W000802` | 200, rows (`SenateTrade` shape) |
| `/stable/house-trades-by-id` | `senateID=P000197` | 200, rows (`HouseDisclosure` shape) |

House rows still use the wire key `senateID`.

## What landed

- `SENATE_TRADES_BY_ID` / `HOUSE_TRADES_BY_ID` on `/stable`
- Sync + async `get_senate_trades_by_id` / `get_house_trades_by_id`
- Mapping, MCP default tools, `docs/api/endpoints.md`, `docs/mcp/tools.md`
- No new public models
- Unit tests assert `senate_id=` is forwarded (not `name=` / `symbol=`) and `validate_params` emits `senateID`
- Integration tests record `W000802` / `P000197` and require a non-empty 200
- e2e harness samples `senate_id` (Senate override `W000802`)

## Isolated

#324 (profile/positions) and #325 (net-worth) stay out of this PR.