### PR TITLE
chore(ci): bump GitHub Actions pins to latest stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           python-version: ${{ matrix.python }}
 
       - name: ⚡  Install uv (with cache)
-        uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d  # v10.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
           version: "0.12.3"
           enable-cache: true
@@ -88,7 +88,7 @@ jobs:
           python-version: "3.14"
 
       - name: ⚡  Install uv
-        uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d  # v10.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
           version: "0.12.3"
 
@@ -145,7 +145,7 @@ jobs:
           python-version: "3.14"
 
       - name: ⚡  Install uv
-        uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d  # v10.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
           version: "0.12.3"
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.auth.outputs.configured == 'true'
         id: claude-review
         continue-on-error: true
-        uses: anthropics/claude-code-action@239e3a730883eeb5c53db12b0fc9573b3024b126  # v1
+        uses: anthropics/claude-code-action@d40ddef4c030e508327d6e35a9c45f3368482c50  # v1.0.195
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # KNOWN GAP, not an oversight (#252). This marketplace resolves to

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@239e3a730883eeb5c53db12b0fc9573b3024b126  # v1
+        uses: anthropics/claude-code-action@d40ddef4c030e508327d6e35a9c45f3368482c50  # v1.0.195
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,12 +30,12 @@ jobs:
           persist-credentials: false
 
       - name: 🔍 Initialize CodeQL
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd  # v4.37.7
         with:
           languages: python
           build-mode: none
 
       - name: 📈 Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd  # v4.37.7
         with:
           category: "/language:python"

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -55,7 +55,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: ⚡  Install uv (with cache)
-        uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d  # v10.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
           version: "0.12.3"
           enable-cache: true

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -50,7 +50,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d  # v10.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
           version: "0.12.3"
           enable-cache: true

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -61,7 +61,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: ⚡  Install uv
-        uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d  # v10.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
           version: "0.12.3"
           enable-cache: false
@@ -321,7 +321,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: ⚡  Install uv
-        uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d  # v10.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
           version: "0.12.3"
           enable-cache: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: ⚡ Install uv
-        uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d  # v10.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
           version: "0.12.3"
           enable-cache: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- **GitHub Actions pins.** `github/codeql-action` 4.37.6 → 4.37.7
+  (default bundle 2.26.3). `astral-sh/setup-uv` 10.0.0 → 10.0.1
+  (tolerate transient manifest timeouts). `anthropics/claude-code-action`
+  1.0.191 → 1.0.195. All remain 40-char SHA pins. The installed uv
+  floor is unchanged (`0.12.3`).
+
 ## [2.7.0] - 2026-08-19
 
 Released from `dev`. A security-and-contracts minor in the same shape as

--- a/tests/unit/test_setup_uv_pin.py
+++ b/tests/unit/test_setup_uv_pin.py
@@ -21,7 +21,7 @@ def test_setup_uv_is_v10_and_tracks_latest_uv() -> None:
             assert len(pin) == 40
             assert all(char in "0123456789abcdef" for char in pin)
             assert "v9.0.0" not in line
-            assert "v10.0.0" in line
+            assert "v10.0.1" in line
         assert 'version: "0.12.3"' in text
     assert seen >= 1
 


### PR DESCRIPTION
## Why

Dependabot opened three separate GitHub Actions pin PRs (#364, #365, #366). Those are the same kind of change (SHA-pinned `uses:` bumps) and are easier to review and revert as one CI-deps PR. Closing the Dependabot PRs in favor of this one.

## What

| Action | From | To | SHA |
|---|---|---|---|
| `github/codeql-action` (`init` + `analyze`) | 4.37.6 | **4.37.7** | `ff2f1c62…` |
| `astral-sh/setup-uv` | 10.0.0 | **10.0.1** | `20cfd1bf…` |
| `anthropics/claude-code-action` | 1.0.191 (`# v1`) | **1.0.195** | `d40ddef4…` |

`claude-code-action` is newer than Dependabot's 1.0.193 (current latest stable). Comment on that pin now names the exact tag.

**Unchanged:** uv install floor stays `0.12.3` (`pyproject.toml` `required-version`, workflow `version:`). CodeQL `init` and `analyze` stay on the same SHA.

## Test plan

- [x] `tests/unit/test_setup_uv_pin.py`, `test_codeql_workflow.py`
- [ ] CI Test-Matrix / Actions shell / CodeQL on this PR

Supersedes #364 #365 #366.