### PR TITLE
fix(intelligence): make leftover RSS pagination optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`SENATE_LATEST` / `HOUSE_LATEST` pagination is optional (#338).**
   `page` / `limit` move to `optional_params`, same rule as trades-by-id.
 
+- **RSS pagination leftovers are optional (#345).**
+  `SENATE_TRADING_RSS.page`, `CROWDFUNDING_RSS` `page`/`limit`, and
+  adjacent `EQUITY_OFFERING_RSS` `page`/`limit` move to
+  `optional_params` so `validate_params({})` applies the documented
+  defaults. Not `PaginationArg` (1-based, different defaults).
+
 - **`SenateNetWorthValueRange` no longer shadows builtins (#336).**
   Fields are `minimum` / `maximum` (wire aliases `min` / `max`).
   Inverted and non-finite ranges are rejected. Callers using `.min` /

--- a/fmp_data/intelligence/endpoints.py
+++ b/fmp_data/intelligence/endpoints.py
@@ -888,7 +888,8 @@ SENATE_TRADING_RSS: Endpoint[SenateTrade] = Endpoint(
         "select it. The live senate-latest endpoint is already exposed as "
         "intelligence.get_senate_latest and returns the same rows."
     ),
-    mandatory_params=[
+    mandatory_params=[],
+    optional_params=[
         EndpointParam(
             name="page",
             location=ParamLocation.QUERY,
@@ -897,7 +898,6 @@ SENATE_TRADING_RSS: Endpoint[SenateTrade] = Endpoint(
             default=0,
         )
     ],
-    optional_params=[],
     response_model=SenateTrade,
 )
 
@@ -1161,7 +1161,8 @@ CROWDFUNDING_RSS: Endpoint[CrowdfundingOffering] = Endpoint(
     path="crowdfunding-offerings-latest",
     version=APIVersion.STABLE,
     description="Get latest crowdfunding offerings",
-    mandatory_params=[
+    mandatory_params=[],
+    optional_params=[
         EndpointParam(
             name="page",
             location=ParamLocation.QUERY,
@@ -1177,7 +1178,6 @@ CROWDFUNDING_RSS: Endpoint[CrowdfundingOffering] = Endpoint(
             default=100,
         ),
     ],
-    optional_params=[],
     response_model=CrowdfundingOffering,
 )
 
@@ -1220,7 +1220,8 @@ EQUITY_OFFERING_RSS: Endpoint[EquityOffering] = Endpoint(
     path="fundraising-latest",
     version=APIVersion.STABLE,
     description="Get latest equity offerings",
-    mandatory_params=[
+    mandatory_params=[],
+    optional_params=[
         EndpointParam(
             name="page",
             location=ParamLocation.QUERY,
@@ -1235,8 +1236,6 @@ EQUITY_OFFERING_RSS: Endpoint[EquityOffering] = Endpoint(
             description="Number of results",
             default=10,
         ),
-    ],
-    optional_params=[
         EndpointParam(
             name="cik",
             location=ParamLocation.QUERY,

--- a/tests/unit/test_intelligence.py
+++ b/tests/unit/test_intelligence.py
@@ -1427,6 +1427,32 @@ class TestMarketIntelligenceClientGovernment:
         assert house_defaults["page"] == 0
         assert house_defaults["limit"] == 100
 
+    def test_rss_pagination_is_optional_like_latest(self) -> None:
+        """Mandatory page/limit defaults never apply (#345)."""
+        from fmp_data.intelligence.endpoints import (
+            CROWDFUNDING_RSS,
+            EQUITY_OFFERING_RSS,
+            SENATE_TRADING_RSS,
+        )
+
+        crowd = CROWDFUNDING_RSS.validate_params({})
+        assert crowd["page"] == 0
+        assert crowd["limit"] == 100
+        equity = EQUITY_OFFERING_RSS.validate_params({})
+        assert equity["page"] == 0
+        assert equity["limit"] == 10
+        rss = SENATE_TRADING_RSS.validate_params({})
+        assert rss["page"] == 0
+
+        for endpoint in (CROWDFUNDING_RSS, EQUITY_OFFERING_RSS, SENATE_TRADING_RSS):
+            mandatory = {param.name for param in endpoint.mandatory_params}
+            optional = {param.name for param in endpoint.optional_params or []}
+            assert "page" in optional, endpoint.name
+            assert "page" not in mandatory, endpoint.name
+            if endpoint is not SENATE_TRADING_RSS:
+                assert "limit" in optional, endpoint.name
+                assert "limit" not in mandatory, endpoint.name
+
     def test_newer_government_models_have_field_descriptions(self) -> None:
         """MCP/JSON schema text should match the rest of intelligence (#338)."""
         from fmp_data.intelligence.models import (


### PR DESCRIPTION
Closes #345

`Closes #N` is inert on dev-base PRs — close by hand after merge.

Isolated follow-up from #343 / #338. Not bundled with #344 (2xx list bodies) or #346 (CalendarDate; closed with cassette evidence, no code).

## What

Requiredness is derived from list membership (#165): a mandatory param with a default still errors if omitted, so the dummy default never applies.

Move `page` / `limit` to `optional_params` (same rule as `SENATE_LATEST` / `HOUSE_LATEST` / trades-by-id):

- `SENATE_TRADING_RSS.page` (`default=0`; method is deprecated and still short-circuits to `[]`)
- `CROWDFUNDING_RSS` `page` / `limit` (`0` / `100`)
- **Adjacent, same pattern:** `EQUITY_OFFERING_RSS` `page` / `limit` (`0` / `10`)

`validate_params({})` now injects those defaults. Client methods already pass `page`/`limit`, so call-site behaviour is unchanged.

Not `PaginationArg` (1-based, different defaults). No `page >= 0` / limit-max factory — that stays a separate slice if we want it later.

## Tests

- `test_rss_pagination_is_optional_like_latest` asserts optional membership and `validate_params({})` defaults
- existing client-method unit tests unchanged

`ruff` clean. `tests/unit/test_intelligence.py`: 93 passed. Catalogue / requiredness tests: 33 passed.