### PR TITLE
fix(company): make leftover segmentation/report defaults optional (#349)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -294,7 +294,7 @@
         "filename": "tests/unit/test_async_clients.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 3157
+        "line_number": 3187
       }
     ],
     "tests/unit/test_base.py": [
@@ -497,5 +497,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-15T02:38:41Z"
+  "generated_at": "2026-08-17T13:06:20Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `optional_params` so `validate_params({})` applies the documented
   defaults. Not `PaginationArg` (1-based, different defaults).
 
+- **Company segmentation/report leftover defaults are optional (#349).**
+  `structure` / `period` on product and geographic revenue
+  segmentation, and `period` on financial-reports JSON/XLSX, move to
+  `optional_params` so `validate_params` applies the documented
+  defaults (`flat` / `annual` / `FY`). Segmentation methods now take
+  `structure: Structure = "flat"` (`Literal["flat", "nested"]`).
+  Stable currently returns the same list-of-objects for both
+  (probed 2026-08-17). `Structure` is not re-exported from
+  `fmp_data`. No remaining mandatory-plus-default params in the
+  catalogue.
+
 - **`SenateNetWorthValueRange` no longer shadows builtins (#336).**
   Fields are `minimum` / `maximum` (wire aliases `min` / `max`).
   Inverted and non-finite ranges are rejected. Callers using `.min` /

--- a/docs/superpowers/plans/2026-08-17-mandatory-defaults-structure.md
+++ b/docs/superpowers/plans/2026-08-17-mandatory-defaults-structure.md
@@ -1,0 +1,673 @@
+# Leftover mandatory defaults and `structure` exposure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the six leftover company mandatory-plus-default params to `optional_params`, expose `structure: Structure = "flat"` on the segmentation methods, and lock both the four endpoints and the catalogue-wide “no mandatory default” invariant (#349).
+
+**Architecture:** Requiredness is list membership (`validate_params` only injects defaults from `optional_params`). Add `Structure = Literal["flat", "nested"]` in `fmp_data/schema.py`, derive leftover `StructureTypeEnum` from it, then move the six params and pass `structure` through the client methods. Live `/stable` returns the same list-of-objects for `flat` and `nested` (probed 2026-08-17); do not add a second model.
+
+**Tech Stack:** Python 3.10+, Pydantic, pytest, ruff. Run tests with `uv run pytest`.
+
+**Spec:** `docs/superpowers/specs/2026-08-17-mandatory-defaults-structure-design.md`
+
+---
+
+## File map
+
+| File | Responsibility |
+|---|---|
+| `fmp_data/schema.py` | `Structure` Literal, `STRUCTURE_VALUES`, leftover `StructureTypeEnum` unpacked from the tuple |
+| `fmp_data/company/endpoints.py` | Move `structure` / `period` to `optional_params`; `structure.valid_values = list(STRUCTURE_VALUES)` |
+| `fmp_data/company/client.py` | Sync methods take `structure: Structure = "flat"` and pass it through |
+| `fmp_data/company/async_client.py` | Same signatures and pass-through |
+| `tests/unit/test_closed_vocabularies.py` | `Structure` Literal + leftover enum pins; `structure` client/endpoint walks. Do **not** add `Structure` to `__all__` |
+| `tests/unit/test_param_required_consistency.py` | Catalogue-wide: no mandatory param may carry a `default` |
+| `tests/unit/test_company.py` | Local membership + `validate_params` lock (RSS-test shape) |
+| `tests/unit/test_company_coverage.py` | Default `structure="flat"` on the wire; explicit `structure="nested"` query |
+| `tests/unit/lc/test_endpoint_method_coverage.py` | Empty `KNOWN_DROPPED_MANDATORY_WIRE` |
+| `tests/unit/lc/test_method_dispatch.py` | Fixture method accepts `structure`; bare partition expects optional |
+| `tests/unit/lc/test_tool_schema.py` | Rewrite stale “13 mandatory-with-default” comment |
+| `CHANGELOG.md` | Unreleased / Changed note |
+
+Do not edit: `fmp_data/mcp/tools_manifest.py`, VCR cassettes, `fmp_data/__init__.py`, `tests/e2e/harness.py` (`structure` is optional and not in `_ALWAYS_FILL`). Leave `test_tool_binding.py::test_partition_demotes_params_the_method_defaults` as the unmapped-omit unit (fake method without `structure`).
+
+Work on a branch off `dev`: `fix/349-company-mandatory-defaults`.
+
+---
+
+### Task 1: `Structure` Literal and leftover enum
+
+**Files:**
+- Modify: `fmp_data/schema.py`
+- Modify: `tests/unit/test_closed_vocabularies.py`
+
+- [ ] **Step 1: Write the failing type tests**
+
+In `tests/unit/test_closed_vocabularies.py`, add `STRUCTURE_VALUES` and `Structure` / `StructureTypeEnum` to the existing imports from `fmp_data.schema`.
+
+Append after `test_period_aliases_are_distinct_contracts`:
+
+```python
+def test_structure_alias_is_flat_or_nested() -> None:
+    assert literal_values(Structure) == ("flat", "nested")
+    assert literal_values(Structure) == STRUCTURE_VALUES
+```
+
+Extend `test_legacy_enums_match_the_literal_sets`:
+
+```python
+    assert tuple(member.value for member in StructureTypeEnum) == STRUCTURE_VALUES
+```
+
+Extend `test_legacy_enums_are_unpacked_from_the_literal_tuples` so the source scan also requires `STRUCTURE_VALUES` in `StructureTypeEnum`, and pin members:
+
+```python
+    assert "STRUCTURE_VALUES" in inspect.getsource(schema.StructureTypeEnum)
+    assert StructureTypeEnum.FLAT.value == "flat"
+    assert StructureTypeEnum.NESTED.value == "nested"
+```
+
+Add a dedicated walk (do **not** fold `structure` into `_closed_sets`, which is period/interval/timeframe only):
+
+```python
+def test_structure_endpoint_valid_values_come_from_the_literal() -> None:
+    found: list[str] = []
+    wrong: list[str] = []
+    for endpoint in _all_endpoints():
+        params = list(endpoint.mandatory_params) + list(endpoint.optional_params or [])
+        for param in params:
+            if param.name != "structure":
+                continue
+            found.append(endpoint.name)
+            values = tuple(str(v) for v in (param.valid_values or ()))
+            if values != STRUCTURE_VALUES:
+                wrong.append(f"{endpoint.name}.structure={values!r}")
+    assert found, "expected revenue-segmentation structure params"
+    assert not wrong, "structure valid_values drifted:\n  " + "\n  ".join(wrong)
+
+
+def test_client_structure_annotations_are_the_typed_literal() -> None:
+    untyped: list[str] = []
+    seen = 0
+    for root_cls in (FMPDataClient, AsyncFMPDataClient):
+        for group, method, func in _iter_group_methods(root_cls):
+            if "structure" not in bindable_params(func):
+                continue
+            seen += 1
+            hints = get_type_hints(func)
+            members = _annotation_members(hints.get("structure", inspect.Parameter.empty))
+            default = inspect.signature(func).parameters["structure"].default
+            if members != STRUCTURE_VALUES:
+                untyped.append(
+                    f"{root_cls.__name__}.{group}.{method} members={members!r}"
+                )
+            if default != "flat":
+                untyped.append(
+                    f"{root_cls.__name__}.{group}.{method} default={default!r}"
+                )
+    assert seen >= 4, f"expected sync+async product+geo methods, saw {seen}"
+    assert not untyped, "structure annotations drifted:\n  " + "\n  ".join(untyped)
+```
+
+Do **not** add `Structure` to `test_closed_vocabularies_are_public_exports`.
+
+- [ ] **Step 2: Run the new tests and confirm they fail**
+
+```bash
+uv run pytest tests/unit/test_closed_vocabularies.py::test_structure_alias_is_flat_or_nested tests/unit/test_closed_vocabularies.py::test_legacy_enums_match_the_literal_sets tests/unit/test_closed_vocabularies.py::test_legacy_enums_are_unpacked_from_the_literal_tuples tests/unit/test_closed_vocabularies.py::test_structure_endpoint_valid_values_come_from_the_literal tests/unit/test_closed_vocabularies.py::test_client_structure_annotations_are_the_typed_literal -v
+```
+
+Expected: `test_structure_alias_is_flat_or_nested` fails with `ImportError` / `NameError` (`Structure` / `STRUCTURE_VALUES` missing). The endpoint walk fails because `structure` has no `valid_values`. The client walk fails (`seen == 0`) because methods do not take `structure` yet — leave that failure until Task 4; **comment the client walk with `pytest.mark.skip(reason="Task 4: methods gain structure=")` only if you commit Task 1 alone**. Prefer committing Task 1 after the alias exists and running only the alias + leftover-enum tests now:
+
+```bash
+uv run pytest tests/unit/test_closed_vocabularies.py::test_structure_alias_is_flat_or_nested tests/unit/test_closed_vocabularies.py::test_legacy_enums_match_the_literal_sets tests/unit/test_closed_vocabularies.py::test_legacy_enums_are_unpacked_from_the_literal_tuples -v
+```
+
+Expected after adding the tests but before schema.py: FAIL (`Structure` not exported).
+
+- [ ] **Step 3: Add `Structure` and derive the leftover enum**
+
+In `fmp_data/schema.py`:
+
+1. **Delete** the current `StructureTypeEnum` class (it sits *above* the period Literals today, around the `FLAT = "flat"` / `NESTED = "nested"` block).
+2. After `TechnicalInterval: TypeAlias = Interval | IntervalAlias`, add:
+
+```python
+Structure: TypeAlias = Literal["flat", "nested"]
+```
+
+3. After `TECHNICAL_INTERVAL_VALUES: tuple[str, ...] = literal_values(TechnicalInterval)`, add:
+
+```python
+STRUCTURE_VALUES: tuple[str, ...] = literal_values(Structure)
+```
+
+4. After `STRUCTURE_VALUES` (and still before `ReportingPeriodEnum`), add:
+
+```python
+class StructureTypeEnum(BaseEnum):
+    """Data structure types.
+
+    Member *values* come from ``Structure``. Retired with the
+    deprecated arg models in 3.0 (#153, #307).
+    """
+
+    FLAT, NESTED = STRUCTURE_VALUES
+```
+
+`fmp_data/company/schema.py` keeps `from fmp_data.schema import StructureTypeEnum`. Do not add `Structure` to `fmp_data/__init__.py`.
+
+- [ ] **Step 4: Re-run the alias / leftover-enum tests**
+
+```bash
+uv run pytest tests/unit/test_closed_vocabularies.py::test_structure_alias_is_flat_or_nested tests/unit/test_closed_vocabularies.py::test_legacy_enums_match_the_literal_sets tests/unit/test_closed_vocabularies.py::test_legacy_enums_are_unpacked_from_the_literal_tuples tests/unit/test_closed_vocabularies.py::test_closed_vocabularies_are_public_exports -v
+```
+
+Expected: PASS. Public-export test still lists only Period / Interval / Timeframe / TechnicalInterval.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add fmp_data/schema.py tests/unit/test_closed_vocabularies.py
+git commit -m "feat(schema): add Structure Literal and derive leftover enum"
+```
+
+---
+
+### Task 2: Failing locks (catalogue-wide + local)
+
+**Files:**
+- Modify: `tests/unit/test_param_required_consistency.py`
+- Modify: `tests/unit/test_company.py`
+
+- [ ] **Step 1: Write the catalogue-wide lock**
+
+Add after `test_required_is_derived_from_list_membership` in `tests/unit/test_param_required_consistency.py`:
+
+```python
+def test_mandatory_params_do_not_carry_defaults() -> None:
+    """A default on a mandatory param never applies (#165 / #349)."""
+    leftovers: list[str] = []
+    checked = 0
+    for module_name, attr, endpoint in _endpoints():
+        for param in endpoint.mandatory_params:
+            checked += 1
+            if param.default is not None:
+                leftovers.append(
+                    f"{module_name}.{attr}.{param.name}: default={param.default!r}"
+                )
+    assert not leftovers, (
+        "mandatory params with a default never apply; move them to "
+        "optional_params:\n  " + "\n  ".join(leftovers)
+    )
+    assert checked >= _MIN_PARAMS, (
+        f"only {checked} mandatory params inspected; is the walk working? "
+        f"skipped: {SKIPPED_MODULES}"
+    )
+```
+
+- [ ] **Step 2: Run it and confirm it fails on the six leftovers**
+
+```bash
+uv run pytest tests/unit/test_param_required_consistency.py::test_mandatory_params_do_not_carry_defaults -v
+```
+
+Expected: FAIL, message names `PRODUCT_REVENUE_SEGMENTATION.structure`, `.period`, `GEOGRAPHIC_REVENUE_SEGMENTATION.structure`, `.period`, `FINANCIAL_REPORTS_JSON.period`, `FINANCIAL_REPORTS_XLSX.period`.
+
+- [ ] **Step 3: Write the local company lock**
+
+At the end of `tests/unit/test_company.py` add:
+
+```python
+class TestSegmentationAndReportDefaults:
+    """Mandatory structure/period defaults never apply (#349)."""
+
+    def test_segmentation_structure_and_period_are_optional(self) -> None:
+        from fmp_data.company.endpoints import (
+            GEOGRAPHIC_REVENUE_SEGMENTATION,
+            PRODUCT_REVENUE_SEGMENTATION,
+        )
+        from fmp_data.exceptions import ValidationError as FMPValidationError
+        from fmp_data.schema import STRUCTURE_VALUES
+
+        for endpoint in (
+            PRODUCT_REVENUE_SEGMENTATION,
+            GEOGRAPHIC_REVENUE_SEGMENTATION,
+        ):
+            mandatory = {param.name for param in endpoint.mandatory_params}
+            optional = {param.name for param in endpoint.optional_params or []}
+            assert mandatory == {"symbol"}, endpoint.name
+            assert "structure" in optional, endpoint.name
+            assert "period" in optional, endpoint.name
+            assert "structure" not in mandatory, endpoint.name
+            assert "period" not in mandatory, endpoint.name
+            injected = endpoint.validate_params({"symbol": "AAPL"})
+            assert injected["symbol"] == "AAPL"
+            assert injected["structure"] == "flat"
+            assert injected["period"] == "annual"
+            structure = next(
+                param
+                for param in (endpoint.optional_params or [])
+                if param.name == "structure"
+            )
+            assert tuple(str(v) for v in (structure.valid_values or ())) == (
+                STRUCTURE_VALUES
+            )
+            with pytest.raises(FMPValidationError, match="Must be one of"):
+                endpoint.validate_params({"symbol": "AAPL", "structure": "tree"})
+
+    def test_report_period_is_optional(self) -> None:
+        from fmp_data.company.endpoints import (
+            FINANCIAL_REPORTS_JSON,
+            FINANCIAL_REPORTS_XLSX,
+        )
+        from fmp_data.exceptions import ValidationError as FMPValidationError
+
+        for endpoint in (FINANCIAL_REPORTS_JSON, FINANCIAL_REPORTS_XLSX):
+            mandatory = {param.name for param in endpoint.mandatory_params}
+            optional = {param.name for param in endpoint.optional_params or []}
+            assert mandatory == {"symbol", "year"}, endpoint.name
+            assert "period" in optional, endpoint.name
+            assert "period" not in mandatory, endpoint.name
+            injected = endpoint.validate_params({"symbol": "AAPL", "year": 2024})
+            assert injected["period"] == "FY"
+            with pytest.raises(FMPValidationError, match="Missing mandatory parameter"):
+                endpoint.validate_params({"symbol": "AAPL"})
+```
+
+- [ ] **Step 4: Run the local lock and confirm it fails**
+
+```bash
+uv run pytest tests/unit/test_company.py::TestSegmentationAndReportDefaults -v
+```
+
+Expected: FAIL (`structure` / `period` still in `mandatory_params`; `validate_params({"symbol": "AAPL"})` raises `Missing mandatory parameter: structure`).
+
+- [ ] **Step 5: Commit the failing tests**
+
+```bash
+git add tests/unit/test_param_required_consistency.py tests/unit/test_company.py
+git commit -m "test: lock leftover mandatory defaults on company endpoints"
+```
+
+(If pre-commit runs the whole suite and refuses a red commit, keep the tests uncommitted and land them with Task 3.)
+
+---
+
+### Task 3: Move the six params and clear the LC allowlist
+
+**Files:**
+- Modify: `fmp_data/company/endpoints.py`
+- Modify: `tests/unit/lc/test_endpoint_method_coverage.py`
+- Modify: `tests/unit/lc/test_method_dispatch.py`
+- Modify: `tests/unit/lc/test_tool_schema.py`
+
+Moving `structure` out of `mandatory_params` makes `KNOWN_DROPPED_MANDATORY_WIRE` **stale** immediately (that guard only walks mandatory params). Empty the allowlist in this task, before the methods grow `structure=`.
+
+- [ ] **Step 1: Import `STRUCTURE_VALUES` and move the params**
+
+In `fmp_data/company/endpoints.py` add `STRUCTURE_VALUES` to the `fmp_data.schema` import.
+
+Replace `PRODUCT_REVENUE_SEGMENTATION` so `mandatory_params` is only `symbol` and `optional_params` is:
+
+```python
+    optional_params=[
+        EndpointParam(
+            name="structure",
+            location=ParamLocation.QUERY,
+            param_type=ParamType.STRING,
+            description="Data structure format",
+            default="flat",
+            valid_values=list(STRUCTURE_VALUES),
+        ),
+        EndpointParam(
+            name="period",
+            location=ParamLocation.QUERY,
+            param_type=ParamType.STRING,
+            description="Annual or quarterly data",
+            default="annual",
+            valid_values=list(PERIOD_ANNUAL_QUARTER_VALUES),
+        ),
+    ],
+```
+
+Same split for `GEOGRAPHIC_REVENUE_SEGMENTATION` (keep its description / `response_model` / `example_queries`).
+
+For `FINANCIAL_REPORTS_JSON` and `FINANCIAL_REPORTS_XLSX`, keep `symbol` and `year` in `mandatory_params` (no defaults). Move `period` to:
+
+```python
+    optional_params=[
+        EndpointParam(
+            name="period",
+            location=ParamLocation.QUERY,
+            param_type=ParamType.STRING,
+            description="Report period (FY or Q1-Q4)",
+            default="FY",
+            valid_values=list(PERIOD_FISCAL_VALUES),
+        ),
+    ],
+```
+
+- [ ] **Step 2: Empty `KNOWN_DROPPED_MANDATORY_WIRE`**
+
+In `tests/unit/lc/test_endpoint_method_coverage.py`:
+
+- Change the header comment `2 dropped-mandatory` to `0 dropped-mandatory`.
+- Replace the allowlist with:
+
+```python
+# ``(client_name, method_name, wire_param)``: mandatory endpoint fields that
+# method dispatch intentionally omits from the tool schema because the
+# client method does not accept them.
+#
+# Empty since #349: revenue ``structure`` is optional and (after Task 4)
+# accepted by the methods. A new dropped-mandatory is a PR failure.
+KNOWN_DROPPED_MANDATORY_WIRE: frozenset[tuple[str, str, str]] = frozenset()
+```
+
+Leave `test_classifier_flags_dropped_mandatory_wire_field` (synthetic endpoint) unchanged.
+
+- [ ] **Step 3: Update the bare partition assertion**
+
+In `tests/unit/lc/test_method_dispatch.py`, `test_partition_omits_unmapped_when_method_active`:
+
+Keep the fixture method **without** `structure` for this task (methods still hardcode it). Change only the bare (`method is None`) assertion from mandatory to optional:
+
+```python
+    bare_mand, bare_opt = partition_params_for_method(
+        PRODUCT_REVENUE_SEGMENTATION.mandatory_params,
+        PRODUCT_REVENUE_SEGMENTATION.optional_params or [],
+        None,
+    )
+    assert "structure" not in {p.name for p in bare_mand}
+    assert "structure" in {p.name for p in bare_opt}
+```
+
+The live-method half of that test still expects `structure` omitted from the fixture method — that stays correct until Task 4.
+
+- [ ] **Step 4: Rewrite the stale tool-schema comment**
+
+In `tests/unit/lc/test_tool_schema.py`, replace the docstring lines about “13 endpoints declare a `default` on a mandatory param and 13 more carry `required=True`…” with:
+
+```python
+    """A tool's required arguments must be the endpoint's mandatory params.
+
+    Not ``param.required`` and not "has no default": after #349 no
+    mandatory param carries a default, and ``required`` is derived from
+    list membership (#165). Membership of ``mandatory_params`` is the
+    only self-consistent answer, so it is the one the schema follows.
+    """
+```
+
+- [ ] **Step 5: Run the locks and LC guards**
+
+```bash
+uv run pytest \
+  tests/unit/test_param_required_consistency.py::test_mandatory_params_do_not_carry_defaults \
+  tests/unit/test_company.py::TestSegmentationAndReportDefaults \
+  tests/unit/test_closed_vocabularies.py::test_structure_endpoint_valid_values_come_from_the_literal \
+  tests/unit/lc/test_endpoint_method_coverage.py \
+  tests/unit/lc/test_method_dispatch.py::test_partition_omits_unmapped_when_method_active \
+  tests/unit/lc/test_tool_schema.py::test_tool_schema_requires_exactly_the_mandatory_params \
+  -v
+```
+
+Expected: PASS. `test_client_structure_annotations_are_the_typed_literal` still fails if you already added it unskipped — do not run it yet.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add fmp_data/company/endpoints.py tests/unit/lc/test_endpoint_method_coverage.py tests/unit/lc/test_method_dispatch.py tests/unit/lc/test_tool_schema.py tests/unit/test_param_required_consistency.py tests/unit/test_company.py
+git commit -m "fix(company): move leftover structure/period defaults to optional"
+```
+
+---
+
+### Task 4: Expose `structure` on sync and async methods
+
+**Files:**
+- Modify: `fmp_data/company/client.py`
+- Modify: `fmp_data/company/async_client.py`
+- Modify: `tests/unit/test_company_coverage.py`
+- Modify: `tests/unit/lc/test_method_dispatch.py`
+- Modify: `tests/unit/test_closed_vocabularies.py` (unskip the client walk if skipped)
+
+- [ ] **Step 1: Write the failing client tests**
+
+In `tests/unit/test_company_coverage.py`, update `test_get_geographic_revenue_segmentation_period` so the forwarded params also include default structure:
+
+```python
+        assert params["symbol"] == "AAPL"
+        assert params["period"] == "annual"
+        assert params["structure"] == "flat"
+```
+
+Add immediately after that method:
+
+```python
+    @patch("httpx.Client.request")
+    def test_get_geographic_revenue_segmentation_nested_structure(
+        self, mock_request, fmp_client, mock_response, geographic_revenue_data
+    ):
+        """structure=nested is forwarded; response model is unchanged."""
+        mock_request.return_value = mock_response(
+            status_code=200, json_data=[geographic_revenue_data]
+        )
+
+        result = fmp_client.company.get_geographic_revenue_segmentation(
+            "AAPL", structure="nested"
+        )
+
+        assert len(result) == 1
+        assert isinstance(result[0], GeographicRevenueSegment)
+        params = mock_request.call_args.kwargs["params"]
+        assert params["structure"] == "nested"
+        assert params["period"] == "annual"
+```
+
+Leave `_COMPANY_LIST_UNWRAP_CASES` / async tables as `{"symbol": "AAPL"}` only.
+
+- [ ] **Step 2: Run the new coverage test and confirm it fails**
+
+```bash
+uv run pytest tests/unit/test_company_coverage.py::TestCompanyClientCoverage::test_get_geographic_revenue_segmentation_nested_structure -v
+```
+
+Expected: FAIL (`TypeError: ... unexpected keyword argument 'structure'`).
+
+- [ ] **Step 3: Update the methods**
+
+In both `fmp_data/company/client.py` and `fmp_data/company/async_client.py`:
+
+Change the schema import to:
+
+```python
+from fmp_data.schema import (
+    Interval,
+    Period,
+    PeriodAnnualQuarter,
+    PeriodFiscal,
+    Structure,
+)
+```
+
+Replace both segmentation methods. Sync product method:
+
+```python
+    def get_product_revenue_segmentation(
+        self,
+        symbol: str,
+        period: PeriodAnnualQuarter = "annual",
+        structure: Structure = "flat",
+    ) -> list[ProductRevenueSegment]:
+        """Get revenue segmentation by product.
+
+        Args:
+            symbol: Company symbol
+            period: Data period ('annual' or 'quarter')
+            structure: Response layout ('flat' or 'nested'). Stable
+                currently returns the same list-of-objects for both
+                (probed 2026-08-17).
+
+        Returns:
+            List of product revenue segments by fiscal year
+        """
+        return self._unwrap_list(
+            self.client.request(
+                PRODUCT_REVENUE_SEGMENTATION,
+                symbol=symbol,
+                structure=structure,
+                period=period,
+            ),
+            ProductRevenueSegment,
+        )
+```
+
+Sync geographic: same signature and docstring sentence, `GEOGRAPHIC_REVENUE_SEGMENTATION` / `GeographicRevenueSegment`.
+
+Async: same signatures; `await self.client.request_async(...)` with `structure=structure`.
+
+Do not change report methods.
+
+- [ ] **Step 4: Point the LC fixture method at the new signature**
+
+In `tests/unit/lc/test_method_dispatch.py`, `test_partition_omits_unmapped_when_method_active`, change the revenue fixture and expectations:
+
+```python
+    def get_product_revenue_segmentation(
+        symbol: str, period: str = "annual", structure: str = "flat"
+    ) -> list[Any]:
+        return []
+```
+
+```python
+    assert {p.name for p in rev_mandatory} == {"symbol"}
+    assert {p.name for p in rev_optional} == {"period", "structure"}
+```
+
+Keep employee `limit` as the unmapped-omit example. Do not change `test_tool_binding.py`.
+
+- [ ] **Step 5: Run client, LC, and the structure signature walk**
+
+```bash
+uv run pytest \
+  tests/unit/test_company_coverage.py::TestCompanyClientCoverage::test_get_geographic_revenue_segmentation_period \
+  tests/unit/test_company_coverage.py::TestCompanyClientCoverage::test_get_geographic_revenue_segmentation_nested_structure \
+  tests/unit/test_closed_vocabularies.py::test_client_structure_annotations_are_the_typed_literal \
+  tests/unit/lc/test_method_dispatch.py::test_partition_omits_unmapped_when_method_active \
+  tests/unit/lc/test_endpoint_method_coverage.py \
+  tests/unit/test_company.py::TestSegmentationAndReportDefaults \
+  tests/unit/test_async_clients.py -k "revenue_segmentation" \
+  tests/unit/test_company.py -k "product_revenue or geographic_revenue" \
+  -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add fmp_data/company/client.py fmp_data/company/async_client.py tests/unit/test_company_coverage.py tests/unit/lc/test_method_dispatch.py tests/unit/test_closed_vocabularies.py
+git commit -m "feat(company): expose structure= on revenue segmentation methods"
+```
+
+---
+
+### Task 5: Changelog and full verification
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add the Unreleased / Changed note**
+
+Insert after the existing RSS leftover bullet (`#345`), same voice:
+
+```markdown
+- **Company segmentation/report leftover defaults are optional (#349).**
+  `structure` / `period` on product and geographic revenue
+  segmentation, and `period` on financial-reports JSON/XLSX, move to
+  `optional_params` so `validate_params` applies the documented
+  defaults (`flat` / `annual` / `FY`). Segmentation methods now take
+  `structure: Structure = "flat"` (`Literal["flat", "nested"]`).
+  Stable currently returns the same list-of-objects for both
+  (probed 2026-08-17). `Structure` is not re-exported from
+  `fmp_data`. No remaining mandatory-plus-default params in the
+  catalogue.
+```
+
+- [ ] **Step 2: Run the focused suite plus the requiredness / catalogue guards**
+
+```bash
+uv run pytest \
+  tests/unit/test_param_required_consistency.py \
+  tests/unit/test_closed_vocabularies.py \
+  tests/unit/test_company.py::TestSegmentationAndReportDefaults \
+  tests/unit/test_company_coverage.py::TestCompanyClientCoverage \
+  tests/unit/lc/test_endpoint_method_coverage.py \
+  tests/unit/lc/test_method_dispatch.py \
+  tests/unit/lc/test_tool_schema.py \
+  tests/unit/test_tool_binding.py \
+  tests/unit/test_catalog_registration.py \
+  -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Format / lint the touched Python**
+
+```bash
+uv run ruff format fmp_data/schema.py fmp_data/company/endpoints.py fmp_data/company/client.py fmp_data/company/async_client.py tests/unit/test_closed_vocabularies.py tests/unit/test_param_required_consistency.py tests/unit/test_company.py tests/unit/test_company_coverage.py tests/unit/lc/test_endpoint_method_coverage.py tests/unit/lc/test_method_dispatch.py tests/unit/lc/test_tool_schema.py
+uv run ruff check fmp_data/schema.py fmp_data/company/endpoints.py fmp_data/company/client.py fmp_data/company/async_client.py tests/unit/test_closed_vocabularies.py tests/unit/test_param_required_consistency.py tests/unit/test_company.py tests/unit/test_company_coverage.py tests/unit/lc/test_endpoint_method_coverage.py tests/unit/lc/test_method_dispatch.py tests/unit/lc/test_tool_schema.py
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Commit changelog**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: note leftover company defaults and structure= (#349)"
+```
+
+- [ ] **Step 5: Open the PR against `dev`**
+
+Subject (from the spec):
+
+`fix(company): make leftover segmentation/report defaults optional (#349)`
+
+Body must say: `Closes #349` is inert on a `dev`-base PR — close #349 by hand after merge. Mention the live probe (AAPL/MSFT/TSLA, `flat` == `nested`, 2026-08-17). Do not add `release:major`.
+
+---
+
+## Spec coverage
+
+| Spec item | Task |
+|---|---|
+| Move six params to `optional_params` | 3 |
+| `validate_params` injects `flat` / `annual` / `FY` | 2–3 |
+| Reject `structure="tree"` | 2–3 |
+| `symbol` / `year` stay mandatory | 2–3 |
+| `Structure` Literal + `STRUCTURE_VALUES` | 1 |
+| Leftover `StructureTypeEnum` from the tuple | 1 |
+| Not in `fmp_data.__all__` | 1 |
+| Methods take `structure: Structure = "flat"` | 4 |
+| Same response models; docstring probe date | 4 |
+| Report methods unchanged | 4 (explicit non-edit) |
+| Empty `KNOWN_DROPPED_MANDATORY_WIRE` | 3 |
+| LC fixture includes `structure`; employee `limit` still omitted | 4 |
+| Bare partition: `structure` optional | 3 |
+| `test_tool_binding` omit-unmapped unit left alone | file map |
+| Stale “13 mandatory-with-default” comment | 3 |
+| Catalogue-wide no-mandatory-default lock | 2–3 |
+| Closed-vocab walks for `structure` | 1, 4 |
+| Coverage test default + nested query | 4 |
+| No new VCR / no harness `_ALWAYS_FILL` | file map |
+| Changelog | 5 |
+| Close #349 by hand after merge | 5 |
+
+## Self-review
+
+- No TBD / “add tests later” / “similar to Task N”.
+- `Structure` / `STRUCTURE_VALUES` / method signature `structure: Structure = "flat"` are the same names in every task.
+- Client walk in Task 1 will fail until Task 4; the plan says to run only alias/enum tests in Task 1, or skip the client walk until Task 4.
+- Emptying the LC allowlist is in Task 3 because moving `structure` to optional makes those triples stale even before the methods change.

--- a/docs/superpowers/specs/2026-08-17-mandatory-defaults-structure-design.md
+++ b/docs/superpowers/specs/2026-08-17-mandatory-defaults-structure-design.md
@@ -1,0 +1,224 @@
+# Leftover mandatory defaults and `structure` exposure
+
+**Date:** 2026-08-17
+**Base:** `dev` @ `10fa6af`
+**Issue:** #349
+**Status:** approved (approach 1)
+
+## Problem
+
+Requiredness is derived from list membership (#165). A param in
+`mandatory_params` with a `default=` still raises `Missing mandatory
+parameter` when omitted, so the default never applies.
+
+#345 / #347 moved leftover **pagination** cases (`page` / `limit`) to
+`optional_params`. A full catalogue walk on 2026-08-17 found exactly six
+remaining mandatory-plus-default params, all on company endpoints:
+
+| Endpoint | Param | Dead default |
+|---|---|---|
+| `PRODUCT_REVENUE_SEGMENTATION` | `structure` | `"flat"` |
+| `PRODUCT_REVENUE_SEGMENTATION` | `period` | `"annual"` |
+| `GEOGRAPHIC_REVENUE_SEGMENTATION` | `structure` | `"flat"` |
+| `GEOGRAPHIC_REVENUE_SEGMENTATION` | `period` | `"annual"` |
+| `FINANCIAL_REPORTS_JSON` | `period` | `"FY"` |
+| `FINANCIAL_REPORTS_XLSX` | `period` | `"FY"` |
+
+Python client methods already supply those values, so call sites are
+unchanged today. Catalogue / `validate_params` / `client.request`
+without those keys still fail.
+
+`structure` is also a product gap: FMP documents it as optional
+`flat` | `nested`, the deprecated arg model already has
+`StructureTypeEnum`, and LangChain allowlists it as a dropped-mandatory
+wire field because the methods hardcode `"flat"`.
+
+## Goal
+
+One PR that:
+
+1. Moves the six params to `optional_params` so documented defaults
+   inject through `validate_params`.
+2. Exposes `structure` on the segmentation methods as
+   `Structure = Literal["flat", "nested"]`, default `"flat"`.
+3. Locks both the four endpoints' defaults and the catalogue-wide
+   invariant that no mandatory param may carry a default.
+
+## Non-goals
+
+- Bounds factory or other leftover classes (#344, #346 are closed and
+  unrelated).
+- A second response model for `nested`. Live `/stable` returns the same
+  list-of-objects for `flat`, `nested`, and omitted (AAPL / MSFT / TSLA,
+  annual and quarter, probed 2026-08-17).
+- Re-exporting `Structure` from `fmp_data.__all__`.
+- New live VCR recordings for `nested`.
+- Changing report method signatures (`period` already defaults to
+  `"FY"` and is always passed).
+- Pydantic / dataclass wrapper for the `structure` choice.
+- Accepting undocumented tokens such as `"tree"` (live API ignores
+  them; we reject them).
+
+## Decisions
+
+| Fork | Choice |
+|---|---|
+| Scope | Expand: move leftovers **and** expose `structure` |
+| Nested | Advertise `flat` \| `nested`; same models; document no-op |
+| Type | `Structure` Literal in `schema.py`; not in `__all__`; derive leftover enum |
+| Locks | Local default test **and** catalogue-wide walk |
+| Packaging | Single PR, same shape as #347 |
+
+## Design
+
+### Catalogue
+
+On `PRODUCT_REVENUE_SEGMENTATION` and
+`GEOGRAPHIC_REVENUE_SEGMENTATION`:
+
+- `mandatory_params`: `symbol` only.
+- `optional_params`: `structure` (default `"flat"`,
+  `valid_values=list(STRUCTURE_VALUES)`) and `period` (default
+  `"annual"`, `valid_values=list(PERIOD_ANNUAL_QUARTER_VALUES)`).
+
+On `FINANCIAL_REPORTS_JSON` and `FINANCIAL_REPORTS_XLSX`:
+
+- `mandatory_params`: `symbol`, `year` (no defaults).
+- `optional_params`: `period` (default `"FY"`,
+  `valid_values=list(PERIOD_FISCAL_VALUES)`).
+
+`validate_params({"symbol": "AAPL"})` on a segmentation endpoint must
+return `structure="flat"` and `period="annual"`.
+`validate_params({"symbol": "AAPL", "year": 2024})` on a report
+endpoint must return `period="FY"`. Missing `symbol` / `year` still
+raises `ValidationError`.
+
+### Types
+
+In `fmp_data/schema.py`, next to the period aliases:
+
+```python
+Structure: TypeAlias = Literal["flat", "nested"]
+STRUCTURE_VALUES: tuple[str, ...] = literal_values(Structure)
+```
+
+Leftover `StructureTypeEnum` unpacks from that tuple:
+
+```python
+class StructureTypeEnum(BaseEnum):
+    """Data structure types.
+
+    Member *values* come from ``Structure``. Retired with the
+    deprecated arg models in 3.0 (#153, #307).
+    """
+
+    FLAT, NESTED = STRUCTURE_VALUES
+```
+
+`StructureTypeEnum` must be declared **after** `STRUCTURE_VALUES`.
+Deprecated `RevenueSegmentationArgs.structure` keeps using the enum.
+
+Do not add `Structure` to `fmp_data.__all__` or to
+`test_closed_vocabularies_are_public_exports`.
+
+### Client methods
+
+Sync and async:
+
+```python
+def get_product_revenue_segmentation(
+    self,
+    symbol: str,
+    period: PeriodAnnualQuarter = "annual",
+    structure: Structure = "flat",
+) -> list[ProductRevenueSegment]: ...
+```
+
+Same shape for `get_geographic_revenue_segmentation`. Pass `structure`
+through to `client.request` / `request_async` instead of hardcoding
+`"flat"`. Return type is unchanged for both values.
+
+Docstring must state that stable currently returns the same
+list-of-objects for `flat` and `nested` (probed 2026-08-17).
+
+Report methods are unchanged.
+
+Default call `get_product_revenue_segmentation("AAPL")` still sends
+`period=annual&structure=flat`. Existing cassettes remain valid.
+
+### LangChain / MCP
+
+`KNOWN_DROPPED_MANDATORY_WIRE` becomes empty: delete both
+`structure` allowlist rows. A new dropped-mandatory wire field is then
+a PR failure (#188).
+
+Once the methods accept `structure`, method dispatch advertises it as
+optional (default `"flat"`). MCP binds the live Python method, so the
+argument appears there without a `DEFAULT_TOOLS` edit.
+
+`STRUCTURE_HINT` stays on both semantics maps.
+
+Tests that assume `structure` is omitted under method dispatch must
+use a fixture method that **includes** `structure=` and expect it in
+optional. Employee-count `limit` remains the unmapped-omit example.
+Bare (`method is None`) partition: `structure` is optional, not
+mandatory.
+
+`test_tool_binding.py::test_partition_demotes_params_the_method_defaults`
+keeps a local fake method without `structure` so the omit-unmapped
+rule still has a unit.
+
+Stale LC copy that says “13 mandatory-with-default” is rewritten:
+there are none after this change; list membership remains the rule.
+
+### Errors
+
+| Input | Result |
+|---|---|
+| Missing `symbol` or report `year` | `ValidationError` (`Missing mandatory parameter`) |
+| `structure="tree"` or other non-member | `ValidationError` (`Must be one of`) |
+| `period` outside that endpoint's Literal | `ValidationError` (`Must be one of`) |
+| Valid `nested` | 200, same models as `flat` |
+
+Live FMP accepts undocumented `structure` tokens and ignores them.
+This client rejects them. That is intentional.
+
+### Tests
+
+1. **Local lock** (new company unit test, same shape as
+   `test_rss_pagination_is_optional_like_latest`):
+   membership + the `validate_params` injections above + reject
+   `"tree"`.
+2. **Catalogue lock** in `test_param_required_consistency.py`: every
+   param in `mandatory_params` has `default is None`. Keep
+   `_MIN_ENDPOINTS` / `_MIN_PARAMS` floors.
+3. **Types:** `literal_values(Structure) == ("flat", "nested")`;
+   `test_legacy_enums_*` pins `StructureTypeEnum` unpacked from
+   `STRUCTURE_VALUES`. Segmentation methods join the closed-vocab
+   signature walk.
+4. **Client:** existing geographic period-forward test also asserts
+   default `structure="flat"`; add one call that passes
+   `structure="nested"` and checks the query string. List-unwrap
+   tables stay `{symbol: "AAPL"}` only.
+
+No new VCR cassettes.
+
+### Changelog
+
+Unreleased / Changed, same voice as the #345 RSS note. Closes #349.
+`Closes #N` is inert on `dev`-base PRs — close #349 by hand after
+merge.
+
+## Out of scope if it shows up in review
+
+- `PaginationArg` / page-limit bounds (explicit #345/#349 non-goal).
+- Promoting `Structure` to the public package surface (separate
+  decision, same as #308 / #311 for Period / TechnicalInterval).
+- Modeling a nested tree if FMP later changes the wire. Re-probe
+  before adding a second model.
+
+## PR plan
+
+One PR on `dev`. Conventional subject:
+
+`fix(company): make leftover segmentation/report defaults optional (#349)`

--- a/fmp_data/company/async_client.py
+++ b/fmp_data/company/async_client.py
@@ -115,7 +115,13 @@ from fmp_data.fundamental.models import (
 from fmp_data.helpers import deprecated
 from fmp_data.intelligence.models import DividendEvent, EarningEvent, StockSplitEvent
 from fmp_data.models import MarketCapitalization, _safe_path_segment
-from fmp_data.schema import Interval, Period, PeriodAnnualQuarter, PeriodFiscal
+from fmp_data.schema import (
+    Interval,
+    Period,
+    PeriodAnnualQuarter,
+    PeriodFiscal,
+    Structure,
+)
 
 
 def _format_date(value: date | None) -> str | None:
@@ -319,13 +325,19 @@ class AsyncCompanyClient(AsyncEndpointGroup):
         return []
 
     async def get_product_revenue_segmentation(
-        self, symbol: str, period: PeriodAnnualQuarter = "annual"
+        self,
+        symbol: str,
+        period: PeriodAnnualQuarter = "annual",
+        structure: Structure = "flat",
     ) -> list[ProductRevenueSegment]:
         """Get revenue segmentation by product.
 
         Args:
             symbol: Company symbol
             period: Data period ('annual' or 'quarter')
+            structure: Response layout ('flat' or 'nested'). Stable
+                currently returns the same list-of-objects for both
+                (probed 2026-08-17).
 
         Returns:
             List of product revenue segments by fiscal year
@@ -334,20 +346,26 @@ class AsyncCompanyClient(AsyncEndpointGroup):
             await self.client.request_async(
                 PRODUCT_REVENUE_SEGMENTATION,
                 symbol=symbol,
-                structure="flat",
+                structure=structure,
                 period=period,
             ),
             ProductRevenueSegment,
         )
 
     async def get_geographic_revenue_segmentation(
-        self, symbol: str, period: PeriodAnnualQuarter = "annual"
+        self,
+        symbol: str,
+        period: PeriodAnnualQuarter = "annual",
+        structure: Structure = "flat",
     ) -> list[GeographicRevenueSegment]:
         """Get revenue segmentation by geographic region.
 
         Args:
             symbol: Company symbol
             period: Data period ('annual' or 'quarter')
+            structure: Response layout ('flat' or 'nested'). Stable
+                currently returns the same list-of-objects for both
+                (probed 2026-08-17).
 
         Returns:
             List of geographic revenue segments by fiscal year
@@ -356,7 +374,7 @@ class AsyncCompanyClient(AsyncEndpointGroup):
             await self.client.request_async(
                 GEOGRAPHIC_REVENUE_SEGMENTATION,
                 symbol=symbol,
-                structure="flat",
+                structure=structure,
                 period=period,
             ),
             GeographicRevenueSegment,

--- a/fmp_data/company/client.py
+++ b/fmp_data/company/client.py
@@ -110,7 +110,13 @@ from fmp_data.fundamental.models import (
 from fmp_data.helpers import deprecated
 from fmp_data.intelligence.models import DividendEvent, EarningEvent, StockSplitEvent
 from fmp_data.models import MarketCapitalization, _safe_path_segment
-from fmp_data.schema import Interval, Period, PeriodAnnualQuarter, PeriodFiscal
+from fmp_data.schema import (
+    Interval,
+    Period,
+    PeriodAnnualQuarter,
+    PeriodFiscal,
+    Structure,
+)
 
 
 def _format_date(value: date | None) -> str | None:
@@ -305,13 +311,19 @@ class CompanyClient(EndpointGroup):
         return []
 
     def get_product_revenue_segmentation(
-        self, symbol: str, period: PeriodAnnualQuarter = "annual"
+        self,
+        symbol: str,
+        period: PeriodAnnualQuarter = "annual",
+        structure: Structure = "flat",
     ) -> list[ProductRevenueSegment]:
         """Get revenue segmentation by product.
 
         Args:
             symbol: Company symbol
             period: Data period ('annual' or 'quarter')
+            structure: Response layout ('flat' or 'nested'). Stable
+                currently returns the same list-of-objects for both
+                (probed 2026-08-17).
 
         Returns:
             List of product revenue segments by fiscal year
@@ -320,20 +332,26 @@ class CompanyClient(EndpointGroup):
             self.client.request(
                 PRODUCT_REVENUE_SEGMENTATION,
                 symbol=symbol,
-                structure="flat",
+                structure=structure,
                 period=period,
             ),
             ProductRevenueSegment,
         )
 
     def get_geographic_revenue_segmentation(
-        self, symbol: str, period: PeriodAnnualQuarter = "annual"
+        self,
+        symbol: str,
+        period: PeriodAnnualQuarter = "annual",
+        structure: Structure = "flat",
     ) -> list[GeographicRevenueSegment]:
         """Get revenue segmentation by geographic region.
 
         Args:
             symbol: Company symbol
             period: Data period ('annual' or 'quarter')
+            structure: Response layout ('flat' or 'nested'). Stable
+                currently returns the same list-of-objects for both
+                (probed 2026-08-17).
 
         Returns:
             List of geographic revenue segments by fiscal year
@@ -342,7 +360,7 @@ class CompanyClient(EndpointGroup):
             self.client.request(
                 GEOGRAPHIC_REVENUE_SEGMENTATION,
                 symbol=symbol,
-                structure="flat",
+                structure=structure,
                 period=period,
             ),
             GeographicRevenueSegment,

--- a/fmp_data/company/endpoints.py
+++ b/fmp_data/company/endpoints.py
@@ -63,6 +63,7 @@ from fmp_data.schema import (
     PERIOD_ANNUAL_QUARTER_VALUES,
     PERIOD_FISCAL_VALUES,
     PERIOD_VALUES,
+    STRUCTURE_VALUES,
 )
 
 QUOTE: Endpoint[Quote] = Endpoint(
@@ -560,12 +561,15 @@ PRODUCT_REVENUE_SEGMENTATION: Endpoint[ProductRevenueSegment] = Endpoint(
             param_type=ParamType.STRING,
             description="Company symbol",
         ),
+    ],
+    optional_params=[
         EndpointParam(
             name="structure",
             location=ParamLocation.QUERY,
             param_type=ParamType.STRING,
             description="Data structure format",
             default="flat",
+            valid_values=list(STRUCTURE_VALUES),
         ),
         EndpointParam(
             name="period",
@@ -576,7 +580,6 @@ PRODUCT_REVENUE_SEGMENTATION: Endpoint[ProductRevenueSegment] = Endpoint(
             valid_values=list(PERIOD_ANNUAL_QUARTER_VALUES),
         ),
     ],
-    optional_params=[],
     response_model=ProductRevenueSegment,
     example_queries=[
         "Show Apple's revenue by product",
@@ -603,12 +606,15 @@ GEOGRAPHIC_REVENUE_SEGMENTATION: Endpoint[GeographicRevenueSegment] = Endpoint(
             param_type=ParamType.STRING,
             description="Company symbol",
         ),
+    ],
+    optional_params=[
         EndpointParam(
             name="structure",
             location=ParamLocation.QUERY,
             param_type=ParamType.STRING,
             description="Data structure format",
             default="flat",
+            valid_values=list(STRUCTURE_VALUES),
         ),
         EndpointParam(
             name="period",
@@ -619,7 +625,6 @@ GEOGRAPHIC_REVENUE_SEGMENTATION: Endpoint[GeographicRevenueSegment] = Endpoint(
             valid_values=list(PERIOD_ANNUAL_QUARTER_VALUES),
         ),
     ],
-    optional_params=[],
     response_model=GeographicRevenueSegment,
     example_queries=[
         "Show Apple's revenue by region",
@@ -1694,6 +1699,8 @@ FINANCIAL_REPORTS_JSON: Endpoint[FinancialReportJSON] = Endpoint(
             param_type=ParamType.INTEGER,
             description="Report year",
         ),
+    ],
+    optional_params=[
         EndpointParam(
             name="period",
             location=ParamLocation.QUERY,
@@ -1703,7 +1710,6 @@ FINANCIAL_REPORTS_JSON: Endpoint[FinancialReportJSON] = Endpoint(
             valid_values=list(PERIOD_FISCAL_VALUES),
         ),
     ],
-    optional_params=[],
     response_model=FinancialReportJSON,
 )
 
@@ -1730,6 +1736,8 @@ FINANCIAL_REPORTS_XLSX: Endpoint[bytes] = Endpoint(
             param_type=ParamType.INTEGER,
             description="Report year",
         ),
+    ],
+    optional_params=[
         EndpointParam(
             name="period",
             location=ParamLocation.QUERY,
@@ -1739,7 +1747,6 @@ FINANCIAL_REPORTS_XLSX: Endpoint[bytes] = Endpoint(
             valid_values=list(PERIOD_FISCAL_VALUES),
         ),
     ],
-    optional_params=[],
     response_model=bytes,  # Binary data
 )
 

--- a/fmp_data/lc/vector_store.py
+++ b/fmp_data/lc/vector_store.py
@@ -171,20 +171,21 @@ class ToolFactory:
 
         Mandatory-ness is taken from which list a parameter arrives in, never
         inferred from the parameter itself. ``EndpointParam.required`` and
-        ``EndpointParam.default`` both disagreed with list membership across
-        the catalog: 14 params sat in ``optional_params`` with
-        ``required=True``, and 13 more sit in ``mandatory_params`` carrying a
-        ``default`` -- so either one would silently mis-shape a schema.
-        ``Endpoint`` itself resolves the same question by list membership in
-        ``validate_params``.
+        ``EndpointParam.default`` both used to disagree with list membership:
+        14 params sat in ``optional_params`` with ``required=True``, and 13
+        more sat in ``mandatory_params`` carrying a ``default`` -- so either
+        one would silently mis-shape a schema. ``Endpoint`` itself resolves
+        the same question by list membership in ``validate_params``.
 
         The ``required`` half is settled as of #165: the flag is no longer
         stored at all, and ``EndpointParam.required`` is now a read-only
         property that ``Endpoint`` derives from these very lists. Reading it
         here would be correct today but circular -- it would route the answer
         through the parameter to get back the list it came from -- so the list
-        stays the direct source. The ``default`` half is still live, and
-        reading *that* would still be wrong.
+        stays the direct source. The ``default`` half is still live: #349
+        cleared the last mandatory-plus-default cases, but optional params
+        may still have ``default is None``, so reading *that* would still be
+        wrong.
 
         Optional parameters get a pydantic default so ``is_required()`` is
         false and the LLM may omit them. That default is ``param.default``

--- a/fmp_data/schema.py
+++ b/fmp_data/schema.py
@@ -158,13 +158,6 @@ class BaseEnum(str, Enum):
         return [e.value for e in cls]
 
 
-class StructureTypeEnum(BaseEnum):
-    """Data structure types"""
-
-    FLAT = "flat"
-    NESTED = "nested"
-
-
 # Closed request vocabularies used by client methods and endpoint valid_values.
 # Three period aliases on purpose: financial-reports and batch bulk reject
 # ``annual``/``quarter``. Period is the union of those two contracts so the
@@ -177,6 +170,7 @@ Timeframe: TypeAlias = Interval | Literal["1day"]
 # Client-only aliases mapped onto Timeframe by TechnicalClient._normalize_timeframe.
 IntervalAlias: TypeAlias = Literal["daily", "hourly"]
 TechnicalInterval: TypeAlias = Interval | IntervalAlias
+Structure: TypeAlias = Literal["flat", "nested"]
 
 
 def literal_values(typ: Any) -> tuple[Any, ...]:
@@ -199,6 +193,17 @@ PERIOD_VALUES: tuple[str, ...] = literal_values(Period)
 INTERVAL_VALUES: tuple[str, ...] = literal_values(Interval)
 TIMEFRAME_VALUES: tuple[str, ...] = literal_values(Timeframe)
 TECHNICAL_INTERVAL_VALUES: tuple[str, ...] = literal_values(TechnicalInterval)
+STRUCTURE_VALUES: tuple[str, ...] = literal_values(Structure)
+
+
+class StructureTypeEnum(BaseEnum):
+    """Data structure types.
+
+    Member *values* come from ``Structure``. Retired with the
+    deprecated arg models in 3.0 (#153, #307).
+    """
+
+    FLAT, NESTED = STRUCTURE_VALUES
 
 
 class ReportingPeriodEnum(BaseEnum):

--- a/fmp_data/tool_binding.py
+++ b/fmp_data/tool_binding.py
@@ -259,8 +259,9 @@ def partition_params_for_method(
     method will fill it. Endpoint params that do not resolve to any method
     parameter are omitted entirely: method dispatch drops unmapped kwargs at
     invoke time, so advertising them as required would force LLMs to supply
-    values that never reach the API (e.g. revenue ``structure``, employee
-    ``limit``). Without a resolvable method the endpoint lists are returned
+    values that never reach the API (e.g. employee-count ``limit``).
+    Revenue ``structure`` is advertised once the method accepts it.
+    Without a resolvable method the endpoint lists are returned
     unchanged (the pre-#172 behaviour).
 
     Takes and returns ``EndpointParam``-shaped objects, but only reads

--- a/tests/unit/lc/test_endpoint_method_coverage.py
+++ b/tests/unit/lc/test_endpoint_method_coverage.py
@@ -59,7 +59,7 @@ from fmp_data.tool_binding import (
 
 # Floors, not equalities: a walk that stops yielding must fail rather than
 # pass vacuously. Observed on the catalogue at time of writing: 215 triples,
-# all 215 method-compatible, 0 request-fallback, 2 dropped-mandatory.
+# all 215 method-compatible, 0 request-fallback, 0 dropped-mandatory.
 _MIN_PAIRS = 200
 _MIN_METHOD_COMPATIBLE = 200
 
@@ -85,14 +85,10 @@ _KNOWN_REQUEST_FALLBACK_METHODS: frozenset[tuple[str, str]] = frozenset(
 # ``(client_name, method_name, wire_param)``: mandatory endpoint fields that
 # method dispatch intentionally omits from the tool schema because the
 # client method does not accept them.
-KNOWN_DROPPED_MANDATORY_WIRE: frozenset[tuple[str, str, str]] = frozenset(
-    {
-        # Endpoint still declares structure (flat|nested, default "flat");
-        # methods only take symbol + period and hardcode structure="flat".
-        ("company", "get_product_revenue_segmentation", "structure"),
-        ("company", "get_geographic_revenue_segmentation", "structure"),
-    }
-)
+#
+# Empty since #349: revenue ``structure`` is optional. A new
+# dropped-mandatory is a PR failure.
+KNOWN_DROPPED_MANDATORY_WIRE: frozenset[tuple[str, str, str]] = frozenset()
 
 
 def _catalog() -> list[tuple[str, Endpoint[Any], Any]]:

--- a/tests/unit/lc/test_endpoint_method_coverage.py
+++ b/tests/unit/lc/test_endpoint_method_coverage.py
@@ -21,8 +21,8 @@ This guard walks every ``(endpoint_map x semantics)`` pair that
    gain more debt.
 3. **mandatory wire dropped under method dispatch** — a mandatory endpoint
    field maps to no method parameter, so method dispatch omits it from the
-   tool schema. Known cases (e.g. revenue ``structure``) are allowlisted;
-   new ones fail until reviewed.
+   tool schema. The dropped-mandatory allowlist is empty; a new
+   dropped-mandatory is a PR failure.
 
 Optional wire fields dropped under method dispatch are intentionally out of
 scope here (they are not required for a successful call). MCP registers the

--- a/tests/unit/lc/test_method_dispatch.py
+++ b/tests/unit/lc/test_method_dispatch.py
@@ -368,7 +368,10 @@ def test_partition_industry_classification_all_optional() -> None:
 
 
 def test_partition_omits_unmapped_when_method_active() -> None:
-    """Endpoint-only params (structure, limit) are dropped under method dispatch."""
+    """Unmapped endpoint params (e.g. employee-count limit) are dropped.
+
+    Revenue ``structure`` is advertised once the method accepts it.
+    """
 
     def get_product_revenue_segmentation(
         symbol: str, period: str = "annual", structure: str = "flat"
@@ -395,7 +398,7 @@ def test_partition_omits_unmapped_when_method_active() -> None:
     assert emp_optional == []
     assert "limit" not in {p.name for p in emp_mandatory + emp_optional}
 
-    # Without a method, pre-#172 lists are unchanged (structure/limit kept).
+    # Without a method, lists stay as declared (structure and limit optional).
     bare_mand, bare_opt = partition_params_for_method(
         PRODUCT_REVENUE_SEGMENTATION.mandatory_params,
         PRODUCT_REVENUE_SEGMENTATION.optional_params or [],

--- a/tests/unit/lc/test_method_dispatch.py
+++ b/tests/unit/lc/test_method_dispatch.py
@@ -371,7 +371,7 @@ def test_partition_omits_unmapped_when_method_active() -> None:
     """Endpoint-only params (structure, limit) are dropped under method dispatch."""
 
     def get_product_revenue_segmentation(
-        symbol: str, period: str = "annual"
+        symbol: str, period: str = "annual", structure: str = "flat"
     ) -> list[Any]:
         return []
 
@@ -384,8 +384,7 @@ def test_partition_omits_unmapped_when_method_active() -> None:
         get_product_revenue_segmentation,
     )
     assert {p.name for p in rev_mandatory} == {"symbol"}
-    assert {p.name for p in rev_optional} == {"period"}
-    assert "structure" not in {p.name for p in rev_mandatory + rev_optional}
+    assert {p.name for p in rev_optional} == {"period", "structure"}
 
     emp_mandatory, emp_optional = partition_params_for_method(
         EMPLOYEE_COUNT.mandatory_params,

--- a/tests/unit/lc/test_method_dispatch.py
+++ b/tests/unit/lc/test_method_dispatch.py
@@ -397,12 +397,13 @@ def test_partition_omits_unmapped_when_method_active() -> None:
     assert "limit" not in {p.name for p in emp_mandatory + emp_optional}
 
     # Without a method, pre-#172 lists are unchanged (structure/limit kept).
-    bare_mand, _bare_opt = partition_params_for_method(
+    bare_mand, bare_opt = partition_params_for_method(
         PRODUCT_REVENUE_SEGMENTATION.mandatory_params,
         PRODUCT_REVENUE_SEGMENTATION.optional_params or [],
         None,
     )
-    assert "structure" in {p.name for p in bare_mand}
+    assert "structure" not in {p.name for p in bare_mand}
+    assert "structure" in {p.name for p in bare_opt}
     bare_emp_mand, bare_emp_opt = partition_params_for_method(
         EMPLOYEE_COUNT.mandatory_params,
         EMPLOYEE_COUNT.optional_params or [],

--- a/tests/unit/lc/test_tool_schema.py
+++ b/tests/unit/lc/test_tool_schema.py
@@ -60,10 +60,10 @@ def _catalog() -> list[tuple[str, Endpoint[Any], EndpointSemantics]]:
 def test_tool_schema_requires_exactly_the_mandatory_params() -> None:
     """A tool's required arguments must be the endpoint's mandatory params.
 
-    Not ``param.required`` and not "has no default": 13 endpoints declare a
-    ``default`` on a mandatory param and 13 more carry ``required=True`` on a
-    param that sits in ``optional_params``. Membership of ``mandatory_params``
-    is the only self-consistent answer, so it is the one the schema follows.
+    Not ``param.required`` and not "has no default": after #349 no
+    mandatory param carries a default, and ``required`` is derived from
+    list membership (#165). Membership of ``mandatory_params`` is the
+    only self-consistent answer, so it is the one the schema follows.
     """
     drift: dict[str, str] = {}
     checked = 0

--- a/tests/unit/test_async_clients.py
+++ b/tests/unit/test_async_clients.py
@@ -593,6 +593,36 @@ class TestAsyncCompanyClient:
         )
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "method_name,endpoint_name",
+        [
+            ("get_product_revenue_segmentation", "PRODUCT_REVENUE_SEGMENTATION"),
+            ("get_geographic_revenue_segmentation", "GEOGRAPHIC_REVENUE_SEGMENTATION"),
+        ],
+    )
+    async def test_revenue_segmentation_nested_structure(
+        self, mock_client, method_name, endpoint_name
+    ):
+        """structure=nested is forwarded on the async methods."""
+        from fmp_data.company import endpoints as company_endpoints
+        from fmp_data.company.async_client import AsyncCompanyClient
+
+        mock_client.request_async.return_value = []
+        async_client = AsyncCompanyClient(mock_client)
+
+        method = getattr(async_client, method_name)
+        result = await method("AAPL", structure="nested")
+
+        assert result == []
+        endpoint = getattr(company_endpoints, endpoint_name)
+        mock_client.request_async.assert_called_once_with(
+            endpoint,
+            symbol="AAPL",
+            structure="nested",
+            period="annual",
+        )
+
+    @pytest.mark.asyncio
     async def test_get_analyst_estimates_params(self, mock_client):
         """Test analyst estimates parameter forwarding."""
         from fmp_data.company import endpoints as company_endpoints

--- a/tests/unit/test_closed_vocabularies.py
+++ b/tests/unit/test_closed_vocabularies.py
@@ -435,7 +435,6 @@ def test_structure_endpoint_valid_values_come_from_the_literal() -> None:
     assert not wrong, "structure valid_values drifted:\n  " + "\n  ".join(wrong)
 
 
-@pytest.mark.skip(reason="Task 4: methods gain structure=")
 def test_client_structure_annotations_are_the_typed_literal() -> None:
     untyped: list[str] = []
     seen = 0

--- a/tests/unit/test_closed_vocabularies.py
+++ b/tests/unit/test_closed_vocabularies.py
@@ -23,6 +23,7 @@ from fmp_data.schema import (
     PERIOD_ANNUAL_QUARTER_VALUES,
     PERIOD_FISCAL_VALUES,
     PERIOD_VALUES,
+    STRUCTURE_VALUES,
     TECHNICAL_INTERVAL_VALUES,
     TIMEFRAME_VALUES,
     Interval,
@@ -32,6 +33,8 @@ from fmp_data.schema import (
     PeriodAnnualQuarter,
     PeriodFiscal,
     ReportingPeriodEnum,
+    Structure,
+    StructureTypeEnum,
     TechnicalInterval,
     Timeframe,
     literal_values,
@@ -77,6 +80,11 @@ def test_period_aliases_are_distinct_contracts() -> None:
     assert get_args(period_runtime) == (PeriodAnnualQuarter, PeriodFiscal)
 
 
+def test_structure_alias_is_flat_or_nested() -> None:
+    assert literal_values(Structure) == ("flat", "nested")
+    assert literal_values(Structure) == STRUCTURE_VALUES
+
+
 def test_literal_values_flattens_unions_and_rejects_non_literals() -> None:
     assert literal_values(TechnicalInterval) == (
         *INTERVAL_VALUES,
@@ -92,6 +100,7 @@ def test_legacy_enums_match_the_literal_sets() -> None:
     assert tuple(member.value for member in ReportingPeriodEnum) == PERIOD_VALUES
     assert tuple(member.value for member in IntervalEnum) == INTERVAL_VALUES
     assert tuple(member.value for member in IntradayTimeInterval) == INTERVAL_VALUES
+    assert tuple(member.value for member in StructureTypeEnum) == STRUCTURE_VALUES
 
 
 def test_legacy_enums_are_unpacked_from_the_literal_tuples() -> None:
@@ -104,6 +113,7 @@ def test_legacy_enums_are_unpacked_from_the_literal_tuples() -> None:
     assert "PERIOD_FISCAL_VALUES" in source
     assert "INTERVAL_VALUES" in inspect.getsource(schema.IntervalEnum)
     assert "INTERVAL_VALUES" in inspect.getsource(company_schema.IntradayTimeInterval)
+    assert "STRUCTURE_VALUES" in inspect.getsource(schema.StructureTypeEnum)
     assert ReportingPeriodEnum.ANNUAL.value == "annual"
     assert ReportingPeriodEnum.QUARTER.value == "quarter"
     assert ReportingPeriodEnum.FY.value == "FY"
@@ -123,6 +133,8 @@ def test_legacy_enums_are_unpacked_from_the_literal_tuples() -> None:
     assert IntradayTimeInterval.THIRTY_MINUTES.value == "30min"
     assert IntradayTimeInterval.ONE_HOUR.value == "1hour"
     assert IntradayTimeInterval.FOUR_HOURS.value == "4hour"
+    assert StructureTypeEnum.FLAT.value == "flat"
+    assert StructureTypeEnum.NESTED.value == "nested"
 
 
 def test_readme_sma_example_does_not_stack_interval_on_timeframe() -> None:
@@ -405,6 +417,49 @@ def test_client_period_interval_annotations_are_the_typed_literals() -> None:
     assert not untyped, "client methods still take a naked str:\n  " + "\n  ".join(
         untyped
     )
+
+
+@pytest.mark.skip(reason="Task 3: structure valid_values on endpoints")
+def test_structure_endpoint_valid_values_come_from_the_literal() -> None:
+    found: list[str] = []
+    wrong: list[str] = []
+    for endpoint in _all_endpoints():
+        params = list(endpoint.mandatory_params) + list(endpoint.optional_params or [])
+        for param in params:
+            if param.name != "structure":
+                continue
+            found.append(endpoint.name)
+            values = tuple(str(v) for v in (param.valid_values or ()))
+            if values != STRUCTURE_VALUES:
+                wrong.append(f"{endpoint.name}.structure={values!r}")
+    assert found, "expected revenue-segmentation structure params"
+    assert not wrong, "structure valid_values drifted:\n  " + "\n  ".join(wrong)
+
+
+@pytest.mark.skip(reason="Task 4: methods gain structure=")
+def test_client_structure_annotations_are_the_typed_literal() -> None:
+    untyped: list[str] = []
+    seen = 0
+    for root_cls in (FMPDataClient, AsyncFMPDataClient):
+        for group, method, func in _iter_group_methods(root_cls):
+            if "structure" not in bindable_params(func):
+                continue
+            seen += 1
+            hints = get_type_hints(func)
+            members = _annotation_members(
+                hints.get("structure", inspect.Parameter.empty)
+            )
+            default = inspect.signature(func).parameters["structure"].default
+            if members != STRUCTURE_VALUES:
+                untyped.append(
+                    f"{root_cls.__name__}.{group}.{method} members={members!r}"
+                )
+            if default != "flat":
+                untyped.append(
+                    f"{root_cls.__name__}.{group}.{method} default={default!r}"
+                )
+    assert seen >= 4, f"expected sync+async product+geo methods, saw {seen}"
+    assert not untyped, "structure annotations drifted:\n  " + "\n  ".join(untyped)
 
 
 def test_fiscal_client_methods_stay_period_fiscal() -> None:

--- a/tests/unit/test_closed_vocabularies.py
+++ b/tests/unit/test_closed_vocabularies.py
@@ -419,7 +419,6 @@ def test_client_period_interval_annotations_are_the_typed_literals() -> None:
     )
 
 
-@pytest.mark.skip(reason="Task 3: structure valid_values on endpoints")
 def test_structure_endpoint_valid_values_come_from_the_literal() -> None:
     found: list[str] = []
     wrong: list[str] = []

--- a/tests/unit/test_closed_vocabularies.py
+++ b/tests/unit/test_closed_vocabularies.py
@@ -1,7 +1,8 @@
-"""Closed request vocabularies: period, interval, timeframe.
+"""Closed request vocabularies: period, interval, timeframe, and structure.
 
 These must stay three *different* period types. One union enum is how
-``annual`` leaked onto financial-reports (FY/Qn only).
+``annual`` leaked onto financial-reports (FY/Qn only). Structure
+(flat|nested) is a separate closed vocab on revenue segmentation.
 """
 
 from __future__ import annotations
@@ -200,6 +201,10 @@ def test_closed_vocabularies_are_public_exports() -> None:
         "Timeframe",
     ):
         assert name in fmp_data.__all__, name
+    # #349: Structure is a closed vocab on public methods but is not
+    # promoted to the package surface (same deferred decision as #308 /
+    # #311 were before Period / TechnicalInterval landed).
+    assert "Structure" not in fmp_data.__all__
     assert "1day" not in literal_values(fmp_data.TechnicalInterval)
     assert "daily" in literal_values(fmp_data.TechnicalInterval)
     assert "hourly" in literal_values(fmp_data.TechnicalInterval)

--- a/tests/unit/test_company.py
+++ b/tests/unit/test_company.py
@@ -1659,3 +1659,59 @@ class TestCompanyLogoUrl:
     def test_path_escapes_are_rejected(self, symbol: str) -> None:
         with pytest.raises(Exception, match="Invalid path parameter"):
             self._client().get_company_logo_url(symbol)
+
+
+class TestSegmentationAndReportDefaults:
+    """Mandatory structure/period defaults never apply (#349)."""
+
+    def test_segmentation_structure_and_period_are_optional(self) -> None:
+        from fmp_data.company.endpoints import (
+            GEOGRAPHIC_REVENUE_SEGMENTATION,
+            PRODUCT_REVENUE_SEGMENTATION,
+        )
+        from fmp_data.exceptions import ValidationError as FMPValidationError
+        from fmp_data.schema import STRUCTURE_VALUES
+
+        for endpoint in (
+            PRODUCT_REVENUE_SEGMENTATION,
+            GEOGRAPHIC_REVENUE_SEGMENTATION,
+        ):
+            mandatory = {param.name for param in endpoint.mandatory_params}
+            optional = {param.name for param in endpoint.optional_params or []}
+            assert mandatory == {"symbol"}, endpoint.name
+            assert "structure" in optional, endpoint.name
+            assert "period" in optional, endpoint.name
+            assert "structure" not in mandatory, endpoint.name
+            assert "period" not in mandatory, endpoint.name
+            injected = endpoint.validate_params({"symbol": "AAPL"})
+            assert injected["symbol"] == "AAPL"
+            assert injected["structure"] == "flat"
+            assert injected["period"] == "annual"
+            structure = next(
+                param
+                for param in (endpoint.optional_params or [])
+                if param.name == "structure"
+            )
+            assert tuple(str(v) for v in (structure.valid_values or ())) == (
+                STRUCTURE_VALUES
+            )
+            with pytest.raises(FMPValidationError, match="Must be one of"):
+                endpoint.validate_params({"symbol": "AAPL", "structure": "tree"})
+
+    def test_report_period_is_optional(self) -> None:
+        from fmp_data.company.endpoints import (
+            FINANCIAL_REPORTS_JSON,
+            FINANCIAL_REPORTS_XLSX,
+        )
+        from fmp_data.exceptions import ValidationError as FMPValidationError
+
+        for endpoint in (FINANCIAL_REPORTS_JSON, FINANCIAL_REPORTS_XLSX):
+            mandatory = {param.name for param in endpoint.mandatory_params}
+            optional = {param.name for param in endpoint.optional_params or []}
+            assert mandatory == {"symbol", "year"}, endpoint.name
+            assert "period" in optional, endpoint.name
+            assert "period" not in mandatory, endpoint.name
+            injected = endpoint.validate_params({"symbol": "AAPL", "year": 2024})
+            assert injected["period"] == "FY"
+            with pytest.raises(FMPValidationError, match="Missing mandatory parameter"):
+                endpoint.validate_params({"symbol": "AAPL"})

--- a/tests/unit/test_company.py
+++ b/tests/unit/test_company.py
@@ -1662,7 +1662,7 @@ class TestCompanyLogoUrl:
 
 
 class TestSegmentationAndReportDefaults:
-    """Mandatory structure/period defaults never apply (#349)."""
+    """Leftover structure/period defaults apply only as optional_params (#349)."""
 
     def test_segmentation_structure_and_period_are_optional(self) -> None:
         from fmp_data.company.endpoints import (

--- a/tests/unit/test_company_coverage.py
+++ b/tests/unit/test_company_coverage.py
@@ -306,6 +306,26 @@ class TestCompanyClientCoverage:
         params = mock_request.call_args.kwargs["params"]
         assert params["symbol"] == "AAPL"
         assert params["period"] == "annual"
+        assert params["structure"] == "flat"
+
+    @patch("httpx.Client.request")
+    def test_get_geographic_revenue_segmentation_nested_structure(
+        self, mock_request, fmp_client, mock_response, geographic_revenue_data
+    ):
+        """structure=nested is forwarded; response model is unchanged."""
+        mock_request.return_value = mock_response(
+            status_code=200, json_data=[geographic_revenue_data]
+        )
+
+        result = fmp_client.company.get_geographic_revenue_segmentation(
+            "AAPL", structure="nested"
+        )
+
+        assert len(result) == 1
+        assert isinstance(result[0], GeographicRevenueSegment)
+        params = mock_request.call_args.kwargs["params"]
+        assert params["structure"] == "nested"
+        assert params["period"] == "annual"
 
     @patch("httpx.Client.request")
     def test_get_intraday_prices_with_filters(

--- a/tests/unit/test_company_coverage.py
+++ b/tests/unit/test_company_coverage.py
@@ -20,6 +20,7 @@ from fmp_data.company.models import (
     HistoricalPrice,
     IntradayPrice,
     MergerAcquisition,
+    ProductRevenueSegment,
     Quote,
     RevenueSegmentItem,
     SimpleQuote,
@@ -308,21 +309,32 @@ class TestCompanyClientCoverage:
         assert params["period"] == "annual"
         assert params["structure"] == "flat"
 
+    @pytest.mark.parametrize(
+        "method_name,model_cls",
+        [
+            ("get_geographic_revenue_segmentation", GeographicRevenueSegment),
+            ("get_product_revenue_segmentation", ProductRevenueSegment),
+        ],
+    )
     @patch("httpx.Client.request")
-    def test_get_geographic_revenue_segmentation_nested_structure(
-        self, mock_request, fmp_client, mock_response, geographic_revenue_data
+    def test_revenue_segmentation_nested_structure(
+        self,
+        mock_request,
+        fmp_client,
+        mock_response,
+        geographic_revenue_data,
+        method_name,
+        model_cls,
     ):
         """structure=nested is forwarded; response model is unchanged."""
         mock_request.return_value = mock_response(
             status_code=200, json_data=[geographic_revenue_data]
         )
 
-        result = fmp_client.company.get_geographic_revenue_segmentation(
-            "AAPL", structure="nested"
-        )
+        result = getattr(fmp_client.company, method_name)("AAPL", structure="nested")
 
         assert len(result) == 1
-        assert isinstance(result[0], GeographicRevenueSegment)
+        assert isinstance(result[0], model_cls)
         params = mock_request.call_args.kwargs["params"]
         assert params["structure"] == "nested"
         assert params["period"] == "annual"

--- a/tests/unit/test_param_required_consistency.py
+++ b/tests/unit/test_param_required_consistency.py
@@ -169,6 +169,27 @@ def test_required_is_derived_from_list_membership() -> None:
     )
 
 
+def test_mandatory_params_do_not_carry_defaults() -> None:
+    """A default on a mandatory param never applies (#165 / #349)."""
+    leftovers: list[str] = []
+    checked = 0
+    for module_name, attr, endpoint in _endpoints():
+        for param in endpoint.mandatory_params:
+            checked += 1
+            if param.default is not None:
+                leftovers.append(
+                    f"{module_name}.{attr}.{param.name}: default={param.default!r}"
+                )
+    assert not leftovers, (
+        "mandatory params with a default never apply; move them to "
+        "optional_params:\n  " + "\n  ".join(leftovers)
+    )
+    assert checked >= _MIN_PARAMS, (
+        f"only {checked} mandatory params inspected; is the walk working? "
+        f"skipped: {SKIPPED_MODULES}"
+    )
+
+
 def test_every_param_has_a_description() -> None:
     """``description`` lost its no-default status; this covers what mypy cannot.
 

--- a/tests/unit/test_param_required_consistency.py
+++ b/tests/unit/test_param_required_consistency.py
@@ -173,19 +173,25 @@ def test_mandatory_params_do_not_carry_defaults() -> None:
     """A default on a mandatory param never applies (#165 / #349)."""
     leftovers: list[str] = []
     checked = 0
-    for module_name, attr, endpoint in _endpoints():
+    endpoints = _endpoints()
+    for module_name, attr, endpoint in endpoints:
         for param in endpoint.mandatory_params:
             checked += 1
             if param.default is not None:
                 leftovers.append(
                     f"{module_name}.{attr}.{param.name}: default={param.default!r}"
                 )
+        checked += len(endpoint.optional_params or [])
     assert not leftovers, (
         "mandatory params with a default never apply; move them to "
         "optional_params:\n  " + "\n  ".join(leftovers)
     )
+    assert len(endpoints) >= _MIN_ENDPOINTS, (
+        f"only {len(endpoints)} endpoints inspected; is the walk working? "
+        f"skipped: {SKIPPED_MODULES}"
+    )
     assert checked >= _MIN_PARAMS, (
-        f"only {checked} mandatory params inspected; is the walk working? "
+        f"only {checked} params inspected; is the walk working? "
         f"skipped: {SKIPPED_MODULES}"
     )
 


### PR DESCRIPTION
## Summary

- Move leftover mandatory-plus-default `structure` / `period` on product and geographic revenue segmentation, and `period` on financial-reports JSON/XLSX, to `optional_params` so `validate_params` applies the documented defaults (`flat` / `annual` / `FY`). Same #165 list-membership rule as #345 / #347.
- Segmentation methods now take `structure: Structure = "flat"` (`Literal["flat", "nested"]`) and pass it through. `Structure` is not re-exported from `fmp_data`. Leftover `StructureTypeEnum` unpacks from `STRUCTURE_VALUES`.
- Live `/stable` returns the same list-of-objects for omitted, `flat`, and `nested` (AAPL / MSFT / TSLA, annual and quarter, probed 2026-08-17). Same response models; undocumented tokens like `"tree"` are rejected locally.
- Catalogue lock: no `mandatory_params` entry may carry a `default`. LangChain `KNOWN_DROPPED_MANDATORY_WIRE` is empty.

`Closes #349` is inert on a `dev`-base PR — close #349 by hand after merge.

## Test Plan

- [x] `uv run pytest` focused suite: 120 passed (`test_param_required_consistency`, closed vocabularies, company locks/coverage, LC coverage/dispatch/tool-schema, tool_binding, catalog registration)
- [ ] Protect Dev / Test-Matrix on this PR
- [ ] Close #349 by hand after merge