### PR TITLE
fix(client): type residual list-shaped 2xx error bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   lists are not walked. Unrelated singleton error lists stay
   `FMPError`.
 
+- **Residual list-shaped 2xx error bodies type as
+  `AuthenticationError` (#344).** A one-element list with decorator
+  keys (`Error Message` plus data fields), a nested error value
+  (`{"message": "Invalid API KEY"}`), or a scalar
+  `["Invalid API KEY"]` now raises instead of falling through
+  validation. Mixed-key rows whose copy is not the junk-key body stay
+  on the validation path. Multi-row lists are still not walked.
+
 ## [2.7.0] - 2026-08-14
 
 Released from `dev`. A security-and-contracts minor in the same shape as

--- a/fmp_data/base.py
+++ b/fmp_data/base.py
@@ -46,6 +46,34 @@ ValidationMode = Literal["lenient", "warn", "strict"]
 _INVALID_API_KEY_BODY = re.compile(r"^invalid api key\b", re.IGNORECASE)
 _ERROR_BODY_KEY_ORDER = ("Error Message", "message", "error")
 _ERROR_BODY_KEYS = frozenset(_ERROR_BODY_KEY_ORDER)
+_ERROR_BODY_UNWRAP_DEPTH = 4
+
+
+def _is_invalid_api_key_text(message: Any) -> bool:
+    """True when the coerced 2xx body is the known invalid-key copy."""
+    return bool(_INVALID_API_KEY_BODY.match(_error_body_text(message).strip()))
+
+
+def _error_body_text(message: Any, *, depth: int = 0) -> str:
+    """Coerce a 2xx error-body value to text.
+
+    Nested dicts are walked along the known error keys so
+    ``{"message": "Invalid API KEY"}`` types as auth, not as a ``str()``
+    repr. Junk that is not on those keys stays a string — it is not
+    mapped to ``None`` (#344).
+    """
+    if depth > _ERROR_BODY_UNWRAP_DEPTH:
+        return str(message)
+    if isinstance(message, str):
+        return message
+    if isinstance(message, dict):
+        for key in _ERROR_BODY_KEY_ORDER:
+            if key in message:
+                return _error_body_text(message[key], depth=depth + 1)
+        return str(message)
+    if isinstance(message, (list, tuple)) and len(message) == 1:
+        return _error_body_text(message[0], depth=depth + 1)
+    return str(message)
 
 
 def _default_http_headers() -> dict[str, str]:
@@ -875,26 +903,51 @@ class BaseClient:
     @staticmethod
     def _raise_response_error(message: Any) -> NoReturn:
         """Raise a typed error for a 2xx JSON error body."""
-        text = str(message)
-        if _INVALID_API_KEY_BODY.match(text.strip()):
+        text = _error_body_text(message)
+        if _is_invalid_api_key_text(text):
             raise AuthenticationError(text, status_code=200)
         raise FMPError(text)
 
     @staticmethod
-    def _check_singleton_error_list(data: list[Any]) -> None:
-        """Route a one-element error-only list through the dict 2xx typer.
+    def _raise_decorator_invalid_key(item: dict[str, Any]) -> None:
+        """Type a mixed-key singleton only when the copy is the junk key."""
+        for key in _ERROR_BODY_KEY_ORDER:
+            if key in item:
+                if _is_invalid_api_key_text(item[key]):
+                    BaseClient._raise_response_error(item[key])
+                return
 
-        A junk-key quote body is a one-row list. Multi-row lists are not
-        inspected. Unrelated singleton copy still becomes FMPError.
+    @staticmethod
+    def _check_singleton_error_list(data: list[Any]) -> None:
+        """Type leftover one-element 2xx list bodies (#342, #344).
+
+        Multi-row lists are not inspected. A one-element list is typed
+        when it is:
+
+        * error-key-only (any copy → AuthenticationError or FMPError)
+        * a dict with decorator keys whose error value is the known
+          invalid-key copy (AuthenticationError). Unrelated mixed-key
+          rows stay on the validation path so a real quote that happens
+          to carry an ``error`` field is not turned into FMPError.
+        * a scalar string that matches the invalid-key copy
+          (AuthenticationError). Other scalars keep the first-field
+          fallback.
         """
         if len(data) != 1:
             return
         item = data[0]
-        if not isinstance(item, dict):
+        if isinstance(item, str):
+            if _is_invalid_api_key_text(item):
+                BaseClient._raise_response_error(item)
+            return
+        if not isinstance(item, dict) or not item:
             return
         keys = set(item)
-        if keys and keys <= _ERROR_BODY_KEYS:
+        if keys <= _ERROR_BODY_KEYS:
             BaseClient._check_error_response(item)
+            return
+        if keys & _ERROR_BODY_KEYS:
+            BaseClient._raise_decorator_invalid_key(item)
 
     @staticmethod
     def _validate_model(

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -910,11 +910,70 @@ def test_process_response_normal_quote_list_is_unchanged() -> None:
     assert result[0].symbol == "AAPL"
 
 
-def test_process_response_singleton_error_plus_data_keys_is_not_typed() -> None:
-    """Decorator keys keep the row on the validation path (#342)."""
+@pytest.mark.parametrize("key", ["Error Message", "message", "error"])
+def test_process_response_singleton_error_plus_data_keys_is_auth_error(
+    key: str,
+) -> None:
+    """Decorator keys plus the invalid-key copy type as auth (#344)."""
+    with pytest.raises(AuthenticationError) as exc_info:
+        BaseClient._process_response(
+            _list_quote_endpoint(),
+            [{key: "Invalid API KEY", "symbol": "AAPL"}],
+        )
+    assert exc_info.value.status_code == 200
+
+
+def test_process_response_singleton_unrelated_decorator_keys_stay_a_row() -> None:
+    """Mixed-key rows that are not the junk-key copy stay data (#344)."""
     result: object = BaseClient._process_response(
         _list_quote_endpoint(),
-        [{"Error Message": "Invalid API KEY", "symbol": "AAPL"}],
+        [{"Error Message": "Legacy endpoint retired", "symbol": "AAPL"}],
+    )
+    assert isinstance(result, list)
+    assert result[0].symbol == "AAPL"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"Error Message": {"message": "Invalid API KEY"}},
+        {"message": {"Error Message": "Invalid API KEY"}},
+        {"error": {"error": "invalid api key"}},
+        [{"Error Message": {"message": "Invalid API KEY"}}],
+    ],
+)
+def test_nested_invalid_api_key_value_is_authentication_error(
+    payload: object,
+) -> None:
+    """Nested error values unwrap instead of becoming a repr (#344)."""
+    with pytest.raises(AuthenticationError) as exc_info:
+        BaseClient._process_response(_list_quote_endpoint(), payload)
+    assert exc_info.value.status_code == 200
+
+
+def test_nested_junk_error_value_stays_fmp_error() -> None:
+    """Do not map an unrecognized nested body to None or to auth (#344)."""
+    with pytest.raises(FMPError) as exc_info:
+        BaseClient._check_error_response({"Error Message": {"foo": 1}})
+    assert type(exc_info.value) is FMPError
+    assert exc_info.value.status_code is None
+
+
+def test_process_response_singleton_invalid_api_key_scalar_is_auth_error() -> None:
+    """A one-element string list must not become the first model field (#344)."""
+    with pytest.raises(AuthenticationError) as exc_info:
+        BaseClient._process_response(
+            _list_quote_endpoint(),
+            ["Invalid API KEY"],
+        )
+    assert exc_info.value.status_code == 200
+
+
+def test_process_response_singleton_plain_scalar_keeps_first_field_fallback() -> None:
+    """Only the invalid-key scalar is typed; other strings stay data."""
+    result: object = BaseClient._process_response(
+        _list_quote_endpoint(),
+        ["AAPL"],
     )
     assert isinstance(result, list)
     assert result[0].symbol == "AAPL"


### PR DESCRIPTION
Closes #344

`Closes #N` is inert on dev-base PRs — close by hand after merge.

Isolated follow-up from #343 / #342. Not bundled with #345 (RSS pagination) or #346 (CalendarDate; closed with cassette evidence, no code).

## What

`_process_response` already typed a **one-element** list whose **only** keys are `Error Message` / `message` / `error`. These leftovers now type as well:

1. **Decorator keys.** `[{"Error Message": "Invalid API KEY", "symbol": "AAPL"}]` raises `AuthenticationError`. A mixed-key row whose copy is *not* the junk-key body stays on the validation path, so a real quote that happens to carry an `error` field is not turned into `FMPError`.
2. **Nested / non-string values.** `{"message": {"message": "Invalid API KEY"}}` unwraps along the known error keys instead of `str()`-repr and staying `FMPError`. Shared with the dict path. Unrecognized nested junk is still `FMPError`, not `None`.
3. **Scalar list bodies.** `["Invalid API KEY"]` raises `AuthenticationError` instead of becoming `Quote.symbol`. Other singleton strings keep the first-field fallback.

Multi-row lists are still not walked.

## Tests

- decorator-key invalid-key list is `AuthenticationError`
- mixed-key unrelated copy stays a quote row
- nested dict (and list-wrapped nested dict) is `AuthenticationError`
- unrecognized nested junk stays status-less `FMPError`
- scalar `["Invalid API KEY"]` is `AuthenticationError`; `["AAPL"]` still parses

`ruff` / `mypy` clean. `tests/unit/test_base.py` + `test_mcp_utils.py`: 239 passed.