### PR TITLE
fix(sec): map leftover RequestError without leaking apikey (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,8 +97,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   secret-absent pin as #97 / #350 (`str` / `repr` / `__cause__` /
   traceback / error log). `ProtocolError` / `ProxyError` stay
   retryable; the others set `FMPNetworkError.retryable = False`.
-  Timeouts stay `FMPTimeoutError`. `validate_api_key` already classifies
-  `FMPNetworkError` as `unavailable`.
+  Timeouts stay `FMPTimeoutError`. `validate_api_key` classifies
+  `FMPNetworkError` and raw non-timeout `httpx.RequestError` (fakes /
+  adapters) as `unavailable`.
 
 - **Timeout and network errors no longer leak `apikey=` (#350).**
   `httpx.TimeoutException` / `httpx.NetworkError` now raise

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Remaining `httpx.RequestError` leftovers no longer leak `apikey=`
+  (#354).** `ProtocolError`, `ProxyError`, `DecodingError`,
+  `TooManyRedirects`, `UnsupportedProtocol`, and any future
+  `RequestError` now raise `FMPNetworkError` with `from None`. Same
+  secret-absent pin as #97 / #350 (`str` / `repr` / `__cause__` /
+  traceback / error log). `ProtocolError` / `ProxyError` stay
+  retryable; the others set `FMPNetworkError.retryable = False`.
+  Timeouts stay `FMPTimeoutError`. `validate_api_key` already classifies
+  `FMPNetworkError` as `unavailable`.
+
 - **Timeout and network errors no longer leak `apikey=` (#350).**
   `httpx.TimeoutException` / `httpx.NetworkError` now raise
   `FMPTimeoutError` / `FMPNetworkError` with `from None`. The request

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,8 +130,11 @@ Each domain client is an `EndpointGroup` wrapper around a shared `BaseClient` an
 
 ### Retry and Rate Limiting
 The `BaseClient` uses `tenacity` for automatic retries on transient failures:
-- Retries on `FMPTimeoutError`, `FMPNetworkError`, and 5xx `FMPError`
-  (plus leftover raw `httpx.TimeoutException` / `httpx.NetworkError`)
+- Retries on `FMPTimeoutError`, retryable `FMPNetworkError`, and 5xx
+  `FMPError` (plus leftover raw `httpx.TimeoutException` /
+  `httpx.NetworkError` / `httpx.ProtocolError` / `httpx.ProxyError`).
+  Leftover `RequestError`s such as `TooManyRedirects` map to
+  `FMPNetworkError(retryable=False)` and are not retried.
 - Exponential backoff: multiplier=1, min=4s, max=10s
 - Configurable maximum attempts (default=3)
 
@@ -159,7 +162,7 @@ Custom exceptions for error handling (all in `fmp_data/exceptions.py`):
 ```text
 FMPError                  # Base exception for all FMP API errors
 ├── FMPTimeoutError       # HTTP request timed out (#350)
-├── FMPNetworkError       # Transport / connect failure (#350)
+├── FMPNetworkError       # Transport / leftover RequestError (#350, #354)
 ├── RateLimitError        # 429 - includes retry_after attribute
 ├── AuthenticationError   # 401 - invalid or missing API key
 ├── ValidationError       # 400 - invalid request parameters

--- a/README.md
+++ b/README.md
@@ -732,7 +732,7 @@ from fmp_data import FMPDataClient
 from fmp_data.exceptions import (
     FMPError,  # Base exception for all FMP errors
     FMPTimeoutError,  # HTTP request timed out
-    FMPNetworkError,  # Transport / connect failure
+    FMPNetworkError,  # Transport / leftover RequestError
     RateLimitError,  # API rate limit exceeded
     AuthenticationError,  # Invalid or missing API key
     ValidationError,  # Invalid request parameters

--- a/docs/superpowers/specs/2026-08-19-remaining-requesterror-key-leak-design.md
+++ b/docs/superpowers/specs/2026-08-19-remaining-requesterror-key-leak-design.md
@@ -1,0 +1,69 @@
+# Remaining `httpx.RequestError` leftovers must not leak `apikey`
+
+**Date:** 2026-08-19
+**Base:** `origin/dev` @ `f712a4d`
+**Issue:** #354
+**Status:** approved (fold leftovers into `FMPNetworkError`; retry Protocol/Proxy only)
+
+## Problem
+
+#350 / PR #353 maps `httpx.TimeoutException` → `FMPTimeoutError` and
+`httpx.NetworkError` → `FMPNetworkError` with `raise … from None`. Other
+`httpx.RequestError` subclasses still hit `_handle_execute_failure`'s
+generic logger (`str(exc)` + `exc_info=True`) and re-raise raw httpx.
+httpx stringifies `request.url`, which carries `apikey=`.
+
+Leftovers on httpx 0.28:
+
+- `ProtocolError` / `ProxyError` / `UnsupportedProtocol` (`TransportError`)
+- `DecodingError` / `TooManyRedirects` (`RequestError`, not `TransportError`)
+- any future `RequestError` that is not a timeout or `NetworkError`
+
+`HTTPStatusError` stays on the #97 path.
+
+## Decisions
+
+| Fork | Choice |
+|---|---|
+| Packaging | Isolated PR; #352 is a follow-up |
+| Types | Fold leftovers into `FMPNetworkError` |
+| Retry | `ProtocolError` / `ProxyError` retryable; other leftovers `retryable=False` |
+| Helper export | None (`raise_secret_safe` stays out of scope) |
+
+## Design
+
+### Mapping
+
+In `_reraise_transport_failure`, after the existing timeout / network
+arms, map leftover `httpx.RequestError` with fixed log lines and
+`raise … from None` **before** the generic logger.
+
+| httpx type | message | `FMPNetworkError.retryable` |
+|---|---|---|
+| `TimeoutException` | `Request timed out` | n/a (`FMPTimeoutError`) |
+| `NetworkError` | `Network error` | `True` (default) |
+| `ProtocolError` | `Protocol error` | `True` |
+| `ProxyError` | `Proxy error` | `True` |
+| other `RequestError` | `Transport error` | `False` |
+
+`_handle_execute_failure` widens its gate from
+`TimeoutException | NetworkError` to `RequestError`.
+
+### Retry
+
+`_is_retryable_error` uses `FMPNetworkError.retryable` instead of
+`isinstance(..., FMPNetworkError)`. Raw httpx defense in depth also
+retries `ProtocolError` / `ProxyError`.
+
+### First-party catcher
+
+`validate_api_key` already maps `FMPNetworkError` → `unavailable`.
+Widen that arm to `FMPNetworkError | httpx.RequestError` so leftover
+fakes/adapters cannot fall through to a valid-key report.
+`TimeoutException` stays in the earlier timeout arm.
+
+## Non-goals
+
+- Public `raise_secret_safe` / exporting `_redaction`
+- `#352` Structure export
+- New `FMPTransportError` parent

--- a/fmp_data/base.py
+++ b/fmp_data/base.py
@@ -465,9 +465,17 @@ class BaseClient:
 
     @staticmethod
     def _is_retryable_error(exc: BaseException) -> bool:
-        if isinstance(exc, FMPTimeoutError | FMPNetworkError):
+        if isinstance(exc, FMPTimeoutError):
             return True
-        if isinstance(exc, httpx.TimeoutException | httpx.NetworkError):
+        if isinstance(exc, FMPNetworkError):
+            return exc.retryable
+        if isinstance(
+            exc,
+            httpx.TimeoutException
+            | httpx.NetworkError
+            | httpx.ProtocolError
+            | httpx.ProxyError,
+        ):
             return True
         if isinstance(exc, RateLimitError):
             return True
@@ -485,10 +493,11 @@ class BaseClient:
     def _reraise_transport_failure(
         self, exc: BaseException, *, endpoint_name: str
     ) -> NoReturn:
-        """Map timeout/network httpx errors without chaining the request URL.
+        """Map request-layer httpx errors without chaining the request URL.
 
         ``from None`` is the same pin as ``_raise_fmp_http_error`` (#97):
-        httpx stringifies ``request.url``, which carries ``apikey=`` (#350).
+        httpx stringifies ``request.url``, which carries ``apikey=``
+        (#350 / #354).
         """
         if isinstance(exc, httpx.TimeoutException):
             self.logger.error(
@@ -502,13 +511,31 @@ class BaseClient:
                 extra={"endpoint": endpoint_name},
             )
             raise FMPNetworkError("Network error") from None
+        if isinstance(exc, httpx.ProtocolError):
+            self.logger.error(
+                "Protocol error",
+                extra={"endpoint": endpoint_name},
+            )
+            raise FMPNetworkError("Protocol error") from None
+        if isinstance(exc, httpx.ProxyError):
+            self.logger.error(
+                "Proxy error",
+                extra={"endpoint": endpoint_name},
+            )
+            raise FMPNetworkError("Proxy error") from None
+        if isinstance(exc, httpx.RequestError):
+            self.logger.error(
+                "Transport error",
+                extra={"endpoint": endpoint_name},
+            )
+            raise FMPNetworkError("Transport error", retryable=False) from None
         raise exc
 
     def _handle_execute_failure(
         self, exc: BaseException, *, endpoint_name: str
     ) -> None:
-        """Log a failed attempt, mapping transport errors first (#350)."""
-        if isinstance(exc, httpx.TimeoutException | httpx.NetworkError):
+        """Log a failed attempt, mapping transport errors first (#350 / #354)."""
+        if isinstance(exc, httpx.RequestError):
             self._reraise_transport_failure(exc, endpoint_name=endpoint_name)
         self.logger.error(
             "Request failed: %s",

--- a/fmp_data/exceptions.py
+++ b/fmp_data/exceptions.py
@@ -22,7 +22,25 @@ class FMPTimeoutError(FMPError):
 
 
 class FMPNetworkError(FMPError):
-    """Raised when an FMP HTTP request fails at the transport layer."""
+    """Raised when an FMP HTTP request fails at the transport layer.
+
+    Covers ``httpx.NetworkError`` and leftover ``httpx.RequestError``
+    subclasses that are not timeouts (#350 / #354). ``retryable`` is True
+    for connect / protocol / proxy failures and False for
+    ``UnsupportedProtocol``, ``DecodingError``, ``TooManyRedirects``, and
+    any future ``RequestError`` that is not one of those.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        status_code: int | None = None,
+        response: dict[str, Any] | list[Any] | None = None,
+        *,
+        retryable: bool = True,
+    ) -> None:
+        super().__init__(message, status_code, response)
+        self.retryable = retryable
 
 
 class RateLimitError(FMPError):

--- a/fmp_data/mcp/utils.py
+++ b/fmp_data/mcp/utils.py
@@ -348,9 +348,10 @@ def validate_api_key(api_key: str) -> tuple[bool, ApiKeyCheckReason]:
         # #350 maps client timeouts to FMPTimeoutError. Keep the raw
         # httpx type for fakes/adapters that still raise it.
         return False, "timeout"
-    except FMPNetworkError:
-        # Same mapping: a connect failure is not proof the key works.
-        # Raw httpx.NetworkError still lands in except Exception below.
+    except (FMPNetworkError, httpx.RequestError):
+        # #350 / #354: leftover RequestError subclasses map to
+        # FMPNetworkError. Keep the raw httpx type for fakes/adapters.
+        # TimeoutException is a RequestError and is handled above.
         return False, "unavailable"
     except FMPError as exc:
         # AuthenticationError (HTTP 401 and typed 2xx invalid-key

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -1497,7 +1497,8 @@ def test_protocol_error_is_retried(mock_request, mock_endpoint, base_client) -> 
     ):
         base_client.request(mock_endpoint)
     assert exc_info.value.retryable is True
-    assert mock_request.call_count > 1
+    assert mock_request.call_count == base_client.config.max_retries
+    _assert_secret_stays_off_exception(exc_info.value, _LEAK_SECRET)
 
 
 @patch("httpx.Client.request")
@@ -1512,6 +1513,72 @@ def test_too_many_redirects_is_not_retried(
         base_client.request(mock_endpoint)
     assert exc_info.value.retryable is False
     assert mock_request.call_count == 1
+    _assert_secret_stays_off_exception(exc_info.value, _LEAK_SECRET)
+
+
+@pytest.mark.asyncio
+async def test_async_protocol_error_is_retried(mock_endpoint, client_config) -> None:
+    """#354: ProtocolError uses the configured attempt count on the async path."""
+    mock_endpoint.method = MagicMock()
+    mock_endpoint.method.value = "GET"
+    mock_endpoint.response_model = SampleResponse
+    config = ClientConfig(
+        api_key=_LEAK_SECRET,
+        base_url=client_config.base_url,
+        max_retries=3,
+        max_rate_limit_retries=0,
+    )
+    client = BaseClient(config)
+    mock_async_client = AsyncMock()
+    mock_async_client.request = AsyncMock(
+        side_effect=_httpx_error_with_key(httpx.ProtocolError, _LEAK_SECRET)
+    )
+    try:
+        with (
+            patch.object(client, "_setup_async_client", return_value=mock_async_client),
+            patch("tenacity.nap.sleep", return_value=None),
+            pytest.raises(FMPNetworkError) as exc_info,
+        ):
+            await client.request_async(mock_endpoint)
+    finally:
+        await client.aclose()
+        client.close()
+    assert exc_info.value.retryable is True
+    assert mock_async_client.request.call_count == config.max_retries
+    _assert_secret_stays_off_exception(exc_info.value, _LEAK_SECRET)
+
+
+@pytest.mark.asyncio
+async def test_async_too_many_redirects_is_not_retried(
+    mock_endpoint, client_config
+) -> None:
+    """#354: TooManyRedirects is a single attempt on the async path."""
+    mock_endpoint.method = MagicMock()
+    mock_endpoint.method.value = "GET"
+    mock_endpoint.response_model = SampleResponse
+    config = ClientConfig(
+        api_key=_LEAK_SECRET,
+        base_url=client_config.base_url,
+        max_retries=3,
+        max_rate_limit_retries=0,
+    )
+    client = BaseClient(config)
+    mock_async_client = AsyncMock()
+    mock_async_client.request = AsyncMock(
+        side_effect=_httpx_error_with_key(httpx.TooManyRedirects, _LEAK_SECRET)
+    )
+    try:
+        with (
+            patch.object(client, "_setup_async_client", return_value=mock_async_client),
+            pytest.raises(FMPNetworkError) as exc_info,
+        ):
+            await client.request_async(mock_endpoint)
+    finally:
+        await client.aclose()
+        client.close()
+    assert exc_info.value.retryable is False
+    assert mock_async_client.request.call_count == 1
+    _assert_secret_stays_off_exception(exc_info.value, _LEAK_SECRET)
 
 
 def test_request_retries_on_http_5xx(base_client):

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -789,6 +789,23 @@ def test_is_retryable_error_includes_mapped_5xx_fmp_errors():
     assert not BaseClient._is_retryable_error(ValueError("other"))
     assert BaseClient._is_retryable_error(FMPTimeoutError("Request timed out"))
     assert BaseClient._is_retryable_error(FMPNetworkError("Network error"))
+    assert BaseClient._is_retryable_error(FMPNetworkError("Protocol error"))
+    assert not BaseClient._is_retryable_error(
+        FMPNetworkError("Transport error", retryable=False)
+    )
+    assert BaseClient._is_retryable_error(
+        httpx.ProtocolError("protocol", request=request)
+    )
+    assert BaseClient._is_retryable_error(httpx.ProxyError("proxy", request=request))
+    assert not BaseClient._is_retryable_error(
+        httpx.TooManyRedirects("redirects", request=request)
+    )
+    assert not BaseClient._is_retryable_error(
+        httpx.UnsupportedProtocol("scheme", request=request)
+    )
+    assert not BaseClient._is_retryable_error(
+        httpx.DecodingError("decode", request=request)
+    )
 
 
 _LEAK_SECRET = "SECRET_FMP_KEY_123"  # noqa: S105  # pragma: allowlist secret
@@ -813,9 +830,17 @@ def _assert_secret_stays_off_exception(exc: BaseException, secret: str) -> None:
     assert secret not in repr(exc)
     assert secret not in repr(exc.__cause__)
     assert secret not in rendered
-    assert "httpx.TimeoutException" not in rendered
-    assert "httpx.ConnectError" not in rendered
-    assert "httpx.NetworkError" not in rendered
+    for name in (
+        "httpx.TimeoutException",
+        "httpx.ConnectError",
+        "httpx.NetworkError",
+        "httpx.ProtocolError",
+        "httpx.ProxyError",
+        "httpx.DecodingError",
+        "httpx.TooManyRedirects",
+        "httpx.UnsupportedProtocol",
+    ):
+        assert name not in rendered, name
 
 
 @patch("httpx.Client.request")
@@ -955,6 +980,101 @@ async def test_async_network_error_does_not_leak_apikey_via_cause_or_logs(
         await client.aclose()
         client.close()
 
+    _assert_secret_stays_off_exception(exc_info.value, _LEAK_SECRET)
+    mock_error.assert_called()
+    for call in mock_error.call_args_list:
+        assert _LEAK_SECRET not in str(call)
+        assert call.kwargs.get("exc_info") is not True
+
+
+_LEFTOVER_REQUEST_CASES = (
+    (httpx.ProtocolError, "Protocol error", True),
+    (httpx.ProxyError, "Proxy error", True),
+    (httpx.TooManyRedirects, "Transport error", False),
+    (httpx.UnsupportedProtocol, "Transport error", False),
+    (httpx.DecodingError, "Transport error", False),
+)
+
+
+@pytest.mark.parametrize(("exc_cls", "message", "retryable"), _LEFTOVER_REQUEST_CASES)
+@patch("httpx.Client.request")
+def test_leftover_request_error_does_not_leak_apikey_via_cause_or_logs(
+    mock_request,
+    mock_endpoint,
+    client_config,
+    exc_cls: type[httpx.RequestError],
+    message: str,
+    retryable: bool,
+) -> None:
+    """#354: leftover RequestError subclasses must not chain httpx or log the URL."""
+    mock_request.side_effect = _httpx_error_with_key(exc_cls, _LEAK_SECRET)
+    mock_endpoint.method = MagicMock()
+    mock_endpoint.method.value = "GET"
+    mock_endpoint.response_model = SampleResponse
+    config = ClientConfig(
+        api_key=_LEAK_SECRET,
+        base_url=client_config.base_url,
+        max_retries=1,
+        max_rate_limit_retries=0,
+    )
+    client = BaseClient(config)
+    try:
+        with (
+            patch.object(client.logger, "error") as mock_error,
+            patch("tenacity.nap.sleep", return_value=None),
+            pytest.raises(FMPNetworkError) as exc_info,
+        ):
+            client.request(mock_endpoint)
+    finally:
+        client.close()
+
+    assert exc_info.value.message == message
+    assert exc_info.value.retryable is retryable
+    _assert_secret_stays_off_exception(exc_info.value, _LEAK_SECRET)
+    mock_error.assert_called()
+    for call in mock_error.call_args_list:
+        assert _LEAK_SECRET not in str(call)
+        assert call.kwargs.get("exc_info") is not True
+
+
+@pytest.mark.parametrize(("exc_cls", "message", "retryable"), _LEFTOVER_REQUEST_CASES)
+@pytest.mark.asyncio
+async def test_async_leftover_request_error_does_not_leak_apikey_via_cause_or_logs(
+    mock_endpoint,
+    client_config,
+    exc_cls: type[httpx.RequestError],
+    message: str,
+    retryable: bool,
+) -> None:
+    """#354 async twin of the leftover RequestError pin."""
+    mock_endpoint.method = MagicMock()
+    mock_endpoint.method.value = "GET"
+    mock_endpoint.response_model = SampleResponse
+    config = ClientConfig(
+        api_key=_LEAK_SECRET,
+        base_url=client_config.base_url,
+        max_retries=1,
+        max_rate_limit_retries=0,
+    )
+    client = BaseClient(config)
+    mock_async_client = AsyncMock()
+    mock_async_client.request = AsyncMock(
+        side_effect=_httpx_error_with_key(exc_cls, _LEAK_SECRET)
+    )
+    try:
+        with (
+            patch.object(client, "_setup_async_client", return_value=mock_async_client),
+            patch.object(client.logger, "error") as mock_error,
+            patch("tenacity.nap.sleep", return_value=None),
+            pytest.raises(FMPNetworkError) as exc_info,
+        ):
+            await client.request_async(mock_endpoint)
+    finally:
+        await client.aclose()
+        client.close()
+
+    assert exc_info.value.message == message
+    assert exc_info.value.retryable is retryable
     _assert_secret_stays_off_exception(exc_info.value, _LEAK_SECRET)
     mock_error.assert_called()
     for call in mock_error.call_args_list:
@@ -1365,6 +1485,33 @@ def test_request_non_retryable_error(mock_request, mock_endpoint, base_client):
         base_client.request(mock_endpoint)
 
     assert mock_request.call_count == 1  # Should not retry
+
+
+@patch("httpx.Client.request")
+def test_protocol_error_is_retried(mock_request, mock_endpoint, base_client) -> None:
+    """#354: ProtocolError stays retryable after mapping."""
+    mock_request.side_effect = _httpx_error_with_key(httpx.ProtocolError, _LEAK_SECRET)
+    with (
+        patch("tenacity.nap.sleep", return_value=None),
+        pytest.raises(FMPNetworkError) as exc_info,
+    ):
+        base_client.request(mock_endpoint)
+    assert exc_info.value.retryable is True
+    assert mock_request.call_count > 1
+
+
+@patch("httpx.Client.request")
+def test_too_many_redirects_is_not_retried(
+    mock_request, mock_endpoint, base_client
+) -> None:
+    """#354: leftover RequestErrors such as TooManyRedirects are not retried."""
+    mock_request.side_effect = _httpx_error_with_key(
+        httpx.TooManyRedirects, _LEAK_SECRET
+    )
+    with pytest.raises(FMPNetworkError) as exc_info:
+        base_client.request(mock_endpoint)
+    assert exc_info.value.retryable is False
+    assert mock_request.call_count == 1
 
 
 def test_request_retries_on_http_5xx(base_client):

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -312,6 +312,10 @@ class TestFMPNetworkError:
         assert fmp_data.FMPNetworkError is FMPNetworkError
         assert "FMPNetworkError" in fmp_data.__all__
 
+    def test_retryable_defaults_true_and_can_be_cleared(self) -> None:
+        assert FMPNetworkError("Network error").retryable is True
+        assert FMPNetworkError("Transport error", retryable=False).retryable is False
+
 
 class TestFMPNotFound:
     """Tests for FMPNotFound"""

--- a/tests/unit/test_mcp_utils.py
+++ b/tests/unit/test_mcp_utils.py
@@ -835,6 +835,43 @@ class TestValidateApiKey:
         assert mcp_utils.validate_api_key("KEY123") == (False, "unavailable")
         assert NetworkClient.instances[-1].closed is True
 
+    def test_leftover_fmp_network_error_is_unavailable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#354: non-retryable leftover RequestError mapping is still unavailable."""
+        from fmp_data.exceptions import FMPNetworkError
+
+        class TransportClient(_FakeFmpClient):
+            def __init__(self, **kwargs: Any) -> None:
+                super().__init__(**kwargs)
+                self.company = _FakeCompany(
+                    raises=FMPNetworkError("Transport error", retryable=False)
+                )
+
+        monkeypatch.setattr("fmp_data.client.FMPDataClient", TransportClient)
+
+        assert mcp_utils.validate_api_key("KEY123") == (False, "unavailable")
+        assert TransportClient.instances[-1].closed is True
+
+    def test_httpx_protocol_error_is_unavailable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#354: raw leftover RequestError fakes stay unavailable."""
+        import httpx
+
+        class ProtocolClient(_FakeFmpClient):
+            def __init__(self, **kwargs: Any) -> None:
+                super().__init__(**kwargs)
+                request = httpx.Request("GET", "https://example.test/quote")
+                self.company = _FakeCompany(
+                    raises=httpx.ProtocolError("broken", request=request)
+                )
+
+        monkeypatch.setattr("fmp_data.client.FMPDataClient", ProtocolClient)
+
+        assert mcp_utils.validate_api_key("KEY123") == (False, "unavailable")
+        assert ProtocolClient.instances[-1].closed is True
+
     def test_non_auth_fmp_error_still_counts_as_valid(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary

#350 / PR #353 mapped `httpx.TimeoutException` and `httpx.NetworkError`. The remaining `httpx.RequestError` subclasses still hit the generic logger (`str(exc)` + `exc_info=True`) and re-raised raw httpx, so `request.url` (with `apikey=`) leaked into logs and `__cause__`.

This PR:

- Maps leftover `RequestError`s to `FMPNetworkError` with `raise … from None` before the generic logger.
- Logs a fixed line (`Protocol error` / `Proxy error` / `Transport error`) with `endpoint` extra only.
- Adds `FMPNetworkError.retryable` (default `True`). `ProtocolError` / `ProxyError` stay retryable; `DecodingError`, `TooManyRedirects`, `UnsupportedProtocol`, and any future leftover `RequestError` set `retryable=False`.
- Widens `validate_api_key` to treat `httpx.RequestError` as `unavailable` (timeout still wins first because `TimeoutException` is a `RequestError`).
- Pins the #97 / #350 secret-absent assertions on ProtocolError, ProxyError, TooManyRedirects, UnsupportedProtocol, and DecodingError (sync + async), plus retry-count pins.

Not in this PR:

- Public `raise_secret_safe` / exporting `_redaction` (still bina-capital#2610).
- `#352` Structure export (follow-up PR).

`Closes #354` is inert on a `dev`-base PR — close #354 by hand after merge.

## Test Plan

- [x] `uv run pytest tests/unit/test_base.py tests/unit/test_exceptions.py tests/unit/test_mcp_utils.py -q` → 297 passed
- [x] ruff + mypy on touched modules; pre-commit passed on commit
- [ ] Protect Dev / Test-Matrix on this PR
- [ ] Close #354 by hand after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of network and request failures to prevent API keys from appearing in error messages or logs.
  * Retry behavior is now more precise: protocol and proxy failures remain retryable, while redirects and other unsupported request errors are not retried.
  * API-key validation consistently reports network-related failures as unavailable.
* **Documentation**
  * Updated retry and network-error documentation to reflect the expanded error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->