### PR TITLE
fix(sec): remaining PR 304 review follow-ups

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -198,21 +198,21 @@
         "filename": "examples/mcp/claude_desktop/troubleshooting.md",
         "hashed_secret": "9ad19750930e5cf133e024641c00daf5fc90c700",
         "is_verified": false,
-        "line_number": 103
+        "line_number": 104
       },
       {
         "type": "Secret Keyword",
         "filename": "examples/mcp/claude_desktop/troubleshooting.md",
         "hashed_secret": "f4bd37ba60c10958ceda8e9c77b44404035e07a0",
         "is_verified": false,
-        "line_number": 127
+        "line_number": 128
       },
       {
         "type": "Secret Keyword",
         "filename": "examples/mcp/claude_desktop/troubleshooting.md",
         "hashed_secret": "a3e14ca24483c78554c083bc907c7194c7846ef1",
         "is_verified": false,
-        "line_number": 225
+        "line_number": 229
       }
     ],
     "examples/mcp/setup_guide.md": [
@@ -497,5 +497,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-19T08:43:31Z"
+  "generated_at": "2026-08-19T09:13:05Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -162,7 +162,7 @@
         "filename": "examples/mcp/claude_desktop/README.md",
         "hashed_secret": "cf4a956e75901c220c0f5fbaec41987fc6177345",
         "is_verified": false,
-        "line_number": 137
+        "line_number": 56
       }
     ],
     "examples/mcp/claude_desktop/claude_desktop_config.json": [
@@ -221,7 +221,7 @@
         "filename": "examples/mcp/setup_guide.md",
         "hashed_secret": "cf4a956e75901c220c0f5fbaec41987fc6177345",
         "is_verified": false,
-        "line_number": 102
+        "line_number": 66
       }
     ],
     "tests/integration/conftest.py": [
@@ -408,7 +408,7 @@
         "filename": "tests/unit/test_export_dotenv.py",
         "hashed_secret": "b3511debb778c2ff2a901c2aed66f84dd85fdadb",
         "is_verified": false,
-        "line_number": 20
+        "line_number": 21
       }
     ],
     "tests/unit/test_logger.py": [
@@ -497,5 +497,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-18T03:13:47Z"
+  "generated_at": "2026-08-19T08:43:31Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,13 @@ typing migration, types period / interval / timeframe as closed
 vocabularies (`Period`, `Interval`, `TechnicalInterval`, `Timeframe`),
 and adds a local VCR-backed client-method sweep.
 
-**Read before upgrading.** One public-type break, narrow:
+**Read before upgrading.** Three public-type breaks, all narrow:
 
 | Change | Who it affects | Migration |
 |---|---|---|
 | Credential config fields are `SecretStr` (#252 FMP-SEC-007) | anyone reading `ClientConfig.api_key`, `LangChainConfig.embedding_api_key`, `EmbeddingConfig.api_key`, or `CacheConfig.redis_url` as a `str` | call `.get_secret_value()` |
+| Senate/House trade dates are `date`, not `datetime` (#338) | anyone comparing `SenateTrade` / `HouseDisclosure` `disclosure_date`, `transaction_date`, or `SenateTrade.date_received` to `datetime.now()` | compare with `date.today()` |
+| `SenateNetWorthValueRange` dropped `.min` / `.max` (#336) | anyone reading those attributes | use `.minimum` / `.maximum` (wire aliases `min` / `max` unchanged) |
 
 Construction is unchanged — passing a plain `str` still works. `repr()` /
 `str()` were already redacted. What breaks is code that *reads* the field
@@ -434,7 +436,8 @@ None. No FMP path we ship was newly retired by this changelog window.
   escaped quotes / backslashes. URL redaction covers ``?api-key=``.
   LangChain tool validation envelopes reuse the already-redacted
   message so a reflected ``apikey=`` cannot reach
-  ``details.validation_errors``.
+  ``details.validation_errors``. Claude Desktop troubleshooting
+  samples that users copy into a config file are valid JSON.
 
 - **`HolderIndustryBreakdown.industry_title` accepts `null`.** A live
   13F industry-breakdown row sends `industryTitle: null`; the field was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [2.7.0] - 2026-08-19
+
+Released from `dev`. A security-and-contracts minor in the same shape as
+2.6.0: credential config fields are now `pydantic.SecretStr`, so
+`model_dump()` can no longer leak an API key, and a large #252 / #273
+hardening pass closes the remaining redaction, publish-isolation, and
+CI-enforcement holes that 2.6.0 left open.
+
+This cut also aligns the client with the 2026 FMP `/stable` surface
+(diluted P/E, screener pagination, Senate/House `senateID`, rating-bulk
+scores, delisted companies), finishes the `Endpoint[T]` / `_unwrap_list`
+typing migration, types period / interval / timeframe as closed
+vocabularies (`Period`, `Interval`, `TechnicalInterval`, `Timeframe`),
+and adds a local VCR-backed client-method sweep.
+
+**Read before upgrading.** One public-type break, narrow:
+
+| Change | Who it affects | Migration |
+|---|---|---|
+| Credential config fields are `SecretStr` (#252 FMP-SEC-007) | anyone reading `ClientConfig.api_key`, `LangChainConfig.embedding_api_key`, `EmbeddingConfig.api_key`, or `CacheConfig.redis_url` as a `str` | call `.get_secret_value()` |
+
+Construction is unchanged — passing a plain `str` still works. `repr()` /
+`str()` were already redacted. What breaks is code that *reads* the field
+as a string (comparisons, slicing, or passing it into a `str` parameter).
+Passing a `SecretStr` where a string is expected often fails *silently*
+(`httpx` sends `apikey=**********` → 401). If you see unexplained auth
+failures after upgrading, look for a missed `.get_secret_value()`.
+
+Logger names no longer double `fmp_data.` (#238). If you filtered
+`fmp_data.fmp_data.*`, switch to `fmp_data.*`.
+
+**3.0 is still the removal cut.** The `Endpoint.arg_model` /
+`EndpointParam.required` deletions and the removal of withdrawn endpoints
+announced in 2.6.0 stay deprecated, not deleted. In-tree tripwires refuse
+a `## [3.x]` changelog heading until that work lands. Withdrawn tools
+still register and return `[]`.
+
 ### Added
 
 - **Senate and House trades by member id (#323).**
@@ -131,7 +168,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`validate_api_key` first classified a status-less `Invalid API KEY`
   body as invalid (#329).** That wizard-side copy matcher is superseded
-  by #340 in this same Unreleased section. Live `/stable/quote` returns
+  by #340 in this same 2.7.0 section. Live `/stable/quote` returns
   HTTP 401 for a junk key (probed 2026-08-15).
 
 - **Setup wizard offers the example MCP profiles again (#320).**
@@ -174,43 +211,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `["Invalid API KEY"]` now raises instead of falling through
   validation. Mixed-key rows whose copy is not the junk-key body stay
   on the validation path. Multi-row lists are still not walked.
-
-## [2.7.0] - 2026-08-14
-
-Released from `dev`. A security-and-contracts minor in the same shape as
-2.6.0: credential config fields are now `pydantic.SecretStr`, so
-`model_dump()` can no longer leak an API key, and a large #252 / #273
-hardening pass closes the remaining redaction, publish-isolation, and
-CI-enforcement holes that 2.6.0 left open.
-
-This cut also aligns the client with the 2026 FMP `/stable` surface
-(diluted P/E, screener pagination, Senate/House `senateID`, rating-bulk
-scores, delisted companies), finishes the `Endpoint[T]` / `_unwrap_list`
-typing migration, types period / interval / timeframe as closed
-vocabularies (`Period`, `Interval`, `TechnicalInterval`, `Timeframe`),
-and adds a local VCR-backed client-method sweep.
-
-**Read before upgrading.** One public-type break, narrow:
-
-| Change | Who it affects | Migration |
-|---|---|---|
-| Credential config fields are `SecretStr` (#252 FMP-SEC-007) | anyone reading `ClientConfig.api_key`, `LangChainConfig.embedding_api_key`, `EmbeddingConfig.api_key`, or `CacheConfig.redis_url` as a `str` | call `.get_secret_value()` |
-
-Construction is unchanged — passing a plain `str` still works. `repr()` /
-`str()` were already redacted. What breaks is code that *reads* the field
-as a string (comparisons, slicing, or passing it into a `str` parameter).
-Passing a `SecretStr` where a string is expected often fails *silently*
-(`httpx` sends `apikey=**********` → 401). If you see unexplained auth
-failures after upgrading, look for a missed `.get_secret_value()`.
-
-Logger names no longer double `fmp_data.` (#238). If you filtered
-`fmp_data.fmp_data.*`, switch to `fmp_data.*`.
-
-**3.0 is still the removal cut.** The `Endpoint.arg_model` /
-`EndpointParam.required` deletions and the removal of withdrawn endpoints
-announced in 2.6.0 stay deprecated, not deleted. In-tree tripwires refuse
-a `## [3.x]` changelog heading until that work lands. Withdrawn tools
-still register and return `[]`.
 
 ### FMP API surface (scan this first)
 
@@ -430,7 +430,11 @@ None. No FMP path we ship was newly retired by this changelog window.
   manifests accept ``TOOLS: list[str] = [...]``. Redis ``SCAN MATCH``
   escapes glob metacharacters in the key prefix. The release remote tag
   is created only after the sdist version check. Makefile ``.env``
-  loading strips dotenv-style inline comments.
+  loading strips dotenv-style inline comments, and quoted values keep
+  escaped quotes / backslashes. URL redaction covers ``?api-key=``.
+  LangChain tool validation envelopes reuse the already-redacted
+  message so a reflected ``apikey=`` cannot reach
+  ``details.validation_errors``.
 
 - **`HolderIndustryBreakdown.industry_title` accepts `null`.** A live
   13F industry-breakdown row sends `industryTitle: null`; the field was

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -25,8 +25,10 @@ qualified spec (`company.profile`). The bare form resolves only when exactly
 one client claims that key. Two keys are claimed by two clients each and must
 always be written in full: `crypto_quotes` (`alternative.crypto_quotes` vs
 `batch.crypto_quotes`) and `forex_quotes` (`alternative.forex_quotes` vs
-`batch.forex_quotes`). Rows marked *Deprecated* below still resolve but emit a
-`DeprecationWarning` and are removed in 3.0.
+`batch.forex_quotes`). Rows marked *Withdrawn* name a 404 FMP path; they still
+resolve and return `[]`, but they are not in `DEFAULT_TOOLS`. Rows marked
+*Deprecated* still resolve but emit a `DeprecationWarning` and are removed in
+3.0. Rows marked *Removed* raise `RemovedEndpointError`.
 
 ## Table of Contents
 
@@ -224,8 +226,8 @@ via a manifest; these return large payloads and several are CSV).
 | `crypto_symbol_news` | Search cryptocurrency news for a specific trading pair to track asset-specific developments |
 | `dividends_calendar` | Get upcoming and historical dividend events including ex-dividend dates, payment dates, and dividend amounts |
 | `earnings_calendar` | Access comprehensive earnings calendar showing upcoming earnings releases, estimated and actual results, and historical earnings data |
-| `earnings_confirmed` | **Deprecated / not in DEFAULT_TOOLS** — client returns `[]`; prefer `earnings_calendar` + `include_report_times` |
-| `earnings_surprises` | **Deprecated / not in DEFAULT_TOOLS** — client returns `[]`; prefer `historical_earnings` and compare eps |
+| `earnings_confirmed` | **Withdrawn / not in DEFAULT_TOOLS** — client returns `[]`; prefer `earnings_calendar` + `include_report_times` |
+| `earnings_surprises` | **Withdrawn / not in DEFAULT_TOOLS** — client returns `[]`; prefer `historical_earnings` and compare eps |
 | `equity_offering_by_cik` | Retrieve equity offerings for a specific company using CIK number including historical and current offerings |
 | `equity_offering_rss` | Get latest equity offerings including new issues, follow-on offerings, and capital raising events |
 | `equity_offering_search` | Search for equity offerings including public and private placements, with detailed offering terms and company information |
@@ -262,10 +264,10 @@ via a manifest; these return large payloads and several are CSV).
 | `senate_trades_by_id` | Get Senate trading data filtered by member id |
 | `senate_trades_by_name` | Get Senate trading data filtered by senator name |
 | `senate_trading` | Access Senate trading activity and disclosures including stock trades, transaction details, and filing information |
-| `senate_trading_rss` | **Withdrawn / not in DEFAULT_TOOLS** — prefer `senate_latest` |
+| `senate_trading_rss` | **Withdrawn / not in DEFAULT_TOOLS** — client returns `[]`; prefer `senate_latest` |
 | `social_sentiment_changes` | **Removed / not in DEFAULT_TOOLS** — raises `RemovedEndpointError` |
 | `stock_news` | Market-wide stock news feed of company events and corporate developments. Not filterable by symbol; narrow it by date range or page |
-| `stock_news_sentiments` | **Deprecated / not in DEFAULT_TOOLS** — client returns `[]` |
+| `stock_news_sentiments` | **Withdrawn / not in DEFAULT_TOOLS** — client returns `[]` |
 | `stock_splits_calendar` | Access upcoming and historical stock split events including split ratios, dates, and affected securities |
 | `trending_social_sentiment` | **Removed / not in DEFAULT_TOOLS** — raises `RemovedEndpointError` |
 

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -262,7 +262,7 @@ via a manifest; these return large payloads and several are CSV).
 | `senate_trades_by_id` | Get Senate trading data filtered by member id |
 | `senate_trades_by_name` | Get Senate trading data filtered by senator name |
 | `senate_trading` | Access Senate trading activity and disclosures including stock trades, transaction details, and filing information |
-| `senate_trading_rss` | Get real-time RSS feed of Senate trading disclosures including new filings and transaction updates |
+| `senate_trading_rss` | **Withdrawn / not in DEFAULT_TOOLS** — prefer `senate_latest` |
 | `social_sentiment_changes` | **Removed / not in DEFAULT_TOOLS** — raises `RemovedEndpointError` |
 | `stock_news` | Market-wide stock news feed of company events and corporate developments. Not filterable by symbol; narrow it by date range or page |
 | `stock_news_sentiments` | **Deprecated / not in DEFAULT_TOOLS** — client returns `[]` |

--- a/examples/mcp/claude_desktop/README.md
+++ b/examples/mcp/claude_desktop/README.md
@@ -53,7 +53,7 @@ Create or edit this file with the following content:
       "command": "python",
       "args": ["-m", "fmp_data.mcp"],
       "env": {
-        "FMP_API_KEY": "your_api_key_here"  # pragma: allowlist secret
+        "FMP_API_KEY": "your_api_key_here"
       }
     }
   }
@@ -187,7 +187,7 @@ We provide pre-configured tool sets for different use cases:
       "command": "python",
       "args": ["-m", "fmp_data.mcp"],
       "env": {
-        "FMP_API_KEY": "your_api_key_here"  # pragma: allowlist secret,
+        "FMP_API_KEY": "your_api_key_here",
         "FMP_MCP_MANIFEST": "examples/mcp/configurations/trading_manifest.py"
       }
     }
@@ -203,7 +203,7 @@ We provide pre-configured tool sets for different use cases:
       "command": "python",
       "args": ["-m", "fmp_data.mcp"],
       "env": {
-        "FMP_API_KEY": "your_api_key_here"  # pragma: allowlist secret,
+        "FMP_API_KEY": "your_api_key_here",
         "FMP_MCP_MANIFEST": "examples/mcp/configurations/research_manifest.py"
       }
     }
@@ -219,7 +219,7 @@ We provide pre-configured tool sets for different use cases:
       "command": "python",
       "args": ["-m", "fmp_data.mcp"],
       "env": {
-        "FMP_API_KEY": "your_api_key_here"  # pragma: allowlist secret,
+        "FMP_API_KEY": "your_api_key_here",
         "FMP_MCP_MANIFEST": "examples/mcp/configurations/crypto_manifest.py"
       }
     }

--- a/examples/mcp/claude_desktop/setup_claude_desktop.py
+++ b/examples/mcp/claude_desktop/setup_claude_desktop.py
@@ -66,7 +66,7 @@ def check_fmp_installation():
         return False
 
 
-def install_fmp_data():
+def install_fmp_data() -> bool:
     """Install fmp-data package with MCP support."""
     print("\n📦 Installing fmp-data with MCP support...")
     try:
@@ -158,7 +158,7 @@ def create_claude_config(api_key, custom_manifest=None):
     return True
 
 
-def test_mcp_server(api_key):
+def test_mcp_server(api_key: str) -> bool:
     """Test if the MCP server can start."""
     print("\n🧪 Testing MCP server...")
 
@@ -195,7 +195,7 @@ def test_mcp_server(api_key):
         return False
 
 
-def choose_configuration():
+def choose_configuration() -> str | None:
     """Let user choose a configuration preset."""
     print("\n🎯 Choose a configuration:")
     print("   1. Default - Comprehensive tool set")

--- a/examples/mcp/claude_desktop/troubleshooting.md
+++ b/examples/mcp/claude_desktop/troubleshooting.md
@@ -92,12 +92,13 @@ which python3
 where python
 ```
 
-Update your config with the correct path:
+Update your config with the correct path (replace `command` with the
+output of `which python3` / `where python`):
 ```json
 {
   "mcpServers": {
     "fmp-data": {
-      "command": "/usr/bin/python3",  // Use your actual path
+      "command": "/usr/bin/python3",
       "args": ["-m", "fmp_data.mcp"],
       "env": {
         "FMP_API_KEY": "your_key"
@@ -173,7 +174,9 @@ except json.JSONDecodeError as e:
 ```
 
 #### Common JSON Mistakes
-```json
+These are intentionally invalid; JSON does not allow comments, trailing
+commas, or single quotes.
+```text
 // ❌ WRONG - Comments not allowed
 {
   "mcpServers": {
@@ -198,8 +201,9 @@ except json.JSONDecodeError as e:
     ...
   }
 }
+```
 
-// ✅ CORRECT
+```json
 {
   "mcpServers": {
     "fmp-data": {
@@ -260,8 +264,9 @@ Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 ```
 
 #### Path Separators
-Use forward slashes or escaped backslashes:
-```json
+Use forward slashes or escaped backslashes. These are fragments, not a
+full JSON document:
+```text
 // ✅ Good
 "FMP_MCP_MANIFEST": "C:/Users/Name/manifests/my_tools.py"
 

--- a/examples/mcp/setup_guide.md
+++ b/examples/mcp/setup_guide.md
@@ -63,7 +63,7 @@ Edit the configuration file and add:
       "command": "/path/to/python",
       "args": ["-m", "fmp_data.mcp"],
       "env": {
-        "FMP_API_KEY": "your_api_key_here"  # pragma: allowlist secret
+        "FMP_API_KEY": "your_api_key_here"
       }
     }
   }

--- a/fmp_data/_redaction.py
+++ b/fmp_data/_redaction.py
@@ -122,7 +122,7 @@ def redact_mapping(data: dict[str, Any]) -> dict[str, Any]:
 # Pattern-only. Never take the live secret as an argument. Safe for
 # logging sinks / stdout (CodeQL py/clear-text-logging-sensitive-data).
 _URL_CREDENTIAL_RE = re.compile(
-    r"([?&](?:api_?key|token|secret)=)[^&\s]+",
+    r"([?&](?:api[_-]?key|token|secret)=)[^&\s]+",
     re.IGNORECASE,
 )
 _URL_APIKEY_RE = re.compile(r"([?&]apikey=)[^&\s]+", re.IGNORECASE)
@@ -143,7 +143,7 @@ _ENCODED_RE = re.compile(r"(apikey%3[Dd])([^&\s\"'<>]+)", re.IGNORECASE)
 # run these on HTTP error bodies (``base._redact_api_keys``).
 _KEY_SHAPED_RES = (
     re.compile(r"\b(?:sk-|pk_)[a-zA-Z0-9_-]{8,}\b"),
-    re.compile(r"\bapi_key=[a-zA-Z0-9_-]{8,}(?=\s|:|;)"),
+    re.compile(r"\bapi_key=[a-zA-Z0-9_-]{8,}(?=\s|:|;|$)"),
     re.compile(r"\b[a-zA-Z0-9]{32,}\b"),
     re.compile(r"[a-fA-F0-9]{40,}"),
 )

--- a/fmp_data/_redaction.py
+++ b/fmp_data/_redaction.py
@@ -121,6 +121,7 @@ def redact_mapping(data: dict[str, Any]) -> dict[str, Any]:
 # --- Free-form text -------------------------------------------------------
 # Pattern-only. Never take the live secret as an argument. Safe for
 # logging sinks / stdout (CodeQL py/clear-text-logging-sensitive-data).
+# ``api[_-]?key`` covers ``apikey``, ``api_key``, and hyphenated ``api-key``.
 _URL_CREDENTIAL_RE = re.compile(
     r"([?&](?:api[_-]?key|token|secret)=)[^&\s]+",
     re.IGNORECASE,

--- a/fmp_data/lc/vector_store.py
+++ b/fmp_data/lc/vector_store.py
@@ -879,8 +879,9 @@ class EndpointVectorStore:
                     # cannot express (e.g. SEC search_industry_classification
                     # requiring at least one of symbol/cik/sic_code).
                     if "ValidationError" in error_type or error_type == "ValueError":
-                        # Parse validation error for better feedback
-                        error_details = str(e).split("\n")
+                        # Parse the already-redacted message so a reflected
+                        # ``apikey=`` cannot reach ``details.validation_errors``.
+                        error_details = error_message.split("\n")
                         field_errors = [
                             line.strip() for line in error_details if "  " in line
                         ]

--- a/scripts/export_dotenv.py
+++ b/scripts/export_dotenv.py
@@ -16,6 +16,19 @@ import shlex
 import sys
 
 _INLINE_COMMENT = re.compile(r"\s+#")
+_SINGLE_ESCAPES = {"\\": "\\", "'": "'"}
+_DOUBLE_ESCAPES = {
+    "\\": "\\",
+    "'": "'",
+    '"': '"',
+    "a": "\a",
+    "b": "\b",
+    "f": "\f",
+    "n": "\n",
+    "r": "\r",
+    "t": "\t",
+    "v": "\v",
+}
 
 # A trusted .env can still clobber the maintainer shell if we export these.
 _BLOCKED_KEYS = frozenset(
@@ -41,6 +54,26 @@ _BLOCKED_KEYS = frozenset(
 )
 
 
+def _quoted_value(raw: str) -> str:
+    """Decode a python-dotenv quoted value; ignore text after the closer."""
+    quote = raw[0]
+    escapes = _SINGLE_ESCAPES if quote == "'" else _DOUBLE_ESCAPES
+    decoded: list[str] = []
+    index = 1
+    while index < len(raw):
+        char = raw[index]
+        if char == "\\" and index + 1 < len(raw):
+            nxt = raw[index + 1]
+            decoded.append(escapes.get(nxt, char + nxt))
+            index += 2
+            continue
+        if char == quote:
+            return "".join(decoded)
+        decoded.append(char)
+        index += 1
+    return "".join(decoded)
+
+
 def export_lines(text: str) -> list[str]:
     lines: list[str] = []
     for raw in text.splitlines():
@@ -59,12 +92,7 @@ def export_lines(text: str) -> list[str]:
             continue
         value = value.strip()
         if value and value[0] in {"'", '"'}:
-            quote = value[0]
-            end = value.find(quote, 1)
-            if end != -1:
-                value = value[1:end]
-            elif len(value) >= 2 and value[-1] == quote:
-                value = value[1:-1]
+            value = _quoted_value(value)
         else:
             value = _INLINE_COMMENT.split(value, maxsplit=1)[0].rstrip()
         lines.append(f"export {key}={shlex.quote(value)}")

--- a/tests/unit/lc/test_method_dispatch.py
+++ b/tests/unit/lc/test_method_dispatch.py
@@ -690,3 +690,34 @@ def test_tool_error_envelope_redacts_reflected_api_keys(tmp_path: Any) -> None:
     rendered = repr(result)
     assert planted not in rendered, f"tool envelope leaked the key: {rendered}"
     assert "[REDACTED]" in rendered
+
+
+def test_validation_error_envelope_redacts_reflected_api_keys(tmp_path: Any) -> None:
+    """Field-error lines must use the redacted message, not raw ``str(e)``."""
+    planted = "PLANTEDCREDENTIALVALUE"
+    boom = ValueError(
+        "  extra  url "
+        f"'https://financialmodelingprep.com/stable/profile?apikey={planted}'"
+    )
+    client = cast(
+        BaseClient,
+        SimpleNamespace(
+            request=Mock(side_effect=boom),
+            sec=SimpleNamespace(
+                search_industry_classification=Mock(side_effect=boom),
+            ),
+        ),
+    )
+    registry = _sec_registry("industry_classification_search")
+    store = _store_with(client, registry, tmp_path)
+    info = registry.get_endpoint("search_industry_classification")
+    assert info is not None
+
+    result = cast(Any, store.create_tool(info)).invoke({"symbol": "AAPL"})
+
+    assert result["status"] == "error"
+    assert result["error_type"] == "validation_error"
+    rendered = repr(result)
+    assert planted not in rendered, f"validation envelope leaked the key: {rendered}"
+    assert planted not in "".join(result["details"]["validation_errors"])
+    assert "[REDACTED]" in rendered

--- a/tests/unit/lc/test_method_dispatch.py
+++ b/tests/unit/lc/test_method_dispatch.py
@@ -717,7 +717,9 @@ def test_validation_error_envelope_redacts_reflected_api_keys(tmp_path: Any) -> 
 
     assert result["status"] == "error"
     assert result["error_type"] == "validation_error"
+    field_errors = result["details"]["validation_errors"]
+    assert field_errors
+    assert all(planted not in err for err in field_errors)
+    assert any("[REDACTED]" in err for err in field_errors)
     rendered = repr(result)
     assert planted not in rendered, f"validation envelope leaked the key: {rendered}"
-    assert planted not in "".join(result["details"]["validation_errors"])
-    assert "[REDACTED]" in rendered

--- a/tests/unit/test_company_coverage.py
+++ b/tests/unit/test_company_coverage.py
@@ -1,7 +1,8 @@
 """Additional tests for company client to improve coverage"""
 
+from collections.abc import Callable
 from datetime import date
-from typing import get_type_hints
+from typing import Any, get_type_hints
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -319,13 +320,13 @@ class TestCompanyClientCoverage:
     @patch("httpx.Client.request")
     def test_revenue_segmentation_nested_structure(
         self,
-        mock_request,
-        fmp_client,
-        mock_response,
-        geographic_revenue_data,
-        method_name,
-        model_cls,
-    ):
+        mock_request: Mock,
+        fmp_client: Any,
+        mock_response: Callable[..., Any],
+        geographic_revenue_data: dict[str, Any],
+        method_name: str,
+        model_cls: type[object],
+    ) -> None:
         """structure=nested is forwarded; response model is unchanged."""
         mock_request.return_value = mock_response(
             status_code=200, json_data=[geographic_revenue_data]

--- a/tests/unit/test_example_json_fences.py
+++ b/tests/unit/test_example_json_fences.py
@@ -1,0 +1,33 @@
+"""Copy-paste ``json`` fences in MCP setup docs must parse (#357)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[2]
+_FENCE = re.compile(r"```json\n(.*?)```", re.DOTALL)
+_DOC_PATHS = (
+    ROOT / "examples" / "mcp" / "claude_desktop" / "README.md",
+    ROOT / "examples" / "mcp" / "claude_desktop" / "troubleshooting.md",
+    ROOT / "examples" / "mcp" / "setup_guide.md",
+)
+
+
+def test_copy_paste_json_fences_parse() -> None:
+    """A ``json`` fence is what users paste into Claude Desktop."""
+    failures: list[str] = []
+    scanned = 0
+    for path in _DOC_PATHS:
+        relative = path.relative_to(ROOT)
+        blocks = _FENCE.findall(path.read_text(encoding="utf-8"))
+        assert blocks, f"no json fences in {relative}"
+        for index, block in enumerate(blocks, start=1):
+            scanned += 1
+            try:
+                json.loads(block)
+            except json.JSONDecodeError as exc:
+                failures.append(f"{relative} block {index}: {exc}")
+    assert scanned >= 8
+    assert failures == [], "invalid json fences:\n  " + "\n  ".join(failures)

--- a/tests/unit/test_export_dotenv.py
+++ b/tests/unit/test_export_dotenv.py
@@ -89,6 +89,10 @@ def test_export_lines_decodes_escaped_quotes_and_backslashes() -> None:
             r'ESCAPED_BACKSLASH="a\\b"',
             r"ESCAPED_SINGLE='a\'b'",
             r'ORDINARY="quoted value"',
+            r'NEWLINE="a\nb"',
+            r"SINGLE_NEWLINE='a\nb'",
+            r'UNKNOWN="\q"',
+            r'UNCLOSED="hello',
         ]
     )
     lines = export_dotenv.export_lines(text)
@@ -100,3 +104,7 @@ def test_export_lines_decodes_escaped_quotes_and_backslashes() -> None:
     assert by_key["ESCAPED_BACKSLASH"] == "a\\b"
     assert by_key["ESCAPED_SINGLE"] == "a'b"
     assert by_key["ORDINARY"] == "quoted value"
+    assert by_key["NEWLINE"] == "a\nb"
+    assert by_key["SINGLE_NEWLINE"] == "a\\nb"
+    assert by_key["UNKNOWN"] == "\\q"
+    assert by_key["UNCLOSED"] == "hello"

--- a/tests/unit/test_export_dotenv.py
+++ b/tests/unit/test_export_dotenv.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+import shlex
 
 _SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "export_dotenv.py"
 _SPEC = importlib.util.spec_from_file_location("export_dotenv", _SCRIPT)
@@ -78,3 +79,24 @@ def test_export_lines_strips_unquoted_inline_comments() -> None:
     assert "export QUOTED_THEN_COMMENT=keep" in joined
     assert "drop" not in joined
     assert any("HASHONLY=" in line and "abc#def" in line for line in lines)
+
+
+def test_export_lines_decodes_escaped_quotes_and_backslashes() -> None:
+    """Quoted values follow python-dotenv: closing quotes must be unescaped."""
+    text = "\n".join(
+        [
+            r'ESCAPED_DOUBLE="a\"b"',
+            r'ESCAPED_BACKSLASH="a\\b"',
+            r"ESCAPED_SINGLE='a\'b'",
+            r'ORDINARY="quoted value"',
+        ]
+    )
+    lines = export_dotenv.export_lines(text)
+    by_key: dict[str, str] = {}
+    for line in lines:
+        key, quoted = line.split("=", 1)
+        by_key[key.removeprefix("export ")] = shlex.split(quoted)[0]
+    assert by_key["ESCAPED_DOUBLE"] == 'a"b'
+    assert by_key["ESCAPED_BACKSLASH"] == "a\\b"
+    assert by_key["ESCAPED_SINGLE"] == "a'b"
+    assert by_key["ORDINARY"] == "quoted value"

--- a/tests/unit/test_mcp_utils.py
+++ b/tests/unit/test_mcp_utils.py
@@ -969,10 +969,9 @@ class TestValidateApiKey:
 
         monkeypatch.setattr("fmp_data.client.FMPDataClient", LeakyClient)
 
-        ok, reason = mcp_utils.validate_api_key(planted)
-        assert ok is False
-        assert reason == "unavailable"
-        assert planted not in reason
+        result = mcp_utils.validate_api_key(planted)
+        assert result == (False, "unavailable")
+        assert planted not in repr(result)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_param_required_consistency.py
+++ b/tests/unit/test_param_required_consistency.py
@@ -55,6 +55,7 @@ SKIPPED_MODULES: dict[str, str] = {}
 #: equalities: without one, a walk that stops yielding reads as a pass.
 _MIN_ENDPOINTS = 250
 _MIN_PARAMS = 500
+_MIN_MANDATORY_PARAMS = 200
 
 
 def _endpoints() -> list[tuple[str, str, Endpoint]]:
@@ -181,7 +182,6 @@ def test_mandatory_params_do_not_carry_defaults() -> None:
                 leftovers.append(
                     f"{module_name}.{attr}.{param.name}: default={param.default!r}"
                 )
-        checked += len(endpoint.optional_params or [])
     assert not leftovers, (
         "mandatory params with a default never apply; move them to "
         "optional_params:\n  " + "\n  ".join(leftovers)
@@ -190,8 +190,8 @@ def test_mandatory_params_do_not_carry_defaults() -> None:
         f"only {len(endpoints)} endpoints inspected; is the walk working? "
         f"skipped: {SKIPPED_MODULES}"
     )
-    assert checked >= _MIN_PARAMS, (
-        f"only {checked} params inspected; is the walk working? "
+    assert checked >= _MIN_MANDATORY_PARAMS, (
+        f"only {checked} mandatory params inspected; is the walk working? "
         f"skipped: {SKIPPED_MODULES}"
     )
 

--- a/tests/unit/test_redaction_rules.py
+++ b/tests/unit/test_redaction_rules.py
@@ -109,6 +109,16 @@ def test_non_string_keys_do_not_raise() -> None:
     assert redact_value({1: "a", None: "b"}) == {1: "a", None: "b"}
 
 
+def test_url_query_redacts_hyphenated_api_key() -> None:
+    """Reflected ``?api-key=`` must not skip the URL credential pattern."""
+    planted = "PLANTED_hyphen_query_secret"
+    redacted = redact_credential_patterns(
+        f"GET https://fmp.test/v3/profile?api-key={planted}&symbol=AAPL"
+    )
+    assert planted not in redacted
+    assert "api-key=[REDACTED]" in redacted
+
+
 def test_pattern_api_redacts_query_assignment_and_encoded() -> None:
     """Shared path covers the former base.py rules (#316)."""
     url = "GET https://fmp.test/v3/profile?apikey=hunter2xyz&symbol=AAPL"
@@ -171,6 +181,13 @@ def test_pattern_api_leaves_32_char_identifiers() -> None:
     assert redact_credential_patterns("saved sk-abcdefgh12345678") == (
         "saved sk-abcdefgh12345678"
     )
+
+
+def test_key_shaped_api_redacts_terminal_api_key_assignment() -> None:
+    """``api_key=`` at end-of-string has no trailing delimiter."""
+    planted = "secret12"
+    assert planted not in redact_key_shaped_tokens(f"denied api_key={planted}")
+    assert redact_key_shaped_tokens(f"denied api_key={planted}") == "denied [REDACTED]"
 
 
 def test_key_shaped_api_redacts_wizard_heuristics() -> None:

--- a/tests/unit/test_redaction_rules.py
+++ b/tests/unit/test_redaction_rules.py
@@ -110,12 +110,18 @@ def test_non_string_keys_do_not_raise() -> None:
 
 
 def test_url_query_redacts_hyphenated_api_key() -> None:
-    """Reflected ``?api-key=`` must not skip the URL credential pattern."""
-    planted = "PLANTED_hyphen_query_secret"
+    """Reflected ``?api-key=`` must not skip the URL credential pattern.
+
+    The value includes a ``"`` so ``_ASSIGNMENT_RE`` cannot consume it
+    (that pattern stops at quotes). Only ``_URL_CREDENTIAL_RE`` covers
+    the full query value.
+    """
+    planted = 'PLANTED_hyphen"query'
     redacted = redact_credential_patterns(
         f"GET https://fmp.test/v3/profile?api-key={planted}&symbol=AAPL"
     )
     assert planted not in redacted
+    assert "query" not in redacted
     assert "api-key=[REDACTED]" in redacted
 
 
@@ -186,8 +192,10 @@ def test_pattern_api_leaves_32_char_identifiers() -> None:
 def test_key_shaped_api_redacts_terminal_api_key_assignment() -> None:
     """``api_key=`` at end-of-string has no trailing delimiter."""
     planted = "secret12"
-    assert planted not in redact_key_shaped_tokens(f"denied api_key={planted}")
     assert redact_key_shaped_tokens(f"denied api_key={planted}") == "denied [REDACTED]"
+    for suffix in (" tail", ":tail", ";tail"):
+        redacted = redact_key_shaped_tokens(f"denied api_key={planted}{suffix}")
+        assert planted not in redacted
 
 
 def test_key_shaped_api_redacts_wizard_heuristics() -> None:

--- a/tests/unit/test_release_tag_push.py
+++ b/tests/unit/test_release_tag_push.py
@@ -68,6 +68,7 @@ def test_only_the_steps_that_need_it_receive_a_token() -> None:
     """A job-level `env: GH_TOKEN` would hand it to the build step too."""
     loaded = yaml.safe_load(RELEASE.read_text(encoding="utf-8"))
     assert isinstance(loaded, dict)
+    assert "GH_TOKEN" not in (loaded.get("env") or {})
     build_job = loaded["jobs"]["build"]
     assert "GH_TOKEN" not in (build_job.get("env") or {})
 

--- a/tests/unit/test_release_tag_push.py
+++ b/tests/unit/test_release_tag_push.py
@@ -66,6 +66,11 @@ def test_checkout_does_not_persist_credentials() -> None:
 
 def test_only_the_steps_that_need_it_receive_a_token() -> None:
     """A job-level `env: GH_TOKEN` would hand it to the build step too."""
+    loaded = yaml.safe_load(RELEASE.read_text(encoding="utf-8"))
+    assert isinstance(loaded, dict)
+    build_job = loaded["jobs"]["build"]
+    assert "GH_TOKEN" not in (build_job.get("env") or {})
+
     holders = {
         str(s.get("name")) for s in _build_steps() if "GH_TOKEN" in (s.get("env") or {})
     }


### PR DESCRIPTION
## Why

Isolated follow-up for [PR 304](https://github.com/MehdiZare/fmp-data/pull/304) (the 2.7.0 `dev → main` cut). Remaining unresolved review threads were small enough to land before the release; broader items stay out of this PR.

## What changed

- Redact hyphenated `?api-key=` query params and end-of-string `api_key=` wizard tokens.
- LangChain validation envelopes reuse the already-redacted message so `details.validation_errors` cannot carry a reflected `apikey=`.
- Makefile dotenv export decodes escaped quotes/backslashes like python-dotenv.
- Claude Desktop JSON samples are valid JSON (scanner pragma removed from fenced `json` blocks).
- `docs/mcp/tools.md` marks `senate_trading_rss` as withdrawn / not in `DEFAULT_TOOLS`; sibling withdrawn Intelligence rows use the same mark.
- Tests: leak assertion is no longer tautological; release `GH_TOKEN` is pinned absent at workflow and job level; mandatory-param floor no longer counts optional params; hyphenated URL / dotenv / envelope tests fail if the production change is reverted; copy-paste `json` fences parse.
- Fold Unreleased notes into `## [2.7.0] - 2026-08-19` so the GitHub Release matches `dev`. Upgrade table lists all three public-type breaks (SecretStr, Senate `date`, net-worth min/max).
- Troubleshooting copy-paste config is valid JSON; teaching snippets use `text` fences.

## Out of scope (issues)

- `search-exchange-variants` already uses `query=` (live `/stable` 200 with `query=Apple`). Not changing the alias.
- Mutable `plugin_marketplaces` remains the accepted gap from #252 — [#359](https://github.com/MehdiZare/fmp-data/issues/359) **P2**.
- Async tenacity sleep-patching — [#358](https://github.com/MehdiZare/fmp-data/issues/358) **P2**.
- Merge duplicate 2.7.0 changelog subsections — [#360](https://github.com/MehdiZare/fmp-data/issues/360) **P2**.
- Remaining `WITHDRAWN_TOOLS` catalog rows that still read as live — [#361](https://github.com/MehdiZare/fmp-data/issues/361) **P3**.

## Test plan

- [x] `pytest` on redaction, dotenv export, vector-store envelope, docs sync, param floor, release-tag token, JSON-fence tests
- [x] fenced `json` samples in the Claude Desktop README / setup guide / troubleshooting parse
- [ ] CI Test-Matrix / coverage / secret scan on this PR