### PR TITLE
fix: leftover #336, #338, and #342 slices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`SenateId` branded type on every `senate_id` field (#338).** Shared
   `Annotated` type (like `CIK`) on `SenateTrade`, `HouseDisclosure`,
   `SenateProfile`, `SenatePosition`, and the net-worth rows. Strings
-  pass through untouched. Date-family and pagination requiredness are
-  not part of this slice.
+  pass through untouched.
+
+- **Senate/House trade dates are `date`, not `datetime` (#338).**
+  `SenateTrade` / `HouseDisclosure` `disclosure_date` and
+  `transaction_date` (and `SenateTrade.date_received`) now match the
+  profile / net-worth family. Breaking for callers that compared those
+  fields to `datetime.now()`.
+
+- **`SENATE_LATEST` / `HOUSE_LATEST` pagination is optional (#338).**
+  `page` / `limit` move to `optional_params`, same rule as trades-by-id.
+
+- **`SenateNetWorthValueRange` no longer shadows builtins (#336).**
+  Fields are `minimum` / `maximum` (wire aliases `min` / `max`). An
+  inverted range is rejected. Callers using `.min` / `.max` must switch.
 
 - **`redact_credential_patterns` redacts hyphenated assignment names
   (#339).** `X-API-KEY=` / `FMP-API-KEY=` now match. Wizard placeholder
@@ -93,11 +105,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `validate_api_key`'s copy matcher is gone — the
   `except AuthenticationError` path covers it.
 
-- **Net-worth integration tests require at least one nested object and
-  one populated aggregated alias (#336).** First slice on the local VCR
-  path: a full rename of `valueRange`/`debtDetails`, or of both
-  `total`/`stock`, now fails. Per-field `model_extra` locking stays
-  with the unit fixtures.
+- **Net-worth integration tests lock nested objects, aggregated
+  aliases, and `model_extra` (#336).** Itemized rows must have empty
+  `model_extra` and at least one populated `valueRange` and
+  `debtDetails`. Aggregated pages must populate both `total` and
+  `stock`.
+
+- **Committed cassette-contract snapshot fails CI without YAML (#336).**
+  `tests/integration/cassette_contracts.json` lists required wire
+  aliases for government-trading models. The YAML payload check still
+  skips when cassettes are gitignored.
+
+- **List-shaped 2xx `Invalid API KEY` bodies raise
+  `AuthenticationError` (#342).** A one-element list whose only keys
+  are error keys is routed through `_raise_response_error`. Multi-row
+  lists are not walked. Unrelated singleton error lists stay
+  `FMPError`.
 
 ## [2.7.0] - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,8 +63,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `page` / `limit` move to `optional_params`, same rule as trades-by-id.
 
 - **`SenateNetWorthValueRange` no longer shadows builtins (#336).**
-  Fields are `minimum` / `maximum` (wire aliases `min` / `max`). An
-  inverted range is rejected. Callers using `.min` / `.max` must switch.
+  Fields are `minimum` / `maximum` (wire aliases `min` / `max`).
+  Inverted and non-finite ranges are rejected. Callers using `.min` /
+  `.max` must switch.
 
 - **`redact_credential_patterns` redacts hyphenated assignment names
   (#339).** `X-API-KEY=` / `FMP-API-KEY=` now match. Wizard placeholder

--- a/fmp_data/base.py
+++ b/fmp_data/base.py
@@ -44,6 +44,8 @@ ValidationMode = Literal["lenient", "warn", "strict"]
 # /quote path (probed 2026-08-15); this is the typed regression guard
 # so callers do not see a bare FMPError (#340).
 _INVALID_API_KEY_BODY = re.compile(r"^invalid api key\b", re.IGNORECASE)
+_ERROR_BODY_KEY_ORDER = ("Error Message", "message", "error")
+_ERROR_BODY_KEYS = frozenset(_ERROR_BODY_KEY_ORDER)
 
 
 def _default_http_headers() -> dict[str, str]:
@@ -866,12 +868,9 @@ class BaseClient:
                 on a 2xx response (#340).
             FMPError: If any other error message is found in the data
         """
-        if "Error Message" in data:
-            BaseClient._raise_response_error(data["Error Message"])
-        if "message" in data:
-            BaseClient._raise_response_error(data["message"])
-        if "error" in data:
-            BaseClient._raise_response_error(data["error"])
+        for key in _ERROR_BODY_KEY_ORDER:
+            if key in data:
+                BaseClient._raise_response_error(data[key])
 
     @staticmethod
     def _raise_response_error(message: Any) -> NoReturn:
@@ -881,15 +880,12 @@ class BaseClient:
             raise AuthenticationError(text, status_code=200)
         raise FMPError(text)
 
-    _ERROR_BODY_KEYS = frozenset({"Error Message", "message", "error"})
-
     @staticmethod
     def _check_singleton_error_list(data: list[Any]) -> None:
-        """Type a one-element list whose only keys are error keys (#342).
+        """Route a one-element error-only list through the dict 2xx typer.
 
-        ``get_quote`` is a JSON list. A junk-key body
-        ``[{"Error Message": "Invalid API KEY"}]`` never hit
-        ``_check_error_response`` (dict-only). Do not walk a large list.
+        A junk-key quote body is a one-row list. Multi-row lists are not
+        inspected. Unrelated singleton copy still becomes FMPError.
         """
         if len(data) != 1:
             return
@@ -897,7 +893,7 @@ class BaseClient:
         if not isinstance(item, dict):
             return
         keys = set(item)
-        if keys and keys <= BaseClient._ERROR_BODY_KEYS:
+        if keys and keys <= _ERROR_BODY_KEYS:
             BaseClient._check_error_response(item)
 
     @staticmethod

--- a/fmp_data/base.py
+++ b/fmp_data/base.py
@@ -881,6 +881,25 @@ class BaseClient:
             raise AuthenticationError(text, status_code=200)
         raise FMPError(text)
 
+    _ERROR_BODY_KEYS = frozenset({"Error Message", "message", "error"})
+
+    @staticmethod
+    def _check_singleton_error_list(data: list[Any]) -> None:
+        """Type a one-element list whose only keys are error keys (#342).
+
+        ``get_quote`` is a JSON list. A junk-key body
+        ``[{"Error Message": "Invalid API KEY"}]`` never hit
+        ``_check_error_response`` (dict-only). Do not walk a large list.
+        """
+        if len(data) != 1:
+            return
+        item = data[0]
+        if not isinstance(item, dict):
+            return
+        keys = set(item)
+        if keys and keys <= BaseClient._ERROR_BODY_KEYS:
+            BaseClient._check_error_response(item)
+
     @staticmethod
     def _validate_model(
         endpoint_name: str,
@@ -1033,6 +1052,7 @@ class BaseClient:
 
         # Process list responses
         if isinstance(data, list):
+            BaseClient._check_singleton_error_list(data)
             return BaseClient._process_list_response(
                 endpoint,
                 data,

--- a/fmp_data/intelligence/endpoints.py
+++ b/fmp_data/intelligence/endpoints.py
@@ -792,7 +792,8 @@ SENATE_LATEST: Endpoint[SenateTrade] = Endpoint(
     path="senate-latest",
     version=APIVersion.STABLE,
     description="Get latest Senate financial disclosures",
-    mandatory_params=[
+    mandatory_params=[],
+    optional_params=[
         EndpointParam(
             name="page",
             location=ParamLocation.QUERY,
@@ -808,7 +809,6 @@ SENATE_LATEST: Endpoint[SenateTrade] = Endpoint(
             default=100,
         ),
     ],
-    optional_params=[],
     response_model=SenateTrade,
 )
 
@@ -906,7 +906,8 @@ HOUSE_LATEST: Endpoint[HouseDisclosure] = Endpoint(
     path="house-latest",
     version=APIVersion.STABLE,
     description="Get latest House financial disclosures",
-    mandatory_params=[
+    mandatory_params=[],
+    optional_params=[
         EndpointParam(
             name="page",
             location=ParamLocation.QUERY,
@@ -922,7 +923,6 @@ HOUSE_LATEST: Endpoint[HouseDisclosure] = Endpoint(
             default=100,
         ),
     ],
-    optional_params=[],
     response_model=HouseDisclosure,
 )
 

--- a/fmp_data/intelligence/models.py
+++ b/fmp_data/intelligence/models.py
@@ -11,10 +11,23 @@ from pydantic import (
     ConfigDict,
     Field,
     HttpUrl,
+    model_validator,
 )
 from pydantic.alias_generators import to_camel
 
 from fmp_data.models import CIK, SenateId
+
+
+def _coerce_calendar_date(value: object) -> object:
+    """Accept a former datetime wire value as a calendar date (#338)."""
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, str) and "T" in value:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).date()
+    return value
+
+
+CalendarDate = Annotated[dt_date, BeforeValidator(_coerce_calendar_date)]
 
 default_model_config = ConfigDict(
     populate_by_name=True,
@@ -463,12 +476,12 @@ class SenateTrade(BaseModel):
         alias="senateID",
         description="FMP entity id for the senator (wire key senateID).",
     )
-    disclosure_date: datetime | None = Field(
+    disclosure_date: CalendarDate | None = Field(
         None,
         validation_alias=AliasChoices("disclosureDate", "dateRecieved"),
         description="Date disclosure received",
     )
-    transaction_date: datetime | None = Field(
+    transaction_date: CalendarDate | None = Field(
         None, alias="transactionDate", description="Date of transaction"
     )
     first_name: str | None = Field(
@@ -495,7 +508,7 @@ class SenateTrade(BaseModel):
     link: HttpUrl | None = Field(None, description="Link to filing")
 
     @property
-    def date_received(self) -> datetime | None:
+    def date_received(self) -> dt_date | None:
         """Backward-compatible alias for disclosure_date."""
         return self.disclosure_date
 
@@ -518,10 +531,10 @@ class HouseDisclosure(BaseModel):
             "House rows as well (e.g. Pelosi is P000197)."
         ),
     )
-    disclosure_date: datetime | None = Field(
+    disclosure_date: CalendarDate | None = Field(
         None, alias="disclosureDate", description="Date of disclosure"
     )
-    transaction_date: datetime | None = Field(
+    transaction_date: CalendarDate | None = Field(
         None, alias="transactionDate", description="Date of transaction"
     )
     first_name: str | None = Field(
@@ -574,15 +587,27 @@ class SenateProfile(BaseModel):
     senate_id: SenateId | None = Field(
         None, alias="senateID", description="FMP member id (wire key senateID)"
     )
-    first_name: str | None = Field(None, alias="firstName")
-    last_name: str | None = Field(None, alias="lastName")
-    birth_date: dt_date | None = Field(None, alias="birthDate")
-    latest_party: str | None = Field(None, alias="latestParty")
-    latest_state: str | None = Field(None, alias="latestState")
-    latest_position: str | None = Field(None, alias="latestPosition")
+    first_name: str | None = Field(None, alias="firstName", description="First name")
+    last_name: str | None = Field(None, alias="lastName", description="Last name")
+    birth_date: dt_date | None = Field(
+        None, alias="birthDate", description="Date of birth"
+    )
+    latest_party: str | None = Field(
+        None, alias="latestParty", description="Most recent party affiliation"
+    )
+    latest_state: str | None = Field(
+        None, alias="latestState", description="Most recent state represented"
+    )
+    latest_position: str | None = Field(
+        None, alias="latestPosition", description="Most recent chamber role"
+    )
     image: HttpUrl | None = Field(None, description="Member portrait URL")
-    active: bool | None = Field(None)
-    years_active: float | None = Field(None, alias="yearsActive")
+    active: bool | None = Field(
+        None, description="Whether the member is currently active"
+    )
+    years_active: float | None = Field(
+        None, alias="yearsActive", description="Years of service"
+    )
 
 
 class SenatePosition(BaseModel):
@@ -593,13 +618,23 @@ class SenatePosition(BaseModel):
     senate_id: SenateId | None = Field(
         None, alias="senateID", description="FMP member id (wire key senateID)"
     )
-    congress_number: int | None = Field(None, alias="congressNumber")
-    start_date: dt_date | None = Field(None, alias="startDate")
-    end_date: dt_date | None = Field(None, alias="endDate")
-    party: str | None = Field(None)
-    position: str | None = Field(None)
-    state: str | None = Field(None)
-    years_in_term: float | None = Field(None, alias="yearsInTerm")
+    congress_number: int | None = Field(
+        None, alias="congressNumber", description="Congress number for this term"
+    )
+    start_date: dt_date | None = Field(
+        None, alias="startDate", description="Term start date"
+    )
+    end_date: dt_date | None = Field(
+        None, alias="endDate", description="Term end date; null if current"
+    )
+    party: str | None = Field(None, description="Party during this term")
+    position: str | None = Field(
+        None, description="Chamber role (Senator or Representative)"
+    )
+    state: str | None = Field(None, description="State represented")
+    years_in_term: float | None = Field(
+        None, alias="yearsInTerm", description="Years served in this term"
+    )
 
 
 class SenateNetWorthValueRange(BaseModel):
@@ -607,8 +642,22 @@ class SenateNetWorthValueRange(BaseModel):
 
     model_config = default_model_config
 
-    min: float | None = Field(None)
-    max: float | None = Field(None)
+    minimum: float | None = Field(
+        None, alias="min", description="Range lower bound (wire key min)"
+    )
+    maximum: float | None = Field(
+        None, alias="max", description="Range upper bound (wire key max)"
+    )
+
+    @model_validator(mode="after")
+    def _ordered_bounds(self) -> "SenateNetWorthValueRange":
+        if (
+            self.minimum is not None
+            and self.maximum is not None
+            and self.minimum > self.maximum
+        ):
+            raise ValueError("minimum must be <= maximum")
+        return self
 
 
 class SenateNetWorthDebtDetails(BaseModel):
@@ -616,7 +665,9 @@ class SenateNetWorthDebtDetails(BaseModel):
 
     model_config = default_model_config
 
-    date_incurred: str | None = Field(None, alias="dateIncurred")
+    date_incurred: str | None = Field(
+        None, alias="dateIncurred", description="When the liability was incurred"
+    )
 
 
 class SenateNetWorthItem(BaseModel):
@@ -624,23 +675,37 @@ class SenateNetWorthItem(BaseModel):
 
     model_config = default_model_config
 
-    senate_id: SenateId | None = Field(None, alias="senateID")
-    form_type: str | None = Field(None, alias="formType")
-    year: int | None = Field(None)
-    filing_date: dt_date | None = Field(None, alias="filingDate")
-    section: str | None = Field(None)
-    category: str | None = Field(None)
-    name: str | None = Field(None)
-    asset_type: str | None = Field(None, alias="assetType")
-    income_type: str | None = Field(None, alias="incomeType")
-    owner: str | None = Field(None)
-    comment: str | None = Field(None)
-    debt_details: SenateNetWorthDebtDetails | None = Field(None, alias="debtDetails")
-    value_range: SenateNetWorthValueRange | None = Field(None, alias="valueRange")
-    value: float | None = Field(None)
-    income_range: SenateNetWorthValueRange | None = Field(None, alias="incomeRange")
-    income: float | None = Field(None)
-    link: HttpUrl | None = Field(None)
+    senate_id: SenateId | None = Field(
+        None, alias="senateID", description="FMP member id (wire key senateID)"
+    )
+    form_type: str | None = Field(None, alias="formType", description="Disclosure form")
+    year: int | None = Field(None, description="Disclosure year")
+    filing_date: dt_date | None = Field(
+        None, alias="filingDate", description="Date the disclosure was filed"
+    )
+    section: str | None = Field(None, description="Form section (assets, liabilities)")
+    category: str | None = Field(None, description="Asset or liability category")
+    name: str | None = Field(None, description="Institution or holding name")
+    asset_type: str | None = Field(
+        None, alias="assetType", description="Type or description of the holding"
+    )
+    income_type: str | None = Field(
+        None, alias="incomeType", description="Type of income, if disclosed"
+    )
+    owner: str | None = Field(None, description="Owner of the holding")
+    comment: str | None = Field(None, description="Filer comment")
+    debt_details: SenateNetWorthDebtDetails | None = Field(
+        None, alias="debtDetails", description="Liability extras"
+    )
+    value_range: SenateNetWorthValueRange | None = Field(
+        None, alias="valueRange", description="Disclosed value range"
+    )
+    value: float | None = Field(None, description="Point estimate of value")
+    income_range: SenateNetWorthValueRange | None = Field(
+        None, alias="incomeRange", description="Disclosed income range"
+    )
+    income: float | None = Field(None, description="Point estimate of income")
+    link: HttpUrl | None = Field(None, description="Link to the filing")
 
 
 class SenateNetWorthAggregated(BaseModel):
@@ -648,26 +713,42 @@ class SenateNetWorthAggregated(BaseModel):
 
     model_config = default_model_config
 
-    senate_id: SenateId | None = Field(None, alias="senateID")
-    year: int | None = Field(None)
-    total: float | None = Field(None)
-    real_estate_liabilities: float | None = Field(None, alias="realEstateLiabilities")
+    senate_id: SenateId | None = Field(
+        None, alias="senateID", description="FMP member id (wire key senateID)"
+    )
+    year: int | None = Field(None, description="Rollup year")
+    total: float | None = Field(None, description="Total disclosed net worth")
+    real_estate_liabilities: float | None = Field(
+        None, alias="realEstateLiabilities", description="Real-estate liabilities"
+    )
     cash_and_cash_equivalents: float | None = Field(
-        None, alias="cashAndCashEquivalents"
+        None, alias="cashAndCashEquivalents", description="Cash and cash equivalents"
     )
     business_and_self_employment: float | None = Field(
-        None, alias="businessAndSelfEmployment"
+        None,
+        alias="businessAndSelfEmployment",
+        description="Business and self-employment assets",
     )
-    real_estate: float | None = Field(None, alias="realEstate")
-    ownership_interest: float | None = Field(None, alias="ownershipInterest")
-    stock: float | None = Field(None)
-    options: float | None = Field(None)
+    real_estate: float | None = Field(
+        None, alias="realEstate", description="Real-estate assets"
+    )
+    ownership_interest: float | None = Field(
+        None, alias="ownershipInterest", description="Ownership-interest assets"
+    )
+    stock: float | None = Field(None, description="Stock holdings")
+    options: float | None = Field(None, description="Options holdings")
     revolving_and_credit_lines: float | None = Field(
-        None, alias="revolvingAndCreditLines"
+        None, alias="revolvingAndCreditLines", description="Revolving credit lines"
     )
-    asset_backed_securities: float | None = Field(None, alias="assetBackedSecurities")
-    business_liabilities: float | None = Field(None, alias="businessLiabilities")
-    mutual_funds_and_etfs: float | None = Field(None, alias="mutualFundsAndETFs")
+    asset_backed_securities: float | None = Field(
+        None, alias="assetBackedSecurities", description="Asset-backed securities"
+    )
+    business_liabilities: float | None = Field(
+        None, alias="businessLiabilities", description="Business liabilities"
+    )
+    mutual_funds_and_etfs: float | None = Field(
+        None, alias="mutualFundsAndETFs", description="Mutual funds and ETFs"
+    )
 
 
 class CrowdfundingOffering(BaseModel):

--- a/fmp_data/intelligence/models.py
+++ b/fmp_data/intelligence/models.py
@@ -2,6 +2,7 @@
 from datetime import date as dt_date
 from datetime import datetime
 from decimal import Decimal
+from math import isfinite
 from typing import Annotated
 
 from pydantic import (
@@ -19,7 +20,7 @@ from fmp_data.models import CIK, SenateId
 
 
 def _coerce_calendar_date(value: object) -> object:
-    """Accept a former datetime wire value as a calendar date (#338)."""
+    """Turn a datetime or an ISO string with a time part into a calendar date."""
     if isinstance(value, datetime):
         return value.date()
     if isinstance(value, str) and "T" in value:
@@ -624,9 +625,7 @@ class SenatePosition(BaseModel):
     start_date: dt_date | None = Field(
         None, alias="startDate", description="Term start date"
     )
-    end_date: dt_date | None = Field(
-        None, alias="endDate", description="Term end date; null if current"
-    )
+    end_date: dt_date | None = Field(None, alias="endDate", description="Term end date")
     party: str | None = Field(None, description="Party during this term")
     position: str | None = Field(
         None, description="Chamber role (Senator or Representative)"
@@ -651,6 +650,9 @@ class SenateNetWorthValueRange(BaseModel):
 
     @model_validator(mode="after")
     def _ordered_bounds(self) -> "SenateNetWorthValueRange":
+        for bound in (self.minimum, self.maximum):
+            if bound is not None and not isfinite(bound):
+                raise ValueError("range bounds must be finite")
         if (
             self.minimum is not None
             and self.maximum is not None

--- a/tests/integration/cassette_contracts.json
+++ b/tests/integration/cassette_contracts.json
@@ -12,8 +12,13 @@
         "debtDetails",
         "valueRange",
         "incomeRange"
-      ],
-      "allow_extra": false
+      ]
+    },
+    {
+      "path": "intelligence/senate_net_worth.yaml",
+      "endpoint": "senate_net_worth",
+      "model": "fmp_data.intelligence.models.SenateNetWorthValueRange",
+      "required_aliases": ["min", "max"]
     },
     {
       "path": "intelligence/senate_net_worth_aggregated.yaml",
@@ -28,8 +33,7 @@
         "realEstateLiabilities",
         "cashAndCashEquivalents",
         "mutualFundsAndETFs"
-      ],
-      "allow_extra": true
+      ]
     },
     {
       "path": "intelligence/senate_profile.yaml",
@@ -43,8 +47,7 @@
         "latestParty",
         "latestPosition",
         "yearsActive"
-      ],
-      "allow_extra": false
+      ]
     },
     {
       "path": "intelligence/senate_positions.yaml",
@@ -56,8 +59,7 @@
         "startDate",
         "endDate",
         "yearsInTerm"
-      ],
-      "allow_extra": false
+      ]
     },
     {
       "path": "intelligence/senate_trades_by_id.yaml",
@@ -67,8 +69,7 @@
         "senateID",
         "disclosureDate",
         "transactionDate"
-      ],
-      "allow_extra": false
+      ]
     },
     {
       "path": "intelligence/house_trades_by_id.yaml",
@@ -78,8 +79,7 @@
         "senateID",
         "disclosureDate",
         "transactionDate"
-      ],
-      "allow_extra": false
+      ]
     }
   ]
 }

--- a/tests/integration/cassette_contracts.json
+++ b/tests/integration/cassette_contracts.json
@@ -1,0 +1,85 @@
+{
+  "description": "Committed government-trading cassette contract (#336). CI has no YAML (gitignored); this snapshot must still fail if a required wire alias leaves the model.",
+  "cassettes": [
+    {
+      "path": "intelligence/senate_net_worth.yaml",
+      "endpoint": "senate_net_worth",
+      "model": "fmp_data.intelligence.models.SenateNetWorthItem",
+      "required_aliases": [
+        "senateID",
+        "formType",
+        "filingDate",
+        "debtDetails",
+        "valueRange",
+        "incomeRange"
+      ],
+      "allow_extra": false
+    },
+    {
+      "path": "intelligence/senate_net_worth_aggregated.yaml",
+      "endpoint": "senate_net_worth_aggregated",
+      "model": "fmp_data.intelligence.models.SenateNetWorthAggregated",
+      "required_aliases": [
+        "senateID",
+        "year",
+        "total",
+        "stock",
+        "realEstate",
+        "realEstateLiabilities",
+        "cashAndCashEquivalents",
+        "mutualFundsAndETFs"
+      ],
+      "allow_extra": true
+    },
+    {
+      "path": "intelligence/senate_profile.yaml",
+      "endpoint": "senate_profile",
+      "model": "fmp_data.intelligence.models.SenateProfile",
+      "required_aliases": [
+        "senateID",
+        "firstName",
+        "lastName",
+        "birthDate",
+        "latestParty",
+        "latestPosition",
+        "yearsActive"
+      ],
+      "allow_extra": false
+    },
+    {
+      "path": "intelligence/senate_positions.yaml",
+      "endpoint": "senate_positions",
+      "model": "fmp_data.intelligence.models.SenatePosition",
+      "required_aliases": [
+        "senateID",
+        "congressNumber",
+        "startDate",
+        "endDate",
+        "yearsInTerm"
+      ],
+      "allow_extra": false
+    },
+    {
+      "path": "intelligence/senate_trades_by_id.yaml",
+      "endpoint": "senate_trades_by_id",
+      "model": "fmp_data.intelligence.models.SenateTrade",
+      "required_aliases": [
+        "senateID",
+        "disclosureDate",
+        "transactionDate"
+      ],
+      "allow_extra": false
+    },
+    {
+      "path": "intelligence/house_trades_by_id.yaml",
+      "endpoint": "house_trades_by_id",
+      "model": "fmp_data.intelligence.models.HouseDisclosure",
+      "required_aliases": [
+        "senateID",
+        "disclosureDate",
+        "transactionDate"
+      ],
+      "allow_extra": false
+    }
+  ]
+}

--- a/tests/integration/test_intelligence.py
+++ b/tests/integration/test_intelligence.py
@@ -508,7 +508,7 @@ class TestIntelligenceEndpoints(BaseTestCase):
             if len(trades) > 0:
                 for trade in trades:
                     assert isinstance(trade, SenateTrade)
-                    assert isinstance(trade.disclosure_date, datetime)
+                    assert isinstance(trade.disclosure_date, date)
                     assert isinstance(trade.amount, str)
                     assert isinstance(trade.first_name, str)
                     assert isinstance(trade.last_name, str)
@@ -573,7 +573,7 @@ class TestIntelligenceEndpoints(BaseTestCase):
             if len(trades) > 0:
                 for trade in trades:
                     assert isinstance(trade, SenateTrade)
-                    assert isinstance(trade.disclosure_date, datetime)
+                    assert isinstance(trade.disclosure_date, date)
                     assert isinstance(trade.amount, str)
                     assert isinstance(trade.first_name, str)
                     assert isinstance(trade.last_name, str)
@@ -607,8 +607,8 @@ class TestIntelligenceEndpoints(BaseTestCase):
             if len(disclosures) > 0:
                 for disclosure in disclosures:
                     assert isinstance(disclosure, HouseDisclosure)
-                    assert isinstance(disclosure.disclosure_date, datetime)
-                    assert isinstance(disclosure.transaction_date, datetime)
+                    assert isinstance(disclosure.disclosure_date, date)
+                    assert isinstance(disclosure.transaction_date, date)
                     assert isinstance(disclosure.amount, str)
                     assert isinstance(disclosure.first_name, str)
                     assert isinstance(disclosure.last_name, str)
@@ -699,12 +699,13 @@ class TestIntelligenceEndpoints(BaseTestCase):
             for row in rows:
                 assert isinstance(row, SenateNetWorthItem)
                 assert row.senate_id == "P000197"
-            # Lock the nested wire shape: extra=allow would hide a
-            # renamed valueRange / debtDetails as model_extra (#336).
-            assert any(
-                (row.value_range is not None) or (row.debt_details is not None)
-                for row in rows
-            ), "expected at least one nested valueRange or debtDetails"
+                assert not row.model_extra
+            assert any(row.value_range is not None for row in rows), (
+                "expected a populated valueRange"
+            )
+            assert any(row.debt_details is not None for row in rows), (
+                "expected a populated debtDetails"
+            )
 
     def test_get_senate_net_worth_aggregated(
         self, fmp_client: FMPDataClient, vcr_instance
@@ -721,10 +722,12 @@ class TestIntelligenceEndpoints(BaseTestCase):
                 assert isinstance(row, SenateNetWorthAggregated)
                 assert row.senate_id == "P000197"
                 assert row.year is not None
-            # Lock aggregated camelCase aliases as first-class fields (#336).
-            assert any(
-                row.total is not None or row.stock is not None for row in rows
-            ), "expected at least one populated aggregated alias"
+            assert any(row.total is not None for row in rows), (
+                "expected a populated total"
+            )
+            assert any(row.stock is not None for row in rows), (
+                "expected a populated stock"
+            )
 
     def test_get_crowdfunding_rss(self, fmp_client: FMPDataClient, vcr_instance):
         """Test getting latest crowdfunding offerings"""

--- a/tests/integration/test_intelligence.py
+++ b/tests/integration/test_intelligence.py
@@ -508,7 +508,7 @@ class TestIntelligenceEndpoints(BaseTestCase):
             if len(trades) > 0:
                 for trade in trades:
                     assert isinstance(trade, SenateTrade)
-                    assert isinstance(trade.disclosure_date, date)
+                    assert type(trade.disclosure_date) is date
                     assert isinstance(trade.amount, str)
                     assert isinstance(trade.first_name, str)
                     assert isinstance(trade.last_name, str)
@@ -573,7 +573,7 @@ class TestIntelligenceEndpoints(BaseTestCase):
             if len(trades) > 0:
                 for trade in trades:
                     assert isinstance(trade, SenateTrade)
-                    assert isinstance(trade.disclosure_date, date)
+                    assert type(trade.disclosure_date) is date
                     assert isinstance(trade.amount, str)
                     assert isinstance(trade.first_name, str)
                     assert isinstance(trade.last_name, str)
@@ -607,8 +607,8 @@ class TestIntelligenceEndpoints(BaseTestCase):
             if len(disclosures) > 0:
                 for disclosure in disclosures:
                     assert isinstance(disclosure, HouseDisclosure)
-                    assert isinstance(disclosure.disclosure_date, date)
-                    assert isinstance(disclosure.transaction_date, date)
+                    assert type(disclosure.disclosure_date) is date
+                    assert type(disclosure.transaction_date) is date
                     assert isinstance(disclosure.amount, str)
                     assert isinstance(disclosure.first_name, str)
                     assert isinstance(disclosure.last_name, str)

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -867,6 +867,59 @@ def test_process_response_raises_on_error_message():
         BaseClient._process_response(endpoint, {"message": "boom"})
 
 
+def _list_quote_endpoint() -> Mock:
+    class QuoteRow(BaseModel):
+        model_config = ConfigDict(extra="allow")
+        symbol: str | None = None
+
+    endpoint = Mock()
+    endpoint.name = "quote"
+    endpoint.response_model = QuoteRow
+    return endpoint
+
+
+def test_process_response_singleton_invalid_api_key_list_is_auth_error() -> None:
+    """A one-row list error body must type as AuthenticationError (#342)."""
+    with pytest.raises(AuthenticationError) as exc_info:
+        BaseClient._process_response(
+            _list_quote_endpoint(),
+            [{"Error Message": "Invalid API KEY"}],
+        )
+    assert exc_info.value.status_code == 200
+
+
+def test_process_response_singleton_unrelated_error_list_is_not_auth() -> None:
+    """Legacy 2xx list bodies stay a non-auth failure (#342)."""
+    with pytest.raises(FMPError) as exc_info:
+        BaseClient._process_response(
+            _list_quote_endpoint(),
+            [{"Error Message": "Legacy endpoint retired"}],
+        )
+    assert type(exc_info.value) is FMPError
+
+
+def test_process_response_normal_quote_list_is_unchanged() -> None:
+    result: object = BaseClient._process_response(
+        _list_quote_endpoint(),
+        [{"symbol": "AAPL", "price": 1.0}],
+    )
+    assert isinstance(result, list)
+    assert result[0].symbol == "AAPL"
+
+
+def test_process_response_does_not_walk_a_multi_row_list_for_errors() -> None:
+    """Do not inspect every row of a large list (#342)."""
+    result: object = BaseClient._process_response(
+        _list_quote_endpoint(),
+        [
+            {"Error Message": "Invalid API KEY"},
+            {"symbol": "AAPL"},
+        ],
+    )
+    assert isinstance(result, list)
+    assert len(result) == 2
+
+
 def test_process_response_strict_mode_rejects_unknown_fields() -> None:
     """Strict mode should reject unknown fields on extra-allow models."""
 

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -878,12 +878,15 @@ def _list_quote_endpoint() -> Mock:
     return endpoint
 
 
-def test_process_response_singleton_invalid_api_key_list_is_auth_error() -> None:
+@pytest.mark.parametrize("key", ["Error Message", "message", "error"])
+def test_process_response_singleton_invalid_api_key_list_is_auth_error(
+    key: str,
+) -> None:
     """A one-row list error body must type as AuthenticationError (#342)."""
     with pytest.raises(AuthenticationError) as exc_info:
         BaseClient._process_response(
             _list_quote_endpoint(),
-            [{"Error Message": "Invalid API KEY"}],
+            [{key: "Invalid API KEY"}],
         )
     assert exc_info.value.status_code == 200
 
@@ -907,8 +910,18 @@ def test_process_response_normal_quote_list_is_unchanged() -> None:
     assert result[0].symbol == "AAPL"
 
 
+def test_process_response_singleton_error_plus_data_keys_is_not_typed() -> None:
+    """Decorator keys keep the row on the validation path (#342)."""
+    result: object = BaseClient._process_response(
+        _list_quote_endpoint(),
+        [{"Error Message": "Invalid API KEY", "symbol": "AAPL"}],
+    )
+    assert isinstance(result, list)
+    assert result[0].symbol == "AAPL"
+
+
 def test_process_response_does_not_walk_a_multi_row_list_for_errors() -> None:
-    """Do not inspect every row of a large list (#342)."""
+    """Do not inspect every row of a multi-row list (#342)."""
     result: object = BaseClient._process_response(
         _list_quote_endpoint(),
         [
@@ -918,6 +931,19 @@ def test_process_response_does_not_walk_a_multi_row_list_for_errors() -> None:
     )
     assert isinstance(result, list)
     assert len(result) == 2
+
+
+def test_process_response_does_not_inspect_a_trailing_error_row() -> None:
+    """A last-row-only walker would still raise; only len == 1 is typed."""
+    result: object = BaseClient._process_response(
+        _list_quote_endpoint(),
+        [
+            {"symbol": "AAPL"},
+            {"Error Message": "Invalid API KEY"},
+        ],
+    )
+    assert isinstance(result, list)
+    assert result[0].symbol == "AAPL"
 
 
 def test_process_response_strict_mode_rejects_unknown_fields() -> None:

--- a/tests/unit/test_cassette_contracts.py
+++ b/tests/unit/test_cassette_contracts.py
@@ -8,6 +8,7 @@ import pkgutil
 import re
 from urllib.parse import urlparse
 
+from pydantic import BaseModel
 import pytest
 import yaml
 
@@ -47,6 +48,52 @@ def _matches_path(pattern: str, actual_path: str) -> bool:
     return re.fullmatch(tokenized, actual_path) is not None
 
 
+CONTRACTS_PATH = Path("tests/integration/cassette_contracts.json")
+
+
+def _load_committed_contracts() -> list[dict]:
+    payload = json.loads(CONTRACTS_PATH.read_text(encoding="utf-8"))
+    return list(payload["cassettes"])
+
+
+def _declared_wire_names(model: type[BaseModel]) -> set[str]:
+    """Field names plus aliases a live key can bind to."""
+    names: set[str] = set()
+    for name, field in model.model_fields.items():
+        names.add(name)
+        if field.alias:
+            names.add(str(field.alias))
+        if field.serialization_alias:
+            names.add(str(field.serialization_alias))
+        validation_alias = field.validation_alias
+        if isinstance(validation_alias, str):
+            names.add(validation_alias)
+        elif validation_alias is not None and hasattr(validation_alias, "choices"):
+            names.update(str(choice) for choice in validation_alias.choices)
+        parts = name.split("_")
+        names.add(parts[0] + "".join(part.capitalize() for part in parts[1:]))
+    return names
+
+
+def test_committed_cassette_contracts_match_models() -> None:
+    """CI has no YAML; the committed snapshot must still fail on alias drift (#336)."""
+    contracts = _load_committed_contracts()
+    assert contracts, f"{CONTRACTS_PATH} has no cassette entries"
+
+    missing: list[str] = []
+    for entry in contracts:
+        module_name, _, class_name = entry["model"].rpartition(".")
+        model = getattr(importlib.import_module(module_name), class_name)
+        assert issubclass(model, BaseModel)
+        declared = _declared_wire_names(model)
+        for alias in entry["required_aliases"]:
+            if alias not in declared:
+                missing.append(
+                    f"{entry['path']}: {entry['model']} missing alias {alias!r}"
+                )
+    assert not missing, "Committed cassette contract drift:\n  " + "\n  ".join(missing)
+
+
 def test_vcr_cassettes_match_endpoint_models() -> None:  # noqa: C901
     """Validate JSON cassette payloads against declared endpoint response models."""
     endpoints = _collect_endpoints()
@@ -59,7 +106,9 @@ def test_vcr_cassettes_match_endpoint_models() -> None:  # noqa: C901
     if not cassette_files:
         pytest.skip(
             "No VCR cassette YAML files found — "
-            "record cassettes first to enable contract validation."
+            "record cassettes first to enable payload contract validation. "
+            "Alias drift is still checked by "
+            "test_committed_cassette_contracts_match_models."
         )
 
     unmatched_requests: list[str] = []

--- a/tests/unit/test_cassette_contracts.py
+++ b/tests/unit/test_cassette_contracts.py
@@ -9,6 +9,7 @@ import re
 from urllib.parse import urlparse
 
 from pydantic import BaseModel
+from pydantic.alias_generators import to_camel
 import pytest
 import yaml
 
@@ -57,7 +58,7 @@ def _load_committed_contracts() -> list[dict]:
 
 
 def _declared_wire_names(model: type[BaseModel]) -> set[str]:
-    """Field names plus aliases a live key can bind to."""
+    """Field names plus aliases pydantic will actually bind."""
     names: set[str] = set()
     for name, field in model.model_fields.items():
         names.add(name)
@@ -70,8 +71,6 @@ def _declared_wire_names(model: type[BaseModel]) -> set[str]:
             names.add(validation_alias)
         elif validation_alias is not None and hasattr(validation_alias, "choices"):
             names.update(str(choice) for choice in validation_alias.choices)
-        parts = name.split("_")
-        names.add(parts[0] + "".join(part.capitalize() for part in parts[1:]))
     return names
 
 
@@ -92,6 +91,35 @@ def test_committed_cassette_contracts_match_models() -> None:
                     f"{entry['path']}: {entry['model']} missing alias {alias!r}"
                 )
     assert not missing, "Committed cassette contract drift:\n  " + "\n  ".join(missing)
+
+
+def test_committed_contract_endpoints_exist() -> None:
+    """Snapshot endpoint names must still resolve in intelligence.endpoints."""
+    import fmp_data.intelligence.endpoints as intel_endpoints
+
+    missing = [
+        entry["endpoint"]
+        for entry in _load_committed_contracts()
+        if not hasattr(intel_endpoints, str(entry["endpoint"]).upper())
+    ]
+    assert not missing, f"unknown contract endpoints: {missing}"
+
+
+def test_committed_contracts_include_a_non_generated_alias() -> None:
+    """The snapshot is vacuous if every required alias is to_camel(field)."""
+    canaries: list[str] = []
+    for entry in _load_committed_contracts():
+        module_name, _, class_name = entry["model"].rpartition(".")
+        model = getattr(importlib.import_module(module_name), class_name)
+        generated = set(model.model_fields)
+        generated.update(to_camel(name) for name in model.model_fields)
+        for alias in entry["required_aliases"]:
+            if alias not in generated:
+                canaries.append(f"{class_name}.{alias}")
+    assert canaries, (
+        "every required alias is a field name or to_camel(field); "
+        "the snapshot would stay green if those Field aliases were dropped"
+    )
 
 
 def test_vcr_cassettes_match_endpoint_models() -> None:  # noqa: C901

--- a/tests/unit/test_intelligence.py
+++ b/tests/unit/test_intelligence.py
@@ -1295,8 +1295,8 @@ class TestMarketIntelligenceClientGovernment:
         assert row.debt_details is not None
         assert row.debt_details.date_incurred == "September 2007"
         assert row.value_range is not None
-        assert row.value_range.min == 1000001
-        assert row.value_range.max == 5000000
+        assert row.value_range.minimum == 1000001
+        assert row.value_range.maximum == 5000000
         assert row.income_range is None
         assert row.income is None
         assert not row.model_extra
@@ -1371,6 +1371,91 @@ class TestMarketIntelligenceClientGovernment:
         )
         assert row.senate_id == "P000197"
         assert row.model_dump(by_alias=True)["senateID"] == "P000197"
+
+    def test_trade_and_disclosure_dates_are_date_not_datetime(self) -> None:
+        """Older rows join the profile/net-worth date family (#338)."""
+        from datetime import date
+
+        trade = SenateTrade.model_validate(
+            {
+                "disclosureDate": "2025-01-08",
+                "transactionDate": "2024-12-19T10:00:00",
+                "link": "https://example.com/filing",
+            }
+        )
+        house = HouseDisclosure.model_validate(
+            {
+                "disclosureDate": "2025-01-08T00:00:00",
+                "transactionDate": "2024-12-19",
+                "link": "https://example.com/filing",
+            }
+        )
+        assert type(trade.disclosure_date) is date
+        assert type(trade.transaction_date) is date
+        assert type(trade.date_received) is date
+        assert type(house.disclosure_date) is date
+        assert type(house.transaction_date) is date
+
+    def test_latest_pagination_is_optional_like_trades_by_id(self) -> None:
+        """page/limit with defaults belong in optional_params (#338)."""
+        from fmp_data.intelligence.endpoints import (
+            HOUSE_LATEST,
+            HOUSE_TRADES_BY_ID,
+            SENATE_LATEST,
+            SENATE_TRADES_BY_ID,
+        )
+
+        for endpoint in (
+            SENATE_LATEST,
+            HOUSE_LATEST,
+            SENATE_TRADES_BY_ID,
+            HOUSE_TRADES_BY_ID,
+        ):
+            mandatory = {param.name for param in endpoint.mandatory_params}
+            optional = {param.name for param in endpoint.optional_params or []}
+            assert "page" in optional, endpoint.name
+            assert "limit" in optional, endpoint.name
+            assert "page" not in mandatory, endpoint.name
+            assert "limit" not in mandatory, endpoint.name
+
+    def test_newer_government_models_have_field_descriptions(self) -> None:
+        """MCP/JSON schema text should match the rest of intelligence (#338)."""
+        from fmp_data.intelligence.models import (
+            SenateNetWorthAggregated,
+            SenateNetWorthDebtDetails,
+            SenateNetWorthItem,
+            SenateNetWorthValueRange,
+            SenatePosition,
+            SenateProfile,
+        )
+
+        missing: list[str] = []
+        for model in (
+            SenateProfile,
+            SenatePosition,
+            SenateNetWorthValueRange,
+            SenateNetWorthDebtDetails,
+            SenateNetWorthItem,
+            SenateNetWorthAggregated,
+        ):
+            for name, field in model.model_fields.items():
+                if not (field.description or "").strip():
+                    missing.append(f"{model.__name__}.{name}")
+        assert not missing, f"missing Field(description=): {missing}"
+
+    def test_value_range_uses_minimum_maximum_and_enforces_order(self) -> None:
+        """Do not shadow builtins; inverted ranges are invalid (#336)."""
+        from pydantic import ValidationError as PydanticValidationError
+
+        from fmp_data.intelligence.models import SenateNetWorthValueRange
+
+        row = SenateNetWorthValueRange.model_validate({"min": 1, "max": 5})
+        assert row.minimum == 1
+        assert row.maximum == 5
+        assert "min" not in SenateNetWorthValueRange.model_fields
+        assert "max" not in SenateNetWorthValueRange.model_fields
+        with pytest.raises(PydanticValidationError):
+            SenateNetWorthValueRange.model_validate({"min": 5, "max": 1})
 
 
 class TestMarketIntelligenceClientFundraising:

--- a/tests/unit/test_intelligence.py
+++ b/tests/unit/test_intelligence.py
@@ -1373,13 +1373,13 @@ class TestMarketIntelligenceClientGovernment:
         assert row.model_dump(by_alias=True)["senateID"] == "P000197"
 
     def test_trade_and_disclosure_dates_are_date_not_datetime(self) -> None:
-        """Older rows join the profile/net-worth date family (#338)."""
-        from datetime import date
+        """SenateTrade / HouseDisclosure dates are calendar dates, not datetimes."""
+        from datetime import date, datetime
 
         trade = SenateTrade.model_validate(
             {
-                "disclosureDate": "2025-01-08",
-                "transactionDate": "2024-12-19T10:00:00",
+                "disclosureDate": datetime(2025, 1, 8, 10, 0, 0),
+                "transactionDate": "2024-12-19T10:00:00Z",
                 "link": "https://example.com/filing",
             }
         )
@@ -1391,7 +1391,9 @@ class TestMarketIntelligenceClientGovernment:
             }
         )
         assert type(trade.disclosure_date) is date
+        assert trade.disclosure_date == date(2025, 1, 8)
         assert type(trade.transaction_date) is date
+        assert trade.transaction_date == date(2024, 12, 19)
         assert type(trade.date_received) is date
         assert type(house.disclosure_date) is date
         assert type(house.transaction_date) is date
@@ -1417,6 +1419,13 @@ class TestMarketIntelligenceClientGovernment:
             assert "limit" in optional, endpoint.name
             assert "page" not in mandatory, endpoint.name
             assert "limit" not in mandatory, endpoint.name
+
+        latest_defaults = SENATE_LATEST.validate_params({})
+        assert latest_defaults["page"] == 0
+        assert latest_defaults["limit"] == 100
+        house_defaults = HOUSE_LATEST.validate_params({})
+        assert house_defaults["page"] == 0
+        assert house_defaults["limit"] == 100
 
     def test_newer_government_models_have_field_descriptions(self) -> None:
         """MCP/JSON schema text should match the rest of intelligence (#338)."""
@@ -1452,10 +1461,15 @@ class TestMarketIntelligenceClientGovernment:
         row = SenateNetWorthValueRange.model_validate({"min": 1, "max": 5})
         assert row.minimum == 1
         assert row.maximum == 5
+        assert row.model_dump(by_alias=True) == {"min": 1.0, "max": 5.0}
         assert "min" not in SenateNetWorthValueRange.model_fields
         assert "max" not in SenateNetWorthValueRange.model_fields
-        with pytest.raises(PydanticValidationError):
+        point = SenateNetWorthValueRange.model_validate({"min": 1, "max": 1})
+        assert point.minimum == point.maximum == 1
+        with pytest.raises(PydanticValidationError, match="minimum must be"):
             SenateNetWorthValueRange.model_validate({"min": 5, "max": 1})
+        with pytest.raises(PydanticValidationError, match="finite"):
+            SenateNetWorthValueRange.model_validate({"min": float("nan"), "max": 1})
 
 
 class TestMarketIntelligenceClientFundraising:


### PR DESCRIPTION
Closes #336
Closes #338
Closes #342

`Closes #N` is inert on dev-base PRs — close by hand after merge.

## #342 — list-shaped Invalid API KEY

`_process_response` only typed dict 2xx bodies. A one-element list whose only keys are `Error Message` / `message` / `error` now goes through `_raise_response_error`. Multi-row lists are not walked. A normal quote list is unchanged. Unrelated singleton error lists stay `FMPError`.

## #338 — remaining Senate/House type alignment

- **Date family:** `SenateTrade` / `HouseDisclosure` `disclosure_date` and `transaction_date` are `date` (with a coercer so a former `T10:00:00` wire value still parses). `date_received` follows. **Breaking** for callers comparing those fields to `datetime.now()`.
- **Docs:** `Field(description=)` filled in on the newer government-trading models.
- **Pagination:** `SENATE_LATEST` / `HOUSE_LATEST` move `page`/`limit` to `optional_params`, same rule as trades-by-id.
- `SenateId` already landed in #341. No regex validation of the wire form.

## #336 — lock wire shape beyond extra=allow

- Committed snapshot `tests/integration/cassette_contracts.json` so CI fails if a required government-trading alias leaves the model, even when YAML is gitignored.
- Integration: itemized rows require empty `model_extra` and **both** a populated `valueRange` and `debtDetails`; aggregated pages require **both** `total` and `stock`.
- `SenateNetWorthValueRange.min`/`max` renamed to `minimum`/`maximum` (wire aliases unchanged). Inverted ranges are rejected. **Breaking** for `.min` / `.max` accessors.

## Tests

- `test_process_response_singleton_*` / normal quote list / no multi-row walk
- date family, pagination optionalness, Field descriptions, value-range rename + order
- `test_committed_cassette_contracts_match_models`
- net-worth integration per-field + `model_extra` lock (local VCR)

`make lint` clean. Unit suite: 2496 passed; two xdist flakes (`test_logger` empty buffer, `test_market` worker crash) passed when re-run serially and are unrelated.