### PR TITLE
fix: 2.7.0 leftovers for sync here-docs, async retries, changelog, and withdrawn rows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,12 +240,18 @@ jobs:
             exit 1
           fi
           sudo apt-get update -qq
-          sudo apt-get install -y -qq shellcheck
+          sudo apt-get install -y -qq shellcheck python3-yaml
           shellcheck --version
           shellcheck "${scripts[@]}"
 
       - name: 🧪 check-pr-mergeable mock matrix
         run: bash .github/actions/check-pr-mergeable/test-check.sh
+
+      # YAML `run: |` strips the common indent, then bash parses the result.
+      # An indented here-doc terminator is not recognized (#363). This is the
+      # same checker as tests/unit/test_workflow_run_scripts.py.
+      - name: 🔍 bash -n every workflow run block
+        run: python3 tests/unit/test_workflow_run_scripts.py
 
   test-matrix-expected:
     name: Test-MatrixExpected

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -160,48 +160,49 @@ jobs:
             git merge -s ours origin/main \
               -m "chore: merge main into dev after release (history sync)"
 
-            # Body must stay indented for YAML; strip the common prefix after.
+            # The terminator must sit at the `run: |` base indent. Extra spaces
+            # survive YAML strip, bash never closes the here-doc, and the rest
+            # of the script is swallowed (#363).
             cat > /tmp/sync-pr-body.md <<'EOF'
-            ## Automatic Sync
+          ## Automatic Sync
 
-            `main` was not an ancestor of `dev`. This PR restores reachability so
-            the next `dev → main` release PR stays MERGEABLE and gets full CI.
+          `main` was not an ancestor of `dev`. This PR restores reachability so
+          the next `dev → main` release PR stays MERGEABLE and gets full CI.
 
-            ### Why this is not a content sync
-            After a squash-merge release, trees are usually identical but histories
-            diverge. Comparing content (`git diff`) misses that; comparing
-            reachability (`git merge-base --is-ancestor`) catches it at the right
-            moment — right after the release — instead of as 20+ conflicts on the
-            next release PR. See #202.
+          ### Why this is not a content sync
+          After a squash-merge release, trees are usually identical but histories
+          diverge. Comparing content (`git diff`) misses that; comparing
+          reachability (`git merge-base --is-ancestor`) catches it at the right
+          moment — right after the release — instead of as 20+ conflicts on the
+          next release PR. See #202.
 
-            ### Merge policy
-            - Auto-merge is enabled with a **merge commit** when required checks
-              (Test-Matrix) are green. Do **not** squash — that re-creates the
-              ancestry break this PR fixes.
-            - Content is usually empty for a pure history merge; review only if
-              the diff is non-empty (unexpected).
-            EOF
-            sed -i 's/^            //' /tmp/sync-pr-body.md
+          ### Merge policy
+          - Auto-merge is enabled with a **merge commit** when required checks
+            (Test-Matrix) are green. Do **not** squash — that re-creates the
+            ancestry break this PR fixes.
+          - Content is usually empty for a pure history merge; review only if
+            the diff is non-empty (unexpected).
+          EOF
 
             open_or_update_pr "Sync: main → dev (history reachability)" /tmp/sync-pr-body.md
           else
             # Hotfix (or other content) landed on main that dev does not have.
             if git merge origin/main \
               -m "chore: merge main into dev (sync after release/hotfix)"; then
+              # Same rule as the history-only body: terminator at run: | base (#363).
               cat > /tmp/sync-pr-body.md <<'EOF'
-              ## Automatic Sync
+          ## Automatic Sync
 
-              `main` was not an ancestor of `dev` and carried content `dev` did not
-              have (hotfix or direct-to-main commit). This PR merges that content
-              back so histories stay connected. See #202.
+          `main` was not an ancestor of `dev` and carried content `dev` did not
+          have (hotfix or direct-to-main commit). This PR merges that content
+          back so histories stay connected. See #202.
 
-              ### Merge policy
-              - Review the content delta before it lands (auto-merge waits for
-                Test-Matrix).
-              - Auto-merge uses a **merge commit** only — do not squash, or the
-                ancestry link is lost again.
-              EOF
-              sed -i 's/^              //' /tmp/sync-pr-body.md
+          ### Merge policy
+          - Review the content delta before it lands (auto-merge waits for
+            Test-Matrix).
+          - Auto-merge uses a **merge commit** only — do not squash, or the
+            ancestry link is lost again.
+          EOF
               open_or_update_pr "Sync: main → dev" /tmp/sync-pr-body.md
             else
               # Do NOT force-push origin/dev over sync/main-to-dev or open an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (tolerate transient manifest timeouts). `anthropics/claude-code-action`
   1.0.191 → 1.0.195. All remain 40-char SHA pins. The installed uv
   floor is unchanged (`0.12.3`).
+- **2.7.0 changelog subsections are unique (#360).** One Added / Changed /
+  Fixed / Security under the version heading. `### FMP API surface` sits
+  immediately under the intro. The published GitHub Release notes are
+  unchanged (they never used this file's body).
+- **Withdrawn MCP catalog rows are marked in `docs/mcp/tools.md` (#361).**
+  Every `WITHDRAWN_TOOLS` spec now carries **Withdrawn / not in
+  DEFAULT_TOOLS** (with successor or none). Docs-sync fails if a
+  withdrawn row omits the mark.
+
+### Fixed
+
+- **Sync-Main-to-Dev here-docs compile under `run: |` (#363).** YAML
+  indent left the `EOF` terminator off column 0 after strip, so bash
+  swallowed the rest of the script and never pushed the `-s ours`
+  merge. Terminators now sit at the `run: |` base indent. `Actions
+  shell checks` runs `bash -n` on every workflow `run:` block.
+- **Async retry tests patch `asyncio.sleep` (#358).** Tenacity 9.1.4
+  async retries go through `_portable_async_sleep` → `asyncio.sleep`,
+  not `tenacity.nap.sleep`. Sync tests keep the nap patch.
 
 ## [2.7.0] - 2026-08-19
 
@@ -54,6 +73,47 @@ announced in 2.6.0 stay deprecated, not deleted. In-tree tripwires refuse
 a `## [3.x]` changelog heading until that work lands. Withdrawn tools
 still register and return `[]`.
 
+### FMP API surface (scan this first)
+
+Source: FMP public changelog
+([docs/changelog](https://site.financialmodelingprep.com/developer/docs/changelog))
+plus a live `/stable` probe on 2026-08-12. Marketing-only items (dashboard,
+localization, Insights Hub, plan add-ons) and FMP's hosted MCP product are
+out of scope.
+
+#### New (now first-class in this client)
+
+| Surface | What you get | Wire key / param | Client |
+|---|---|---|---|
+| Financial ratios | Diluted P/E | `priceToEarningsDilutedRatio` | `FinancialRatios.price_to_earnings_diluted_ratio` |
+| Financial ratios | Diluted PEG | `priceToEarningsDilutedGrowthRatio` | `FinancialRatios.price_to_earnings_diluted_growth_ratio` |
+| Ratios TTM (+ `ratios-ttm-bulk`) | Diluted P/E TTM | `priceToEarningsDilutedRatioTTM` | `FinancialRatiosTTM.price_to_earnings_diluted_ratio_ttm` |
+| Ratios TTM (+ `ratios-ttm-bulk`) | Diluted PEG TTM | `priceToEarningsDilutedGrowthRatioTTM` | `FinancialRatiosTTM.price_to_earnings_diluted_growth_ratio_ttm` |
+| Company screener | Pagination | `page` (optional, omitted when unset) | `market.get_company_screener(..., page=None)` |
+| Senate / House trades | Entity id | `senateID` (same key on House rows) | `SenateTrade.senate_id` / `HouseDisclosure.senate_id` |
+| Ratings bulk | Score columns | `discountedCashFlowScore`, `returnOnEquityScore`, `returnOnAssetsScore`, `debtToEquityScore`, `priceToEarningsScore`, `priceToBookScore` | `CompanyRating.*_score` |
+| Delisted companies | Slim delist list | `/stable/delisted-companies` (`page`, `limit`) | `company.get_delisted_companies` → `DelistedCompany` |
+
+#### Updated (path or contract still matches; no caller change)
+
+| FMP note | Path probed | Result |
+|---|---|---|
+| Exchange directory taxonomy (2025-06) | `/stable/available-exchanges` | 200. Keys `exchange`, `name`, `countryName`, `countryCode`, `delay`, `symbolSuffix` — already on `ExchangeSymbol`. |
+| Exchange variants (2025-05/06) | `/stable/search-exchange-variants?query=Apple` | 200. Profile-shaped rows still parse as `CompanySearchResult`. |
+| DCF valuations bulk naming (2025-06) | `/stable/dcf-bulk` | 200. Headers `symbol,date,dcf,Stock Price`. Client still remaps `Stock Price` → `stockPrice`. |
+| Historical S&P 500 symbol naming (2025-06) | `/stable/historical-sp500-constituent` | 200. `symbol` present; `HistoricalIndexConstituent` still parses. |
+| Stock ratings bulk field standardization (2025-06) | `/stable/rating-bulk` | 200. Score columns now typed on `CompanyRating` (see New). |
+| CUSIP on fund disclosure holders (2025-10) | `/stable/funds/disclosure-holders-latest` | Only `securityCusip`. Already modeled; no second key. |
+| ETF `isActivelyTrading` (2025-12) | `/stable/etf/info` | Present. Already modeled. |
+| Splits calendar `splitType` (2025-11) | `/stable/splits-calendar` | Present (may be `null`). Already modeled. |
+| Earnings `includeReportTimes` (2026-06) | `/stable/earnings-calendar?includeReportTimes=true` | Extra fields `confirmed`, `fiscalPeriod`, `fiscalYear`, `periodEnding`, `time`, `lastUpdated` already modeled. |
+| Profile bulk `part=0..3` (2024-10) | `/stable/profile-bulk?part=0` | 200. Multi-part scheme unchanged. |
+| Legacy route auth-gate (2025-08) | `/api/v3/profile/AAPL` | 403. No remaining live client path uses `APIVersion.V3`. The one leftover `V4` declaration is the already-withdrawn `stock-news-sentiments`. |
+
+#### Deprecated / withdrawn in this pass
+
+None. No FMP path we ship was newly retired by this changelog window.
+
 ### Added
 
 - **Senate and House trades by member id (#323).**
@@ -83,6 +143,68 @@ still register and return `[]`.
   It is `Literal["flat", "nested"]`. Live `/stable` returns the same
   list-of-objects for both (probed 2026-08-17). `StructureTypeEnum`
   stays leftover / deprecated.
+
+- **Closed request vocabularies for period, interval, and timeframe
+  (#306, #308).** Client methods now take `Period` / `PeriodFiscal` /
+  `PeriodAnnualQuarter`, `Interval`, and `Timeframe` (`Literal` aliases
+  in `fmp_data.schema`) instead of a naked `str`. Three period types on
+  purpose: financial reports and batch bulk accept only `FY`/`Q1`–`Q4`.
+  Endpoint `valid_values` are derived from the same aliases. Plain
+  strings still work at runtime. Re-exported from `fmp_data` (`__all__`):
+  `from fmp_data import Period, PeriodFiscal, PeriodAnnualQuarter,
+  Interval, Timeframe`. The e2e harness samples required closed params
+  from the method annotation, not a global `"annual"` table.
+
+- **Public re-export of `TechnicalInterval` (#311).** Annotate
+  `TechnicalClient.interval=` against
+  `from fmp_data import TechnicalInterval`. It is `Interval` plus
+  `"daily"` / `"hourly"`, not `Timeframe` (`1day`). Client-only leftover
+  aliases mapped by `_normalize_timeframe`; endpoint `valid_values` stay
+  on `Timeframe` / `Interval`.
+
+- **Local VCR-backed client-method e2e sweep.** Maintainer script
+  `scripts/e2e_endpoints.py` (`make e2e-record` / `make e2e-replay`) calls
+  every public sync `FMPDataClient` method, records gitignored cassettes
+  under `tests/e2e/vcr_cassettes/`, and prints a per-method report. Opt-in
+  (`-m not e2e` in addopts); not run by `make test`. First live pass
+  covered 265 methods: 239 ok, 26 deprecated skips.
+
+- **FMP hosted MCP vs `fmp-mcp` positioning (#230).** Docs-only: we are not
+  wrapping FMP's remote MCP URL. README + `docs/mcp/index.md` point at
+  `docs/mcp/hosted.md`, which records the 2026-08-12 decision (A+D: position
+  + coverage matrix), a live `tools/list` of **28** dataset tools (changelog
+  said 27; `tipranks` is a paid add-on), and when to use hosted MCP vs this
+  package. No runtime helper, no FastMCP dependency, no CI smoke.
+
+- **FMP changelog alignment (#229).** Three confirmed 2026 wire gaps, the
+  leftover 2025-10 delisted-companies wiring (#233), plus the older-note
+  re-probe above. Live `/stable` checks used the current API key on
+  2026-08-12.
+
+  - **Diluted P/E on ratios.** `FinancialRatios` and `FinancialRatiosTTM` now
+    declare the diluted PE / diluted PEG pair FMP added on 2026-07-30
+    (`priceToEarningsDilutedRatio`, `priceToEarningsDilutedGrowthRatio`, and
+    the `*TTM` names on TTM + `ratios-ttm-bulk`). They previously landed only
+    in `__pydantic_extra__` and could warn under `FMP_VALIDATION_MODE=warn`.
+  - **Screener `page`.** `market.get_company_screener` / async accept optional
+    `page: int | None = None`. Unset is omitted from the request (existing
+    callers keep the same wire). `page=0` is sent. Live: `limit=2&page=0`
+    and `limit=2&page=1` return distinct first rows.
+  - **`senateID` on Senate and House trades.** `SenateTrade.senate_id` and
+    `HouseDisclosure.senate_id` alias `senateID`. The wire name is kept on
+    House rows (Pelosi → `P000197`); we do not invent `house_id`.
+  - **`CompanyRating` score columns.** `rating-bulk` headers
+    `discountedCashFlowScore` / `returnOnEquityScore` / `returnOnAssetsScore`
+    / `debtToEquityScore` / `priceToEarningsScore` / `priceToBookScore` are
+    now typed attributes. Fractional CSV cells such as ``"3.0"`` coerce to
+    ``int`` so ``parse_csv_models`` does not skip the whole company row.
+  - **`company.get_delisted_companies`.** The 2025-10 delisted-companies
+    architecture sync left a live `/stable/delisted-companies` path whose
+    declaration used `CompanyProfile` and had no client method. Sync and
+    async clients now expose `get_delisted_companies(page=0, limit=100)`
+    returning `DelistedCompany` (`symbol`, `companyName`, `exchange`,
+    `ipoDate`, `delistedDate`). MCP: `company.delisted_companies` (in
+    `DEFAULT_TOOLS`). LangChain indexes the same semantics key.
 
 ### Changed
 
@@ -139,131 +261,6 @@ still register and return `[]`.
 - **`redact_credential_patterns` redacts hyphenated assignment names
   (#339).** `X-API-KEY=` / `FMP-API-KEY=` now match. Wizard placeholder
   `[YOUR_API_KEY]` and 32-char request ids are still left alone.
-
-### Fixed
-
-- **Remaining `httpx.RequestError` leftovers no longer leak `apikey=`
-  (#354).** `ProtocolError`, `ProxyError`, `DecodingError`,
-  `TooManyRedirects`, `UnsupportedProtocol`, and any future
-  `RequestError` now raise `FMPNetworkError` with `from None`. Same
-  secret-absent pin as #97 / #350 (`str` / `repr` / `__cause__` /
-  traceback / error log). `ProtocolError` / `ProxyError` stay
-  retryable; the others set `FMPNetworkError.retryable = False`.
-  Timeouts stay `FMPTimeoutError`. `validate_api_key` classifies
-  `FMPNetworkError` and raw non-timeout `httpx.RequestError` (fakes /
-  adapters) as `unavailable`.
-
-- **Timeout and network errors no longer leak `apikey=` (#350).**
-  `httpx.TimeoutException` / `httpx.NetworkError` now raise
-  `FMPTimeoutError` / `FMPNetworkError` with `from None`. The request
-  URL is not logged (`str(httpx_exc)` and `exc_info=True` are off that
-  path). Status errors were already mapped in #97; this is the leftover
-  transport path. Callers that caught raw httpx timeouts should catch
-  the new types (they remain `FMPError` subclasses and stay retryable).
-  `validate_api_key` classifies `FMPTimeoutError` as `timeout` and
-  `FMPNetworkError` as `unavailable` so a transport failure cannot
-  report a valid key.
-
-- **MCP setup helpers no longer echo subprocess stderr (#319).**
-  `validate_api_key` and `test_mcp_server` return classified reasons
-  (`valid` / `invalid` / `timeout` / `unavailable` and
-  `passed` / `started` / `failed` / `unavailable`). `fmp-mcp status`
-  and `fmp-mcp test` print sink-local literals so a key quoted in
-  child stderr cannot reach the terminal.
-
-- **`validate_api_key` now probes FMP (#317).**
-  A typed junk key no longer reports success. The helper constructs a
-  client and calls `company.get_quote("AAPL")`; 401 and 403 map to
-  `invalid`. Rate-limit / other HTTP errors still count as `valid`.
-
-- **`validate_api_key` first classified a status-less `Invalid API KEY`
-  body as invalid (#329).** That wizard-side copy matcher is superseded
-  by #340 in this same 2.7.0 section. Live `/stable/quote` returns
-  HTTP 401 for a junk key (probed 2026-08-15).
-
-- **Setup wizard offers the example MCP profiles again (#320).**
-  `get_manifest_choices` looks in `examples/mcp/configurations/` (the
-  real directory). The example Claude Desktop script, JSON profiles,
-  and README / troubleshooting copies use the same path.
-
-- **E2E sweep no longer treats Senate/House trades-by-id as allowed
-  empty (#337).** Those methods pin known-nonempty ids (`W000802` /
-  `P000197`); a 200/`[]` is the 404-as-empty class, not entity
-  emptiness. Name-based lookups stay on `ALLOW_EMPTY`.
-
-- **2xx `Invalid API KEY` bodies raise `AuthenticationError` (#340).**
-  `_check_error_response` types the known invalid-key copy instead of
-  a status-less `FMPError`. Unrelated 2xx bodies stay `FMPError`.
-  `validate_api_key`'s copy matcher is gone — the
-  `except AuthenticationError` path covers it.
-
-- **Net-worth integration tests lock nested objects, aggregated
-  aliases, and `model_extra` (#336).** Itemized rows must have empty
-  `model_extra` and at least one populated `valueRange` and
-  `debtDetails`. Aggregated pages must populate both `total` and
-  `stock`.
-
-- **Committed cassette-contract snapshot fails CI without YAML (#336).**
-  `tests/integration/cassette_contracts.json` lists required wire
-  aliases for government-trading models. The YAML payload check still
-  skips when cassettes are gitignored.
-
-- **List-shaped 2xx `Invalid API KEY` bodies raise
-  `AuthenticationError` (#342).** A one-element list whose only keys
-  are error keys is routed through `_raise_response_error`. Multi-row
-  lists are not walked. Unrelated singleton error lists stay
-  `FMPError`.
-
-- **Residual list-shaped 2xx error bodies type as
-  `AuthenticationError` (#344).** A one-element list with decorator
-  keys (`Error Message` plus data fields), a nested error value
-  (`{"message": "Invalid API KEY"}`), or a scalar
-  `["Invalid API KEY"]` now raises instead of falling through
-  validation. Mixed-key rows whose copy is not the junk-key body stay
-  on the validation path. Multi-row lists are still not walked.
-
-### FMP API surface (scan this first)
-
-Source: FMP public changelog
-([docs/changelog](https://site.financialmodelingprep.com/developer/docs/changelog))
-plus a live `/stable` probe on 2026-08-12. Marketing-only items (dashboard,
-localization, Insights Hub, plan add-ons) and FMP's hosted MCP product are
-out of scope.
-
-#### New (now first-class in this client)
-
-| Surface | What you get | Wire key / param | Client |
-|---|---|---|---|
-| Financial ratios | Diluted P/E | `priceToEarningsDilutedRatio` | `FinancialRatios.price_to_earnings_diluted_ratio` |
-| Financial ratios | Diluted PEG | `priceToEarningsDilutedGrowthRatio` | `FinancialRatios.price_to_earnings_diluted_growth_ratio` |
-| Ratios TTM (+ `ratios-ttm-bulk`) | Diluted P/E TTM | `priceToEarningsDilutedRatioTTM` | `FinancialRatiosTTM.price_to_earnings_diluted_ratio_ttm` |
-| Ratios TTM (+ `ratios-ttm-bulk`) | Diluted PEG TTM | `priceToEarningsDilutedGrowthRatioTTM` | `FinancialRatiosTTM.price_to_earnings_diluted_growth_ratio_ttm` |
-| Company screener | Pagination | `page` (optional, omitted when unset) | `market.get_company_screener(..., page=None)` |
-| Senate / House trades | Entity id | `senateID` (same key on House rows) | `SenateTrade.senate_id` / `HouseDisclosure.senate_id` |
-| Ratings bulk | Score columns | `discountedCashFlowScore`, `returnOnEquityScore`, `returnOnAssetsScore`, `debtToEquityScore`, `priceToEarningsScore`, `priceToBookScore` | `CompanyRating.*_score` |
-| Delisted companies | Slim delist list | `/stable/delisted-companies` (`page`, `limit`) | `company.get_delisted_companies` → `DelistedCompany` |
-
-#### Updated (path or contract still matches; no caller change)
-
-| FMP note | Path probed | Result |
-|---|---|---|
-| Exchange directory taxonomy (2025-06) | `/stable/available-exchanges` | 200. Keys `exchange`, `name`, `countryName`, `countryCode`, `delay`, `symbolSuffix` — already on `ExchangeSymbol`. |
-| Exchange variants (2025-05/06) | `/stable/search-exchange-variants?query=Apple` | 200. Profile-shaped rows still parse as `CompanySearchResult`. |
-| DCF valuations bulk naming (2025-06) | `/stable/dcf-bulk` | 200. Headers `symbol,date,dcf,Stock Price`. Client still remaps `Stock Price` → `stockPrice`. |
-| Historical S&P 500 symbol naming (2025-06) | `/stable/historical-sp500-constituent` | 200. `symbol` present; `HistoricalIndexConstituent` still parses. |
-| Stock ratings bulk field standardization (2025-06) | `/stable/rating-bulk` | 200. Score columns now typed on `CompanyRating` (see New). |
-| CUSIP on fund disclosure holders (2025-10) | `/stable/funds/disclosure-holders-latest` | Only `securityCusip`. Already modeled; no second key. |
-| ETF `isActivelyTrading` (2025-12) | `/stable/etf/info` | Present. Already modeled. |
-| Splits calendar `splitType` (2025-11) | `/stable/splits-calendar` | Present (may be `null`). Already modeled. |
-| Earnings `includeReportTimes` (2026-06) | `/stable/earnings-calendar?includeReportTimes=true` | Extra fields `confirmed`, `fiscalPeriod`, `fiscalYear`, `periodEnding`, `time`, `lastUpdated` already modeled. |
-| Profile bulk `part=0..3` (2024-10) | `/stable/profile-bulk?part=0` | 200. Multi-part scheme unchanged. |
-| Legacy route auth-gate (2025-08) | `/api/v3/profile/AAPL` | 403. No remaining live client path uses `APIVersion.V3`. The one leftover `V4` declaration is the already-withdrawn `stock-news-sentiments`. |
-
-#### Deprecated / withdrawn in this pass
-
-None. No FMP path we ship was newly retired by this changelog window.
-
-### Changed
 
 - **BREAKING: credential config fields are `pydantic.SecretStr` (#252
   FMP-SEC-007).** `ClientConfig.api_key`, `LangChainConfig.embedding_api_key`,
@@ -354,71 +351,120 @@ None. No FMP path we ship was newly retired by this changelog window.
   `TechnicalClient` signatures are unchanged. The arg-model types
   themselves stay until 3.0.
 
-### Added
+- **CI and local uv are 0.12.3+.** ``setup-uv`` v10 installs uv ``0.12.3``.
+  ``[tool.uv] required-version = ">=0.12.3"`` rejects older local
+  installs. The action pin remains the v10.0.0 SHA.
+- **Separate extras coverage gate for ``lc`` / ``mcp`` / Redis (#273).**
+  The core 80% report still omits those trees. ``nox -s coverage_extras``
+  (CI job ``extras-coverage``) installs the extras, measures only those
+  files, and fails under 65% (measured baseline 66.78% on 2026-08-13).
+  ``Test-MatrixExpected`` requires that job. The ``mcp-server`` session
+  now runs every ``tests/unit/test_mcp*.py`` file.
 
-- **Closed request vocabularies for period, interval, and timeframe
-  (#306, #308).** Client methods now take `Period` / `PeriodFiscal` /
-  `PeriodAnnualQuarter`, `Interval`, and `Timeframe` (`Literal` aliases
-  in `fmp_data.schema`) instead of a naked `str`. Three period types on
-  purpose: financial reports and batch bulk accept only `FY`/`Q1`–`Q4`.
-  Endpoint `valid_values` are derived from the same aliases. Plain
-  strings still work at runtime. Re-exported from `fmp_data` (`__all__`):
-  `from fmp_data import Period, PeriodFiscal, PeriodAnnualQuarter,
-  Interval, Timeframe`. The e2e harness samples required closed params
-  from the method annotation, not a global `"annual"` table.
-
-- **Public re-export of `TechnicalInterval` (#311).** Annotate
-  `TechnicalClient.interval=` against
-  `from fmp_data import TechnicalInterval`. It is `Interval` plus
-  `"daily"` / `"hourly"`, not `Timeframe` (`1day`). Client-only leftover
-  aliases mapped by `_normalize_timeframe`; endpoint `valid_values` stay
-  on `Timeframe` / `Interval`.
-
-- **Local VCR-backed client-method e2e sweep.** Maintainer script
-  `scripts/e2e_endpoints.py` (`make e2e-record` / `make e2e-replay`) calls
-  every public sync `FMPDataClient` method, records gitignored cassettes
-  under `tests/e2e/vcr_cassettes/`, and prints a per-method report. Opt-in
-  (`-m not e2e` in addopts); not run by `make test`. First live pass
-  covered 265 methods: 239 ok, 26 deprecated skips.
-
-- **FMP hosted MCP vs `fmp-mcp` positioning (#230).** Docs-only: we are not
-  wrapping FMP's remote MCP URL. README + `docs/mcp/index.md` point at
-  `docs/mcp/hosted.md`, which records the 2026-08-12 decision (A+D: position
-  + coverage matrix), a live `tools/list` of **28** dataset tools (changelog
-  said 27; `tipranks` is a paid add-on), and when to use hosted MCP vs this
-  package. No runtime helper, no FastMCP dependency, no CI smoke.
-
-- **FMP changelog alignment (#229).** Three confirmed 2026 wire gaps, the
-  leftover 2025-10 delisted-companies wiring (#233), plus the older-note
-  re-probe above. Live `/stable` checks used the current API key on
-  2026-08-12.
-
-  - **Diluted P/E on ratios.** `FinancialRatios` and `FinancialRatiosTTM` now
-    declare the diluted PE / diluted PEG pair FMP added on 2026-07-30
-    (`priceToEarningsDilutedRatio`, `priceToEarningsDilutedGrowthRatio`, and
-    the `*TTM` names on TTM + `ratios-ttm-bulk`). They previously landed only
-    in `__pydantic_extra__` and could warn under `FMP_VALIDATION_MODE=warn`.
-  - **Screener `page`.** `market.get_company_screener` / async accept optional
-    `page: int | None = None`. Unset is omitted from the request (existing
-    callers keep the same wire). `page=0` is sent. Live: `limit=2&page=0`
-    and `limit=2&page=1` return distinct first rows.
-  - **`senateID` on Senate and House trades.** `SenateTrade.senate_id` and
-    `HouseDisclosure.senate_id` alias `senateID`. The wire name is kept on
-    House rows (Pelosi → `P000197`); we do not invent `house_id`.
-  - **`CompanyRating` score columns.** `rating-bulk` headers
-    `discountedCashFlowScore` / `returnOnEquityScore` / `returnOnAssetsScore`
-    / `debtToEquityScore` / `priceToEarningsScore` / `priceToBookScore` are
-    now typed attributes. Fractional CSV cells such as ``"3.0"`` coerce to
-    ``int`` so ``parse_csv_models`` does not skip the whole company row.
-  - **`company.get_delisted_companies`.** The 2025-10 delisted-companies
-    architecture sync left a live `/stable/delisted-companies` path whose
-    declaration used `CompanyProfile` and had no client method. Sync and
-    async clients now expose `get_delisted_companies(page=0, limit=100)`
-    returning `DelistedCompany` (`symbol`, `companyName`, `exchange`,
-    `ipoDate`, `delistedDate`). MCP: `company.delisted_companies` (in
-    `DEFAULT_TOOLS`). LangChain indexes the same semantics key.
+- **Extras coverage gate raised to 80% and made a required check (#273, #282).**
+  Dedicated tests for `cache/redis_backend.py`, `lc/validation.py`,
+  `lc/__init__.py`, `mcp/utils.py` and `mcp/setup.py` took the measured extras
+  number from 66.78% to 86.99%, so `nox -s coverage_extras` now fails under 80
+  with ~7 points of headroom. `Extras Coverage`, `coverage`, `Secret Scan`,
+  `Actions shell checks` and `Test-MatrixExpected` are now required status
+  checks on **Protect Dev** and **Protect Main**; previously only
+  `tests (3.10–3.14)` were required, so a red extras or secret scan could not
+  block a merge. Also fixed the `Protocol` exclusion in `extras.coveragerc`,
+  which had been copied from TOML with `\\(` and so never matched.
+- **`uv.lock` stays uncommitted, by decision (#273).** Recorded in
+  `CONTRIBUTING.md` under "Lock file policy": this is a library, so the
+  compatibility contract is the floors in `pyproject.toml`; drift is caught by
+  `nox -s security` auditing a live `uv export` with `pip-audit --strict`
+  rather than frozen behind stale pins. The old `.gitignore` rationale cited a
+  non-existent "GitHub 500KB warning" (that threshold is pre-commit's
+  `check-added-large-files` default) and has been replaced.
+- **`fmp-mcp generate` writes JSON / YAML / TOML from the output suffix (#256).**
+  `.json` is preferred (`{"tools": [...]}`). `.yaml` / `.yml` and `.toml` use
+  the same `tools` object. A path with no suffix becomes `<name>.json`.
+  `.py` still writes the restricted `TOOLS = ["..."]` form so existing
+  scripts keep working. Unknown suffixes are refused.
 
 ### Fixed
+
+- **Remaining `httpx.RequestError` leftovers no longer leak `apikey=`
+  (#354).** `ProtocolError`, `ProxyError`, `DecodingError`,
+  `TooManyRedirects`, `UnsupportedProtocol`, and any future
+  `RequestError` now raise `FMPNetworkError` with `from None`. Same
+  secret-absent pin as #97 / #350 (`str` / `repr` / `__cause__` /
+  traceback / error log). `ProtocolError` / `ProxyError` stay
+  retryable; the others set `FMPNetworkError.retryable = False`.
+  Timeouts stay `FMPTimeoutError`. `validate_api_key` classifies
+  `FMPNetworkError` and raw non-timeout `httpx.RequestError` (fakes /
+  adapters) as `unavailable`.
+
+- **Timeout and network errors no longer leak `apikey=` (#350).**
+  `httpx.TimeoutException` / `httpx.NetworkError` now raise
+  `FMPTimeoutError` / `FMPNetworkError` with `from None`. The request
+  URL is not logged (`str(httpx_exc)` and `exc_info=True` are off that
+  path). Status errors were already mapped in #97; this is the leftover
+  transport path. Callers that caught raw httpx timeouts should catch
+  the new types (they remain `FMPError` subclasses and stay retryable).
+  `validate_api_key` classifies `FMPTimeoutError` as `timeout` and
+  `FMPNetworkError` as `unavailable` so a transport failure cannot
+  report a valid key.
+
+- **MCP setup helpers no longer echo subprocess stderr (#319).**
+  `validate_api_key` and `test_mcp_server` return classified reasons
+  (`valid` / `invalid` / `timeout` / `unavailable` and
+  `passed` / `started` / `failed` / `unavailable`). `fmp-mcp status`
+  and `fmp-mcp test` print sink-local literals so a key quoted in
+  child stderr cannot reach the terminal.
+
+- **`validate_api_key` now probes FMP (#317).**
+  A typed junk key no longer reports success. The helper constructs a
+  client and calls `company.get_quote("AAPL")`; 401 and 403 map to
+  `invalid`. Rate-limit / other HTTP errors still count as `valid`.
+
+- **`validate_api_key` first classified a status-less `Invalid API KEY`
+  body as invalid (#329).** That wizard-side copy matcher is superseded
+  by #340 in this same 2.7.0 section. Live `/stable/quote` returns
+  HTTP 401 for a junk key (probed 2026-08-15).
+
+- **Setup wizard offers the example MCP profiles again (#320).**
+  `get_manifest_choices` looks in `examples/mcp/configurations/` (the
+  real directory). The example Claude Desktop script, JSON profiles,
+  and README / troubleshooting copies use the same path.
+
+- **E2E sweep no longer treats Senate/House trades-by-id as allowed
+  empty (#337).** Those methods pin known-nonempty ids (`W000802` /
+  `P000197`); a 200/`[]` is the 404-as-empty class, not entity
+  emptiness. Name-based lookups stay on `ALLOW_EMPTY`.
+
+- **2xx `Invalid API KEY` bodies raise `AuthenticationError` (#340).**
+  `_check_error_response` types the known invalid-key copy instead of
+  a status-less `FMPError`. Unrelated 2xx bodies stay `FMPError`.
+  `validate_api_key`'s copy matcher is gone — the
+  `except AuthenticationError` path covers it.
+
+- **Net-worth integration tests lock nested objects, aggregated
+  aliases, and `model_extra` (#336).** Itemized rows must have empty
+  `model_extra` and at least one populated `valueRange` and
+  `debtDetails`. Aggregated pages must populate both `total` and
+  `stock`.
+
+- **Committed cassette-contract snapshot fails CI without YAML (#336).**
+  `tests/integration/cassette_contracts.json` lists required wire
+  aliases for government-trading models. The YAML payload check still
+  skips when cassettes are gitignored.
+
+- **List-shaped 2xx `Invalid API KEY` bodies raise
+  `AuthenticationError` (#342).** A one-element list whose only keys
+  are error keys is routed through `_raise_response_error`. Multi-row
+  lists are not walked. Unrelated singleton error lists stay
+  `FMPError`.
+
+- **Residual list-shaped 2xx error bodies type as
+  `AuthenticationError` (#344).** A one-element list with decorator
+  keys (`Error Message` plus data fields), a nested error value
+  (`{"message": "Invalid API KEY"}`), or a scalar
+  `["Invalid API KEY"]` now raises instead of falling through
+  validation. Mixed-key rows whose copy is not the junk-key body stay
+  on the validation path. Multi-row lists are still not walked.
 
 - **TestPyPI / Dev-Release / Release sdist version-assert no longer
   SIGPIPEs.** `set -euo pipefail` plus `tar -xOf … | awk … exit` made
@@ -487,17 +533,21 @@ None. No FMP path we ship was newly retired by this changelog window.
   had made every unsigned automation commit need `--admin` despite green checks;
   required Test-Matrix jobs, no force-push, and no branch deletion remain.
 
-### Changed
-
-- **CI and local uv are 0.12.3+.** ``setup-uv`` v10 installs uv ``0.12.3``.
-  ``[tool.uv] required-version = ">=0.12.3"`` rejects older local
-  installs. The action pin remains the v10.0.0 SHA.
-- **Separate extras coverage gate for ``lc`` / ``mcp`` / Redis (#273).**
-  The core 80% report still omits those trees. ``nox -s coverage_extras``
-  (CI job ``extras-coverage``) installs the extras, measures only those
-  files, and fails under 65% (measured baseline 66.78% on 2026-08-13).
-  ``Test-MatrixExpected`` requires that job. The ``mcp-server`` session
-  now runs every ``tests/unit/test_mcp*.py`` file.
+- **Async requests work again (#252 FMP-SEC-004).** `httpx.AsyncClient` *awaits*
+  every response hook (`await hook(response)`), while `httpx.Client` calls it
+  plainly. The cross-origin redirect guard added for FMP-SEC-004 was a plain
+  `def` registered on both clients, so httpx awaited `None` and **every**
+  successful async response raised
+  `TypeError: object NoneType can't be used in 'await' expression` — not only
+  redirects. `_areject_cross_origin_redirect` now wraps the check for the async
+  client. Unreleased regression: it never shipped in a tagged version. The async
+  tests replaced the client with `AsyncMock` and asserted only hook membership,
+  so nothing exercised the real send path; they now drive
+  `httpx.MockTransport` and assert the hook is a coroutine function.
+- **`_unwrap_list_result` refuses a bytes file (#253).** `request_list` already
+  raised `TypeError` for `Endpoint[bytes]`, but the shared unwrap helper still
+  treated `isinstance(payload, bytes)` as a lone row and returned `[bytes]`.
+  Quote-list unwrap is unchanged.
 
 ### Security
 
@@ -691,51 +741,6 @@ None. No FMP path we ship was newly retired by this changelog window.
   TOML uses `tomli` from the `mcp` extra; 3.11+ uses stdlib `tomllib`.
   Existing generated and example `.py` manifests keep working. A file
   that previously ran arbitrary code as "validation" now fails closed.
-
-### Fixed
-
-- **Async requests work again (#252 FMP-SEC-004).** `httpx.AsyncClient` *awaits*
-  every response hook (`await hook(response)`), while `httpx.Client` calls it
-  plainly. The cross-origin redirect guard added for FMP-SEC-004 was a plain
-  `def` registered on both clients, so httpx awaited `None` and **every**
-  successful async response raised
-  `TypeError: object NoneType can't be used in 'await' expression` — not only
-  redirects. `_areject_cross_origin_redirect` now wraps the check for the async
-  client. Unreleased regression: it never shipped in a tagged version. The async
-  tests replaced the client with `AsyncMock` and asserted only hook membership,
-  so nothing exercised the real send path; they now drive
-  `httpx.MockTransport` and assert the hook is a coroutine function.
-- **`_unwrap_list_result` refuses a bytes file (#253).** `request_list` already
-  raised `TypeError` for `Endpoint[bytes]`, but the shared unwrap helper still
-  treated `isinstance(payload, bytes)` as a lone row and returned `[bytes]`.
-  Quote-list unwrap is unchanged.
-
-### Changed
-
-- **Extras coverage gate raised to 80% and made a required check (#273, #282).**
-  Dedicated tests for `cache/redis_backend.py`, `lc/validation.py`,
-  `lc/__init__.py`, `mcp/utils.py` and `mcp/setup.py` took the measured extras
-  number from 66.78% to 86.99%, so `nox -s coverage_extras` now fails under 80
-  with ~7 points of headroom. `Extras Coverage`, `coverage`, `Secret Scan`,
-  `Actions shell checks` and `Test-MatrixExpected` are now required status
-  checks on **Protect Dev** and **Protect Main**; previously only
-  `tests (3.10–3.14)` were required, so a red extras or secret scan could not
-  block a merge. Also fixed the `Protocol` exclusion in `extras.coveragerc`,
-  which had been copied from TOML with `\\(` and so never matched.
-- **`uv.lock` stays uncommitted, by decision (#273).** Recorded in
-  `CONTRIBUTING.md` under "Lock file policy": this is a library, so the
-  compatibility contract is the floors in `pyproject.toml`; drift is caught by
-  `nox -s security` auditing a live `uv export` with `pip-audit --strict`
-  rather than frozen behind stale pins. The old `.gitignore` rationale cited a
-  non-existent "GitHub 500KB warning" (that threshold is pre-commit's
-  `check-added-large-files` default) and has been replaced.
-- **`fmp-mcp generate` writes JSON / YAML / TOML from the output suffix (#256).**
-  `.json` is preferred (`{"tools": [...]}`). `.yaml` / `.yml` and `.toml` use
-  the same `tools` object. A path with no suffix becomes `<name>.json`.
-  `.py` still writes the restricted `TOOLS = ["..."]` form so existing
-  scripts keep working. Unknown suffixes are refused.
-
-### Security
 
 - **TestPyPI tag guard cannot be shadowed by a tag (#252 FMP-SEC-003).** The
   ancestry check compared against the *unqualified* rev `origin/main`. Git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   floor is unchanged (`0.12.3`).
 - **2.7.0 changelog subsections are unique (#360).** One Added / Changed /
   Fixed / Security under the version heading. `### FMP API surface` sits
-  immediately under the intro. The published GitHub Release notes are
-  unchanged (they never used this file's body).
+  immediately under the intro. The uniqueness tripwire matches dated
+  `## [X.Y.Z] - date` headings; empty Unreleased stays valid. The
+  published GitHub Release notes are unchanged (they never used this
+  file's body).
 - **Withdrawn MCP catalog rows are marked in `docs/mcp/tools.md` (#361).**
   Every `WITHDRAWN_TOOLS` spec now carries **Withdrawn / not in
   DEFAULT_TOOLS** (with successor or none). Docs-sync fails if a
@@ -29,7 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   indent left the `EOF` terminator off column 0 after strip, so bash
   swallowed the rest of the script and never pushed the `-s ours`
   merge. Terminators now sit at the `run: |` base indent. `Actions
-  shell checks` runs `bash -n` on every workflow `run:` block.
+  shell checks` runs `bash -n` on every workflow `run:` block and
+  flags space-indented here-doc terminators (not only unclosed ones).
 - **Async retry tests patch `asyncio.sleep` (#358).** Tenacity 9.1.4
   async retries go through `_portable_async_sleep` → `asyncio.sleep`,
   not `tenacity.nap.sleep`. Sync tests keep the nap patch.

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -53,7 +53,7 @@ resolve and return `[]`, but they are not in `DEFAULT_TOOLS`. Rows marked
 | Tool Key | Description |
 |----------|-------------|
 | `commodities_list` | Get a list of all available commodities |
-| `commodities_quotes` | Get current quotes for all available commodities |
+| `commodities_quotes` | **Withdrawn / not in DEFAULT_TOOLS** — client returns `[]`; prefer `commodity_quotes` (batch) |
 | `commodity_historical` | Get historical price data for a commodity |
 | `commodity_intraday` | Get intraday price data for commodities |
 | `commodity_quote` | Get detailed quote for a specific commodity |
@@ -61,12 +61,12 @@ resolve and return `[]`, but they are not in `DEFAULT_TOOLS`. Rows marked
 | `crypto_intraday` | Get detailed intraday price data for a cryptocurrency |
 | `crypto_list` | Get a list of all available cryptocurrencies and their basic information |
 | `crypto_quote` | Get detailed real-time quote for a specific cryptocurrency |
-| `crypto_quotes` | Get current price quotes for all available cryptocurrencies |
+| `crypto_quotes` | **Withdrawn / not in DEFAULT_TOOLS** — client returns `[]`; prefer `batch.crypto_quotes` |
 | `forex_historical` | Get historical exchange rate data for a currency pair |
 | `forex_intraday` | Get intraday exchange rate data at specified intervals |
 | `forex_list` | Get a complete list of available forex currency pairs |
 | `forex_quote` | Get detailed real-time quote for a specific currency pair |
-| `forex_quotes` | Get real-time quotes for all available forex currency pairs |
+| `forex_quotes` | **Withdrawn / not in DEFAULT_TOOLS** — client returns `[]`; prefer `batch.forex_quotes` |
 
 ## Batch
 
@@ -115,10 +115,10 @@ via a manifest; these return large payloads and several are CSV).
 | `aftermarket_quote` | Get after-hours bid/ask quote data for a stock with sizes, prices, and timestamp |
 | `aftermarket_trade` | Get after-hours trade data for a stock, including price, size, and trade timestamp |
 | `analyst_estimates` | Retrieve detailed analyst estimates including revenue, earnings, EBITDA, and other financial metrics forecasts with high/low/average ranges |
-| `analyst_recommendations` | Retrieve analyst buy/sell/hold recommendations and consensus ratings for stocks including detailed rating breakdowns |
+| `analyst_recommendations` | **Withdrawn / not in DEFAULT_TOOLS** — client returns `[]`; prefer `grades_consensus` |
 | `company_logo_url` | Get the URL of the company's official logo image for use in applications, websites, or documentation |
 | `company_notes` | Retrieve company financial notes and disclosures from SEC filings, providing additional context and explanations about financial statements |
-| `core_information` | Get essential company information including CIK number, exchange listing, SIC code, state of incorporation, and fiscal year details |
+| `core_information` | **Withdrawn / not in DEFAULT_TOOLS** — client returns `[]`; prefer `profile` |
 | `delisted_companies` | Get companies FMP reports as delisted, including the last exchange, IPO date, and delist date |
 | `employee_count` | Get historical employee count data showing how company workforce has changed over time |
 | `executive_compensation` | Get detailed executive compensation information including salary, bonuses, stock awards, and total compensation packages for company leaders |
@@ -127,12 +127,12 @@ via a manifest; these return large payloads and several are CSV).
 | `historical_market_cap` | Retrieve historical market capitalization data to track changes in company value over time |
 | `historical_price` | *Deprecated — use `historical_prices`; removed in 3.0.* Retrieve historical daily price data including open, high, low, close, and adjusted prices with volume information . |
 | `historical_prices` | Retrieve historical price data including OHLCV (Open, High, Low, Close, Volume) information for detailed technical and performance analysis. |
-| `historical_share_float` | Get historical share float data showing how the number of tradable shares has changed over time |
+| `historical_share_float` | **Withdrawn / not in DEFAULT_TOOLS** — client returns `[]`; prefer `share_float` |
 | `intraday_price` | *Deprecated — use `intraday_prices`; removed in 3.0.* Get intraday price data at various intervals (1min to 4hour) for detailed analysis of price movements within the trading day |
 | `intraday_prices` | Get intraday price data with minute-by-minute or hourly intervals |
 | `key_executives` | Get detailed information about company's key executives including their names, titles, tenure, and basic compensation data |
 | `market_cap` | Get current market capitalization data for a company, including total market value and related metrics |
-| `price_target` | Retrieve analyst price targets for a specific stock, including target prices, analyst details, and publication dates |
+| `price_target` | **Withdrawn / not in DEFAULT_TOOLS** — client returns `[]`; prefer `price_target_summary` |
 | `price_target_consensus` | Get detailed consensus information about analyst price targets, including target distribution, recent changes, and analyst recommendations. |
 | `price_target_summary` | Get a summary of analyst price targets for a stock, including average, highest, and lowest targets along with number of analysts. |
 | `product_revenue_segmentation` | Get detailed revenue breakdown by product lines or services, showing how company revenue is distributed across different offerings |
@@ -143,8 +143,8 @@ via a manifest; these return large payloads and several are CSV).
 | `simple_quote` | Get real-time basic stock quote including price, volume, and change information |
 | `stock_price_change` | Get percentage price changes across multiple time horizons for a stock |
 | `symbol_changes` | Get historical record of company ticker symbol changes, tracking when and why companies changed their trading symbols |
-| `upgrades_downgrades` | Access stock rating changes including upgrades, downgrades, and rating adjustments with analyst and firm information |
-| `upgrades_downgrades_consensus` | Get aggregated rating consensus data including buy/sell/hold counts and overall recommendation trends |
+| `upgrades_downgrades` | **Withdrawn / not in DEFAULT_TOOLS** — client returns `[]`; prefer `grades` |
+| `upgrades_downgrades_consensus` | **Withdrawn / not in DEFAULT_TOOLS** — client returns `[]`; prefer `grades_consensus` |
 
 ## Economics
 
@@ -174,7 +174,7 @@ via a manifest; these return large payloads and several are CSV).
 | `financial_ratios` | Access comprehensive financial ratios for analyzing company performance, efficiency, and financial health. |
 | `financial_reports_dates` | Retrieve available financial report dates and access links for a company, including quarterly and annual filings. |
 | `full_financial_statement` | Access complete financial statements as reported to regulatory authorities, including detailed line items, notes, and supplementary information. |
-| `historical_rating` | Retrieve historical company ratings and scoring metrics over time based on fundamental analysis. |
+| `historical_rating` | **Withdrawn / not in DEFAULT_TOOLS** — client returns `[]`; prefer `ratings_historical` |
 | `income_statement` | Retrieve detailed income statements showing revenue, costs, expenses and profitability metrics for a company over multiple periods. |
 | `key_metrics` | Access essential financial metrics and KPIs including profitability, efficiency, and valuation measures. |
 | `latest_financial_statements` | Get the latest financial statement publication metadata across symbols with pagination. |
@@ -200,10 +200,10 @@ via a manifest; these return large payloads and several are CSV).
 
 | Tool Key | Description |
 |----------|-------------|
-| `asset_allocation` | Analyze asset allocation data from 13F filings |
+| `asset_allocation` | **Withdrawn / not in DEFAULT_TOOLS** — client returns `[]` |
 | `beneficial_ownership` | Retrieve beneficial ownership information including voting rights and dispositive power for major shareholders of a company. |
 | `cik_mappings` | Get a comprehensive mapping between CIK numbers and company/institution names. |
-| `fail_to_deliver` | Get data on failed trade settlements (FTDs) for a security. |
+| `fail_to_deliver` | **Withdrawn / not in DEFAULT_TOOLS** — client returns `[]` |
 | `form_13f` | Retrieve Form 13F filings data for institutional investment managers, including detailed holdings information, share quantities, and market values. |
 | `form_13f_dates` | Get a list of available Form 13F filing dates for a specific institutional investment manager, helping track their reporting history and timeline. |
 | `insider_roster` | Get a list of company insiders including executives, directors, and major shareholders, along with their positions and latest transaction dates. |
@@ -279,18 +279,18 @@ via a manifest; these return large payloads and several are CSV).
 |----------|-------------|
 | `etf_country_weightings` | Get detailed geographic allocation data for an ETF, showing the percentage of the portfolio invested in different countries |
 | `etf_exposure` | Retrieve detailed stock exposure data for an ETF, showing specific securities held and their weights in the portfolio |
-| `etf_holder` | Get information about institutional holders of an ETF, including their holdings and position sizes |
-| `etf_holding_dates` | Get a list of available portfolio dates for which ETF holdings data is available |
+| `etf_holder` | **Withdrawn / not in DEFAULT_TOOLS** — client returns `[]`; prefer `fund_disclosure_holders_latest` |
+| `etf_holding_dates` | **Withdrawn / not in DEFAULT_TOOLS** — client returns `[]`; prefer `mutual_fund_dates` |
 | `etf_holdings` | Retrieve detailed holdings information for an ETF including assets, weights, and market values as of a specific date |
 | `etf_info` | Get comprehensive information about an ETF including expense ratio, assets under management, and fund characteristics |
 | `etf_sector_weightings` | Retrieve detailed sector allocation data for an ETF, showing the percentage of the portfolio invested in different market sectors |
 | `fund_disclosure` | Retrieve detailed fund disclosure holdings for a symbol and reporting period, including security metadata and portfolio percentages |
 | `fund_disclosure_holders_latest` | Retrieve the latest fund disclosure holders for a symbol, including holder name, shares, and weight percentage |
 | `fund_disclosure_holders_search` | Search fund disclosure holders by name to retrieve fund identifiers and entity details |
-| `mutual_fund_by_name` | Search for mutual funds by name to get their holdings and basic information |
+| `mutual_fund_by_name` | **Withdrawn / not in DEFAULT_TOOLS** — client returns `[]` |
 | `mutual_fund_dates` | Retrieve available portfolio dates for mutual fund holdings data, helping track portfolio composition changes over time |
-| `mutual_fund_holder` | Get information about institutional holders of a mutual fund, including their holdings and position sizes |
-| `mutual_fund_holdings` | Get detailed holdings information for a mutual fund, including securities held, weights, and market values as of a specific date |
+| `mutual_fund_holder` | **Withdrawn / not in DEFAULT_TOOLS** — client returns `[]`; prefer `fund_disclosure_holders_latest` |
+| `mutual_fund_holdings` | **Withdrawn / not in DEFAULT_TOOLS** — client returns `[]`; prefer `etf_holdings` |
 
 ## Market
 
@@ -313,7 +313,7 @@ via a manifest; these return large payloads and several are CSV).
 | `losers` | Get list of top losing stocks by percentage change, showing the worst performing stocks in the current trading session |
 | `market_hours` | Check current market status and trading hours for a specific exchange |
 | `most_active` | Get list of most actively traded stocks by volume, showing stocks with the highest trading activity in the current session |
-| `pre_post_market` | Retrieve pre-market and post-market trading data including prices, volume, and trading session information outside regular market hours |
+| `pre_post_market` | **Withdrawn / not in DEFAULT_TOOLS** — client returns `[]` |
 | `search` | Search for companies by name, ticker, or other identifiers. |
 | `search_by_cik` | Search for companies by their SEC Central Index Key (CIK) number |
 | `search_by_cusip` | Search for companies by their CUSIP identifier |

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -934,7 +934,7 @@ async def test_async_timeout_does_not_leak_apikey_via_cause_or_logs(
         with (
             patch.object(client, "_setup_async_client", return_value=mock_async_client),
             patch.object(client.logger, "error") as mock_error,
-            patch("tenacity.nap.sleep", return_value=None),
+            patch("asyncio.sleep", new_callable=AsyncMock),
             pytest.raises(FMPTimeoutError) as exc_info,
         ):
             await client.request_async(mock_endpoint)
@@ -972,7 +972,7 @@ async def test_async_network_error_does_not_leak_apikey_via_cause_or_logs(
         with (
             patch.object(client, "_setup_async_client", return_value=mock_async_client),
             patch.object(client.logger, "error") as mock_error,
-            patch("tenacity.nap.sleep", return_value=None),
+            patch("asyncio.sleep", new_callable=AsyncMock),
             pytest.raises(FMPNetworkError) as exc_info,
         ):
             await client.request_async(mock_endpoint)
@@ -1065,7 +1065,7 @@ async def test_async_leftover_request_error_does_not_leak_apikey_via_cause_or_lo
         with (
             patch.object(client, "_setup_async_client", return_value=mock_async_client),
             patch.object(client.logger, "error") as mock_error,
-            patch("tenacity.nap.sleep", return_value=None),
+            patch("asyncio.sleep", new_callable=AsyncMock),
             pytest.raises(FMPNetworkError) as exc_info,
         ):
             await client.request_async(mock_endpoint)
@@ -1536,7 +1536,7 @@ async def test_async_protocol_error_is_retried(mock_endpoint, client_config) -> 
     try:
         with (
             patch.object(client, "_setup_async_client", return_value=mock_async_client),
-            patch("tenacity.nap.sleep", return_value=None),
+            patch("asyncio.sleep", new_callable=AsyncMock),
             pytest.raises(FMPNetworkError) as exc_info,
         ):
             await client.request_async(mock_endpoint)

--- a/tests/unit/test_changelog_headings.py
+++ b/tests/unit/test_changelog_headings.py
@@ -3,7 +3,10 @@
 Folding Unreleased into 2.7.0 left two Added / four Changed / three Fixed /
 two Security under the same version heading, with FMP API surface in the
 middle. The merge is editorial; this pin keeps it from happening again on
-Unreleased and on 2.7.0+.
+Unreleased and on dated ``## [X.Y.Z] - YYYY-MM-DD`` headings from 2.7.0+.
+
+Empty Unreleased is allowed (the post-cut bucket). Duplicate standard
+headings are not.
 """
 
 from __future__ import annotations
@@ -17,7 +20,12 @@ CHANGELOG = Path(__file__).resolve().parents[2] / "CHANGELOG.md"
 _STANDARD = frozenset(
     {"Added", "Changed", "Deprecated", "Removed", "Fixed", "Security"}
 )
-_VERSION_HEADER = re.compile(r"^## (?:Unreleased|\[(\d+)\.(\d+)\.[^\]]+\])\s*$")
+# Keep a Changelog dates the version: `## [2.7.0] - 2026-08-19`.
+# A `$` immediately after `]` would skip every shipped section and leave
+# only Unreleased gated (#360 follow-up on #369).
+_VERSION_HEADER = re.compile(
+    r"^## (?:Unreleased|\[(\d+)\.(\d+)\.[^\]]+\])(?:\s+-.*)?\s*$"
+)
 _HEADING = re.compile(r"^### (.+)$", re.M)
 
 
@@ -41,16 +49,48 @@ def _gated_sections(text: str) -> list[tuple[str, str]]:
     return out
 
 
+def test_version_header_matches_dated_keep_a_changelog() -> None:
+    """The uniqueness pin must see dated 2.7+ headings, not only Unreleased."""
+    dated = _VERSION_HEADER.match("## [2.7.0] - 2026-08-19")
+    assert dated is not None
+    assert dated.group(1) == "2"
+    assert dated.group(2) == "7"
+    assert _VERSION_HEADER.match("## Unreleased") is not None
+    assert _VERSION_HEADER.match("## [2.6.0] - 2026-08-10") is not None
+    assert _VERSION_HEADER.match("## Future Roadmap") is None
+
+
+def test_gated_sections_include_dated_2_7_and_allow_empty_unreleased() -> None:
+    text = (
+        "## Unreleased\n\n"
+        "## [2.7.0] - 2026-08-19\n\n### Added\n\n- note\n\n"
+        "## [2.6.0] - 2026-08-10\n\n### Added\n\n- old\n"
+    )
+    sections = _gated_sections(text)
+    headers = [header for header, _ in sections]
+    assert headers == ["## Unreleased", "## [2.7.0] - 2026-08-19"]
+    unreleased_headings = [
+        name for name in _HEADING.findall(sections[0][1]) if name in _STANDARD
+    ]
+    assert unreleased_headings == []
+
+
 def test_changelog_standard_headings_are_unique_from_2_7() -> None:
     text = CHANGELOG.read_text(encoding="utf-8")
     sections = _gated_sections(text)
     assert sections, "expected Unreleased and/or 2.7.0+ sections"
+    dated = [header for header, _ in sections if header.startswith("## [")]
+    assert dated, (
+        "uniqueness pin matched no dated 2.7+ section; "
+        "the version-header regex is probably ignoring `## [X.Y.Z] - date`"
+    )
 
     duplicates: dict[str, list[str]] = {}
     for header, body in sections:
         headings = _HEADING.findall(body)
         standard = [name for name in headings if name in _STANDARD]
-        assert standard, f"{header}: no standard Keep a Changelog headings"
+        # Empty Unreleased is the post-cut bucket (#360). Version sections
+        # that still have notes must not repeat a standard heading.
         repeated = sorted(
             name for name, count in Counter(standard).items() if count > 1
         )

--- a/tests/unit/test_changelog_headings.py
+++ b/tests/unit/test_changelog_headings.py
@@ -1,0 +1,71 @@
+"""Keep a Changelog version sections must not repeat standard headings (#360).
+
+Folding Unreleased into 2.7.0 left two Added / four Changed / three Fixed /
+two Security under the same version heading, with FMP API surface in the
+middle. The merge is editorial; this pin keeps it from happening again on
+Unreleased and on 2.7.0+.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+import re
+
+CHANGELOG = Path(__file__).resolve().parents[2] / "CHANGELOG.md"
+
+_STANDARD = frozenset(
+    {"Added", "Changed", "Deprecated", "Removed", "Fixed", "Security"}
+)
+_VERSION_HEADER = re.compile(r"^## (?:Unreleased|\[(\d+)\.(\d+)\.[^\]]+\])\s*$")
+_HEADING = re.compile(r"^### (.+)$", re.M)
+
+
+def _gated_sections(text: str) -> list[tuple[str, str]]:
+    """``(header, body)`` for Unreleased and every ``[X.Y.*]`` with X.Y >= 2.7."""
+    chunks = re.split(r"(?=^## )", text, flags=re.M)
+    out: list[tuple[str, str]] = []
+    for chunk in chunks:
+        lines = chunk.splitlines()
+        if not lines:
+            continue
+        header = lines[0].strip()
+        match = _VERSION_HEADER.match(header)
+        if match is None:
+            continue
+        if match.group(1) is not None:
+            major, minor = int(match.group(1)), int(match.group(2))
+            if (major, minor) < (2, 7):
+                continue
+        out.append((header, chunk))
+    return out
+
+
+def test_changelog_standard_headings_are_unique_from_2_7() -> None:
+    text = CHANGELOG.read_text(encoding="utf-8")
+    sections = _gated_sections(text)
+    assert sections, "expected Unreleased and/or 2.7.0+ sections"
+
+    duplicates: dict[str, list[str]] = {}
+    for header, body in sections:
+        headings = _HEADING.findall(body)
+        standard = [name for name in headings if name in _STANDARD]
+        assert standard, f"{header}: no standard Keep a Changelog headings"
+        repeated = sorted(
+            name for name, count in Counter(standard).items() if count > 1
+        )
+        if repeated:
+            duplicates[header] = repeated
+
+    assert duplicates == {}, f"duplicate changelog headings: {duplicates}"
+
+
+def test_2_7_0_puts_fmp_api_surface_first() -> None:
+    text = CHANGELOG.read_text(encoding="utf-8")
+    match = re.search(r"^## \[2\.7\.0\].*?(?=^## \[)", text, re.M | re.S)
+    assert match is not None, "missing ## [2.7.0] section"
+    headings = _HEADING.findall(match.group(0))
+    assert headings, "2.7.0 has no ### headings"
+    assert headings[0].startswith("FMP API surface"), headings[0]
+    for name in ("Added", "Changed", "Fixed", "Security"):
+        assert headings.count(name) == 1, headings

--- a/tests/unit/test_docs_tools_sync.py
+++ b/tests/unit/test_docs_tools_sync.py
@@ -144,6 +144,40 @@ _NO_SUCCESSOR_WORDS = {
 }
 
 
+_WITHDRAWN_MARK = "**Withdrawn / not in DEFAULT_TOOLS**"
+_ROW_FULL_RE = re.compile(r"^\| `(?P<key>[a-z_0-9]+)` \| (?P<desc>.*) \|$")
+
+
+def _documented_row_text() -> dict[str, str]:
+    """``{client.key: description}`` for every catalog row."""
+    rows: dict[str, str] = {}
+    client: str | None = None
+
+    for line in DOC_PATH.read_text().splitlines():
+        section = _SECTION_RE.match(line)
+        if section:
+            title = section.group("title")
+            client = None if title == "Table of Contents" else title.lower()
+            continue
+
+        row = _ROW_FULL_RE.match(line)
+        if row and client is not None:
+            rows[f"{client}.{row.group('key')}"] = row.group("desc")
+
+    return rows
+
+
+def test_withdrawn_catalog_rows_are_marked() -> None:
+    """Every WITHDRAWN_TOOLS spec must carry the withdrawn mark in its row."""
+    rows = _documented_row_text()
+    missing = sorted(
+        spec for spec in WITHDRAWN_TOOLS if _WITHDRAWN_MARK not in rows.get(spec, "")
+    )
+    assert missing == [], (
+        f"{DOC_PATH.name} withdrawn rows omit {_WITHDRAWN_MARK!r}: {missing}"
+    )
+
+
 def test_withdrawn_preamble_counts_match_source() -> None:
     """The withdrawn-endpoint prose must track WITHDRAWN_TOOLS, not rot."""
     text = DOC_PATH.read_text()

--- a/tests/unit/test_workflow_run_scripts.py
+++ b/tests/unit/test_workflow_run_scripts.py
@@ -1,0 +1,166 @@
+"""Compile every GitHub Actions ``run:`` block with ``bash -n`` (#363).
+
+YAML ``run: |`` strips the block's common indent, then bash parses what
+remains. A here-doc terminator that is still indented after that strip is
+not recognized, so bash eats the rest of the script. Sync-Main-to-Dev hit
+that after the 2.7.0 squash (#363): the job died at
+``here-document at line 115 delimited by end-of-file`` and never pushed
+the ``-s ours`` merge.
+
+This module is both a pytest file and a CLI (``python3`` this file) so
+the ``Actions shell checks`` job can run it without the test extra.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+# <<EOF, <<'EOF', <<"EOF", <<-EOF (tab-stripping). Token is group 2/3/4.
+_HEREDOC_START = re.compile(r"""<<(-)?(?:'([^']+)'|"([^"]+)"|\\?(\w+))\s*$""")
+
+
+def _workflow_paths() -> list[Path]:
+    paths = sorted(WORKFLOWS.glob("*.yml")) + sorted(WORKFLOWS.glob("*.yaml"))
+    assert paths, f"no workflow files under {WORKFLOWS}"
+    return paths
+
+
+def _iter_run_scripts(node: object, prefix: str = "") -> Iterator[tuple[str, str]]:
+    """Yield ``(label, script)`` for every mapping that has a string ``run``."""
+    if isinstance(node, dict):
+        run = node.get("run")
+        if isinstance(run, str):
+            name = str(node.get("name") or "run")
+            label = f"{prefix}:{name}" if prefix else name
+            yield label, run
+        for key, value in node.items():
+            next_prefix = f"{prefix}.{key}" if prefix else str(key)
+            yield from _iter_run_scripts(value, next_prefix)
+    elif isinstance(node, list):
+        for index, item in enumerate(node):
+            yield from _iter_run_scripts(item, f"{prefix}[{index}]")
+
+
+def _load_run_scripts(path: Path) -> list[tuple[str, str]]:
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return list(_iter_run_scripts(loaded, prefix=path.name))
+
+
+def _heredoc_problems(script: str) -> list[str]:
+    """Return problems for here-docs that bash would not close at column 0."""
+    problems: list[str] = []
+    lines = script.splitlines()
+    index = 0
+    while index < len(lines):
+        match = _HEREDOC_START.search(lines[index])
+        if match is None:
+            index += 1
+            continue
+        strip_tabs, single, double, bare = match.groups()
+        token = single or double or bare
+        assert token is not None
+        index += 1
+        found = False
+        while index < len(lines):
+            raw = lines[index]
+            candidate = raw.lstrip("\t") if strip_tabs else raw
+            if candidate == token:
+                if not strip_tabs and raw != token:
+                    problems.append(
+                        f"indented here-doc terminator {token!r} "
+                        f"(survives YAML strip; bash will not close it)"
+                    )
+                found = True
+                break
+            index += 1
+        if not found:
+            problems.append(f"unclosed here-doc {token!r}")
+        index += 1
+    return problems
+
+
+# GitHub evaluates ${{ }} before bash sees the script. Replace them so
+# bash -n is checking the post-expression source, not the template.
+_GH_EXPR = re.compile(r"\$\{\{.*?\}\}", re.DOTALL)
+
+
+def _for_bash(script: str) -> str:
+    return _GH_EXPR.sub("GH_EXPR", script)
+
+
+def _bash_n(script: str) -> subprocess.CompletedProcess[str]:
+    rendered = _for_bash(script)
+    with tempfile.NamedTemporaryFile(
+        "w",
+        encoding="utf-8",
+        suffix=".sh",
+        delete=False,
+    ) as handle:
+        handle.write(rendered)
+        if rendered and not rendered.endswith("\n"):
+            handle.write("\n")
+        temp_path = handle.name
+    try:
+        return subprocess.run(  # noqa: S603
+            ["bash", "-n", temp_path],  # noqa: S607
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        Path(temp_path).unlink(missing_ok=True)
+
+
+def _collect_failures() -> list[str]:
+    failures: list[str] = []
+    for path in _workflow_paths():
+        for label, script in _load_run_scripts(path):
+            for problem in _heredoc_problems(script):
+                failures.append(f"{label}: {problem}")
+            compiled = _bash_n(script)
+            if compiled.returncode != 0:
+                detail = (compiled.stderr or compiled.stdout).strip()
+                failures.append(f"{label}: bash -n failed\n{detail}")
+    return failures
+
+
+def test_every_workflow_run_block_compiles() -> None:
+    """Every workflow ``run:`` block must be valid bash after YAML strip."""
+    failures = _collect_failures()
+    assert failures == [], "workflow run: blocks failed bash -n:\n" + "\n".join(
+        failures
+    )
+
+
+def test_sync_main_to_dev_is_among_the_compiled_scripts() -> None:
+    """A missing Sync-Main-to-Dev file would make the #363 pin vacuous."""
+    labels = [
+        label for path in _workflow_paths() for label, _ in _load_run_scripts(path)
+    ]
+    matching = [label for label in labels if "sync-main-to-dev" in label]
+    assert matching, "sync-main-to-dev.yml produced no run: blocks"
+
+
+def main() -> int:
+    failures = _collect_failures()
+    if failures:
+        print("workflow run: blocks failed bash -n:", file=sys.stderr)
+        for item in failures:
+            print(item, file=sys.stderr)
+        return 1
+    print(f"ok: bash -n passed for run: blocks in {len(_workflow_paths())} workflows")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_workflow_run_scripts.py
+++ b/tests/unit/test_workflow_run_scripts.py
@@ -159,6 +159,21 @@ def test_sync_main_to_dev_is_among_the_compiled_scripts() -> None:
     assert matching, "sync-main-to-dev.yml produced no run: blocks"
 
 
+def test_sync_main_to_dev_here_docs_survive_yaml_strip() -> None:
+    """#363 is the here-docs, not merely the presence of the workflow file."""
+    scripts = [
+        script
+        for path in _workflow_paths()
+        if path.name == "sync-main-to-dev.yml"
+        for _, script in _load_run_scripts(path)
+        if any(_HEREDOC_START.search(line) for line in script.splitlines())
+    ]
+    assert scripts, "sync-main-to-dev.yml produced no here-doc run: block"
+    for script in scripts:
+        assert _heredoc_problems(script) == []
+        assert "EOF" in script.splitlines(), "column-0 EOF missing after YAML strip"
+
+
 def test_indented_heredoc_terminator_is_flagged() -> None:
     """Spaces in front of EOF survive YAML strip; bash never closes the doc."""
     script = "cat <<'EOF'\nhello\n  EOF\n"

--- a/tests/unit/test_workflow_run_scripts.py
+++ b/tests/unit/test_workflow_run_scripts.py
@@ -73,13 +73,21 @@ def _heredoc_problems(script: str) -> list[str]:
         found = False
         while index < len(lines):
             raw = lines[index]
-            candidate = raw.lstrip("\t") if strip_tabs else raw
-            if candidate == token:
-                if not strip_tabs and raw != token:
-                    problems.append(
-                        f"indented here-doc terminator {token!r} "
-                        f"(survives YAML strip; bash will not close it)"
-                    )
+            # `<<-` strips leading tabs only. `<<` requires column 0.
+            # Spaces in front of the token survive YAML strip and must
+            # be flagged; matching only the exact line made the indented
+            # diagnostic dead and reported those as "unclosed" instead.
+            if strip_tabs and raw.lstrip("\t") == token:
+                found = True
+                break
+            if raw == token:
+                found = True
+                break
+            if raw.lstrip() == token:
+                problems.append(
+                    f"indented here-doc terminator {token!r} "
+                    f"(survives YAML strip; bash will not close it)"
+                )
                 found = True
                 break
             index += 1
@@ -149,6 +157,31 @@ def test_sync_main_to_dev_is_among_the_compiled_scripts() -> None:
     ]
     matching = [label for label in labels if "sync-main-to-dev" in label]
     assert matching, "sync-main-to-dev.yml produced no run: blocks"
+
+
+def test_indented_heredoc_terminator_is_flagged() -> None:
+    """Spaces in front of EOF survive YAML strip; bash never closes the doc."""
+    script = "cat <<'EOF'\nhello\n  EOF\n"
+    problems = _heredoc_problems(script)
+    assert problems, "indented terminator must be reported"
+    assert any("indented here-doc terminator" in item for item in problems)
+
+
+def test_column0_heredoc_terminator_is_clean() -> None:
+    script = "cat <<'EOF'\nhello\nEOF\n"
+    assert _heredoc_problems(script) == []
+
+
+def test_tab_stripped_dash_heredoc_is_clean() -> None:
+    script = "cat <<-EOF\nhello\n\tEOF\n"
+    assert _heredoc_problems(script) == []
+
+
+def test_unclosed_heredoc_is_flagged() -> None:
+    script = "cat <<'EOF'\nhello\n"
+    problems = _heredoc_problems(script)
+    assert problems
+    assert any("unclosed here-doc" in item for item in problems)
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary

Closes the remaining 2.7.0 leftover tickets except #359 (deferred).

Checked against current `dev` (issues were slightly stale):

| Issue | Status on `dev` | This PR |
|---|---|---|
| **#363** (P0) | Ancestry recovered by #362; here-docs still YAML-broken | Unindent `EOF` to the `run: \|` base indent; `Actions shell checks` + unit test `bash -n` every workflow `run:` block |
| **#358** | Still patched `tenacity.nap.sleep` on async retries | Four async retry tests patch `asyncio.sleep` with `AsyncMock`; sync tests unchanged |
| **#360** | Worse than filed: 2×Added / 4×Changed / 3×Fixed / 2×Security; FMP API surface in the middle. GitHub Release already published (generated stub) | In-repo 2.7.0 rewritten to one of each heading, FMP API surface first. **Did not edit the GitHub Release** |
| **#361** | Preamble + four Intelligence rows marked; 18 other `WITHDRAWN_TOOLS` rows still looked live | All 22 rows marked **Withdrawn / not in DEFAULT_TOOLS**; docs-sync fails if a withdrawn row omits the mark |
| **#359** | Still a documented gap (`plugin_marketplaces` bare git URL) | **Out of scope.** Left open; comment on the issue |

Adjacent, not in this PR:
- Standing release PR #367 (`dev` → `main`, GHA pin bump only) stays unlabeled. It will absorb this after merge. Do not cut 2.7.1 from it unless we mean to.
- `release-pr.yml` has a here-doc too; its terminator is already at script column 0 and compiles.

## Test plan

- [x] `uv run pytest tests/unit/test_workflow_run_scripts.py tests/unit/test_docs_tools_sync.py tests/unit/test_changelog_headings.py tests/unit/test_base.py` (190 passed)
- [x] `python3 tests/unit/test_workflow_run_scripts.py` (`bash -n` all 12 workflows)
- [x] Pre-commit (ruff, mypy, yaml, detect-secrets)
- [ ] CI Test-Matrix + Actions shell checks on this PR

Fixes #358
Fixes #360
Fixes #361
Fixes #363

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded release notes with new API capabilities, request options, technical intervals, security updates, and client improvements.
  - Updated MCP tool documentation for withdrawn tools, including replacement guidance and empty-result behavior.

- **Bug Fixes**
  - Corrected generated synchronization pull-request formatting.
  - Improved async retry test reliability.

- **Quality Improvements**
  - Added automated validation for workflow scripts and here-document syntax.
  - Added checks for changelog heading consistency and withdrawn-tool documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->