### PR TITLE
feat(schema): re-export Structure from the public fmp_data surface (#352)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,9 +81,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   defaults (`flat` / `annual` / `FY`). Segmentation methods now take
   `structure: Structure = "flat"` (`Literal["flat", "nested"]`).
   Stable currently returns the same list-of-objects for both
-  (probed 2026-08-17). `Structure` is not re-exported from
-  `fmp_data`. No remaining mandatory-plus-default params in the
-  catalogue.
+  (probed 2026-08-17). No remaining mandatory-plus-default params in
+  the catalogue.
 
 - **`SenateNetWorthValueRange` no longer shadows builtins (#336).**
   Fields are `minimum` / `maximum` (wire aliases `min` / `max`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   2026-08-15 returned 200 with 12 yearly rows when it was omitted,
   sent empty, or set to `total`. Missing `senateID` is 400.
 
+- **Public re-export of `Structure` (#352).** Annotate revenue
+  segmentation `structure=` against `from fmp_data import Structure`.
+  It is `Literal["flat", "nested"]`. Live `/stable` returns the same
+  list-of-objects for both (probed 2026-08-17). `StructureTypeEnum`
+  stays leftover / deprecated.
+
 ### Changed
 
 - **One module now owns credential display redaction (#316).**

--- a/LLM.md
+++ b/LLM.md
@@ -79,6 +79,7 @@ from fmp_data import (
     Period,
     PeriodAnnualQuarter,
     PeriodFiscal,
+    Structure,
     TechnicalInterval,
     Timeframe,
 )
@@ -89,7 +90,9 @@ Keep the three period types distinct. Most statement endpoints take `Period`
 take only `PeriodFiscal`. Some company series take only `PeriodAnnualQuarter`.
 `Timeframe` is `Interval` plus `"1day"`. `TechnicalClient.interval=` takes
 `TechnicalInterval` (`Interval` plus `"daily"` / `"hourly"`), not
-`Timeframe`. Plain strings still work at runtime.
+`Timeframe`. Revenue segmentation `structure=` takes `Structure`
+(`flat` / `nested`); live `/stable` returns the same list-of-objects for
+both. Plain strings still work at runtime.
 
 ## Responses and data handling
 Endpoints return Pydantic models (or lists of models). Use attributes directly

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -3,9 +3,9 @@
 ## Closed request vocabularies
 
 `Period`, `PeriodFiscal`, `PeriodAnnualQuarter`, `Interval`,
-`TechnicalInterval`, and `Timeframe` are re-exported from `fmp_data`.
-They are the typed contracts for client method parameters. Import them
-from the package root:
+`TechnicalInterval`, `Timeframe`, and `Structure` are re-exported from
+`fmp_data`. They are the typed contracts for client method parameters.
+Import them from the package root:
 
 ```python
 from fmp_data import (
@@ -13,6 +13,7 @@ from fmp_data import (
     Period,
     PeriodAnnualQuarter,
     PeriodFiscal,
+    Structure,
     TechnicalInterval,
     Timeframe,
 )
@@ -23,7 +24,9 @@ Do not collapse the three period aliases. Most statement endpoints take
 batch bulk accept only `PeriodFiscal`. Some company series take only
 `PeriodAnnualQuarter`. `Timeframe` is `Interval` plus `"1day"`.
 `TechnicalClient.interval=` takes `TechnicalInterval` (`Interval` plus
-`"daily"` / `"hourly"`), not `Timeframe`.
+`"daily"` / `"hourly"`), not `Timeframe`. Revenue segmentation
+`structure=` takes `Structure` (`flat` / `nested`); live `/stable`
+returns the same list-of-objects for both.
 
 ## Main Clients
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -120,6 +120,7 @@ from fmp_data import (
     Period,
     PeriodAnnualQuarter,
     PeriodFiscal,
+    Structure,
     TechnicalInterval,
     Timeframe,
 )
@@ -130,7 +131,9 @@ There are three period types on purpose: most statement endpoints take
 batch bulk take only `PeriodFiscal`. Some company series take only
 `PeriodAnnualQuarter`. `Timeframe` is `Interval` plus `"1day"`.
 `TechnicalClient.interval=` takes `TechnicalInterval` (`Interval` plus
-`"daily"` / `"hourly"`), not `Timeframe`.
+`"daily"` / `"hourly"`), not `Timeframe`. Revenue segmentation
+`structure=` takes `Structure` (`flat` / `nested`); live `/stable`
+returns the same list-of-objects for both.
 
 ### Response Caching
 

--- a/fmp_data/__init__.py
+++ b/fmp_data/__init__.py
@@ -43,6 +43,7 @@ from fmp_data.schema import (
     Period,
     PeriodAnnualQuarter,
     PeriodFiscal,
+    Structure,
     TechnicalInterval,
     Timeframe,
 )
@@ -76,6 +77,7 @@ __all__ = [
     "PeriodFiscal",
     "RateLimitConfig",
     "RateLimitError",
+    "Structure",
     "TechnicalInterval",
     "Timeframe",
     "ValidationError",

--- a/fmp_data/company/endpoints.py
+++ b/fmp_data/company/endpoints.py
@@ -567,7 +567,11 @@ PRODUCT_REVENUE_SEGMENTATION: Endpoint[ProductRevenueSegment] = Endpoint(
             name="structure",
             location=ParamLocation.QUERY,
             param_type=ParamType.STRING,
-            description="Data structure format",
+            description=(
+                "Response layout (flat or nested). Stable currently "
+                "returns the same list-of-objects for both "
+                "(probed 2026-08-17)."
+            ),
             default="flat",
             valid_values=list(STRUCTURE_VALUES),
         ),
@@ -612,7 +616,11 @@ GEOGRAPHIC_REVENUE_SEGMENTATION: Endpoint[GeographicRevenueSegment] = Endpoint(
             name="structure",
             location=ParamLocation.QUERY,
             param_type=ParamType.STRING,
-            description="Data structure format",
+            description=(
+                "Response layout (flat or nested). Stable currently "
+                "returns the same list-of-objects for both "
+                "(probed 2026-08-17)."
+            ),
             default="flat",
             valid_values=list(STRUCTURE_VALUES),
         ),

--- a/fmp_data/company/hints.py
+++ b/fmp_data/company/hints.py
@@ -1,10 +1,19 @@
 from fmp_data.lc.models import ParameterHint, ResponseFieldInfo
 
+# Live /stable returns the same list-of-objects for flat and nested
+# (probed 2026-08-17). Method docstrings and endpoint descriptions say
+# this; the extra clue keeps LangChain tool text aligned (#352).
 STRUCTURE_HINT = ParameterHint(
     natural_names=["structure", "format", "data format"],
     extraction_patterns=[r"\b(flat|nested)\b"],
     examples=["flat", "nested"],
-    context_clues=["structure", "format", "organize", "arrangement"],
+    context_clues=[
+        "structure",
+        "format",
+        "organize",
+        "arrangement",
+        "same list-of-objects",
+    ],
 )
 
 # Common response field hints

--- a/fmp_data/company/hints.py
+++ b/fmp_data/company/hints.py
@@ -1,8 +1,5 @@
 from fmp_data.lc.models import ParameterHint, ResponseFieldInfo
 
-# Live /stable returns the same list-of-objects for flat and nested
-# (probed 2026-08-17). Method docstrings and endpoint descriptions say
-# this; the extra clue keeps LangChain tool text aligned (#352).
 STRUCTURE_HINT = ParameterHint(
     natural_names=["structure", "format", "data format"],
     extraction_patterns=[r"\b(flat|nested)\b"],

--- a/fmp_data/company/schema.py
+++ b/fmp_data/company/schema.py
@@ -89,7 +89,11 @@ class RevenueSegmentationArgs(SymbolArg):
 
     structure: StructureTypeEnum = Field(
         default=StructureTypeEnum.FLAT,
-        description="Data structure format",
+        description=(
+            "Response layout (flat or nested). Stable currently "
+            "returns the same list-of-objects for both "
+            "(probed 2026-08-17)."
+        ),
         json_schema_extra={"enum": ["flat", "nested"], "examples": ["flat"]},
     )
     period: ReportingPeriodEnum = Field(

--- a/tests/unit/test_closed_vocabularies.py
+++ b/tests/unit/test_closed_vocabularies.py
@@ -183,7 +183,7 @@ def test_getting_started_income_statement_examples_use_period() -> None:
 
 
 def test_closed_vocabularies_are_public_exports() -> None:
-    """#308 / #311: callers annotate against the live contracts from fmp_data."""
+    """#308 / #311 / #352: callers annotate against the live contracts from fmp_data."""
     import fmp_data
 
     assert fmp_data.Period is Period
@@ -192,6 +192,7 @@ def test_closed_vocabularies_are_public_exports() -> None:
     assert fmp_data.Interval is Interval
     assert fmp_data.Timeframe is Timeframe
     assert fmp_data.TechnicalInterval is TechnicalInterval
+    assert fmp_data.Structure is Structure
     for name in (
         "Period",
         "PeriodFiscal",
@@ -199,12 +200,9 @@ def test_closed_vocabularies_are_public_exports() -> None:
         "Interval",
         "TechnicalInterval",
         "Timeframe",
+        "Structure",
     ):
         assert name in fmp_data.__all__, name
-    # #349: Structure is a closed vocab on public methods but is not
-    # promoted to the package surface (same deferred decision as #308 /
-    # #311 were before Period / TechnicalInterval landed).
-    assert "Structure" not in fmp_data.__all__
     assert "1day" not in literal_values(fmp_data.TechnicalInterval)
     assert "daily" in literal_values(fmp_data.TechnicalInterval)
     assert "hourly" in literal_values(fmp_data.TechnicalInterval)
@@ -422,6 +420,32 @@ def test_client_period_interval_annotations_are_the_typed_literals() -> None:
     assert not untyped, "client methods still take a naked str:\n  " + "\n  ".join(
         untyped
     )
+
+
+def test_structure_endpoint_description_mentions_stable_same_shape() -> None:
+    """#352: LangChain tools read the endpoint description, not the method docstring."""
+    found: list[str] = []
+    stale: list[str] = []
+    for endpoint in _all_endpoints():
+        params = list(endpoint.mandatory_params) + list(endpoint.optional_params or [])
+        for param in params:
+            if param.name != "structure":
+                continue
+            found.append(endpoint.name)
+            description = param.description or ""
+            if "same list-of-objects" not in description:
+                stale.append(f"{endpoint.name}: {description!r}")
+    assert found, "expected revenue-segmentation structure params"
+    assert not stale, (
+        "structure description omitted the stable same-shape note:\n  "
+        + ("\n  ".join(stale))
+    )
+
+
+def test_structure_hint_mentions_stable_same_shape() -> None:
+    from fmp_data.company.hints import STRUCTURE_HINT
+
+    assert "same list-of-objects" in STRUCTURE_HINT.context_clues
 
 
 def test_structure_endpoint_valid_values_come_from_the_literal() -> None:


### PR DESCRIPTION
## Summary

Follow-up from #351 / #349. `Structure = Literal["flat", "nested"]` is a closed request vocabulary on the product and geographic revenue-segmentation methods, but it was left off `fmp_data.__all__` the same way Period / TechnicalInterval were before #308 / #311.

This PR:

- Imports `Structure` in `fmp_data/__init__.py` and adds it to `__all__`.
- Flips the negative pin in `test_closed_vocabularies_are_public_exports`.
- Updates the `structure` endpoint descriptions (and leftover `RevenueSegmentationArgs`) plus `STRUCTURE_HINT` so LangChain tools see that live `/stable` currently returns the same list-of-objects for `flat` and `nested` (probed 2026-08-17). Method docstrings already said this.
- Changelog Unreleased / Added, same voice as #311.

`StructureTypeEnum` stays leftover / deprecated. Not a catalogue sweep.

`Closes #352` is inert on a `dev`-base PR — close #352 by hand after merge.

## Test Plan

- [x] `uv run pytest tests/unit/test_closed_vocabularies.py tests/unit/test_company.py tests/unit/test_company_coverage.py tests/unit/lc/test_tool_schema.py tests/unit/test_hint_consolidation.py -q` → 217 passed
- [x] ruff + mypy on touched modules; pre-commit passed on commit
- [ ] Protect Dev / Test-Matrix on this PR
- [ ] Close #352 by hand after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the public `Structure` type with supported values `flat` and `nested`.
  * Revenue segmentation now documents both structure options and their current response format.

* **Documentation**
  * Updated API references, usage guides, and endpoint descriptions with structure parameter details.
  * Clarified that both options currently return the same list-of-objects response.
  * Documented improved network error classification and API-key protection.

* **Tests**
  * Added coverage for the public export and updated endpoint guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->