### PR TITLE
fix(ci): skip identical-tree Release-PR slots (#375)

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,7 +1,12 @@
 name: Release-PR
 
-# On every push to dev, ensure an open PR from dev → main exists so the
-# release checklist (labels, TestPyPI, CI) has somewhere to live.
+# On every push to `dev`, open a `dev → main` PR when there is a *content*
+# delta so the release checklist (labels, TestPyPI, CI) has somewhere to live.
+#
+# Identical trees are not a release. After a squash-merge + history-only
+# Sync-Main-to-Dev (`-s ours`), `dev` is commits-ahead of `main` with the
+# same tree. Opening a slot then (as #374 did) makes an unlabeled empty
+# squash recreate the #202 ancestry break for no package change. See #375.
 #
 # This deliberately does NOT use peter-evans/create-pull-request: that action
 # is for committing working-tree changes onto a new branch. Checking out dev
@@ -23,7 +28,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
-  issues: write  # gh label create
+  issues: write  # gh label create + empty-slot comment
 
 jobs:
   create-release-pr:
@@ -61,7 +66,7 @@ jobs:
           # Do not swallow gh failures — an auth/API error must not be treated
           # as "no PR exists."
           EXISTING_JSON=$(gh pr list --base main --head dev --state open \
-            --json number,url)
+            --json number,url,title,isDraft,body)
           EXISTING_NUM=$(echo "$EXISTING_JSON" | jq -r '.[0].number // empty')
 
           check_ancestry() {
@@ -74,8 +79,104 @@ jobs:
             fi
           }
 
+          # Post-squash history sync leaves different SHAs, AHEAD > 0, and
+          # an identical tree. SHA / rev-list checks miss that (#375).
+          trees_match() {
+            git diff --quiet origin/dev origin/main
+          }
+
+          # Terminators sit at the `run: |` base indent so YAML strip leaves
+          # them at column 0 (#363).
+          cat > /tmp/release-pr-body.md <<'RELEASE_BODY_EOF'
+          ## Release Checklist
+
+          Automated release PR from `dev` to `main`.
+
+          ### Pre-merge Checklist
+          - [ ] All CI checks pass (Test-Matrix, Guard-Main-Origin, etc.)
+          - [ ] Test PyPI validation successful (version + commit SHA in the bot comment match the tip you are releasing)
+          - [ ] Documentation is up to date
+
+          ### Release Type
+          Add **exactly one** of these labels to determine the version bump:
+          - `release:major` — Breaking changes
+          - `release:minor` — New features (backwards compatible)
+          - `release:patch` — Bug fixes
+
+          ### After Merge
+          The release workflow will automatically:
+          1. Create a new git tag
+          2. Build and publish to PyPI
+          3. Create a GitHub Release
+
+          The Sync-Main-to-Dev workflow then records the squash on `dev` so
+          the *next* release PR stays MERGEABLE. See #202 / #203 / #206.
+          RELEASE_BODY_EOF
+
+          cat > /tmp/empty-slot-body.md <<'EMPTY_SLOT_BODY_EOF'
+          ## Empty standing slot — do not merge
+
+          <!-- empty-tree-release-slot -->
+
+          `dev` and `main` have **identical trees**. This is not a release.
+
+          Opened (or kept) automatically after a squash onto `main` and the
+          history-only Sync-Main-to-Dev merge. An unlabeled empty squash
+          recreates the #202 ancestry break for no package change.
+
+          - Leave unlabeled; no `release:*`.
+          - Do **not** squash-merge while the trees match.
+          - This PR is converted to draft until `dev` has a content delta.
+            The next content push restores the release checklist and marks
+            it ready.
+
+          See #375.
+          EMPTY_SLOT_BODY_EOF
+
+          cat > /tmp/empty-slot-comment.md <<'EMPTY_SLOT_COMMENT_EOF'
+          <!-- empty-tree-release-slot -->
+
+          Converted to draft: `dev` and `main` have identical trees, so this
+          is not a release. Squash-merging it unlabeled would recreate the
+          #202 ancestry break for no package change. See #375.
+          EMPTY_SLOT_COMMENT_EOF
+
+          mark_empty_slot() {
+            local pr_number="$1"
+            echo "Release PR #${pr_number} has identical trees; converting to empty slot (draft)."
+            gh pr ready "$pr_number" --undo 2>/dev/null || true
+            gh pr edit "$pr_number" \
+              --title "Release: dev → main (empty slot — do not merge)" \
+              --body-file /tmp/empty-slot-body.md
+            if ! gh api "repos/${GITHUB_REPOSITORY}/issues/${pr_number}/comments" --paginate \
+              --jq '.[].body' | grep -Fq '<!-- empty-tree-release-slot -->'; then
+              gh pr comment "$pr_number" --body-file /tmp/empty-slot-comment.md
+            fi
+          }
+
+          restore_release_pr() {
+            local pr_number="$1"
+            local stamped="$2"
+            local is_draft="$3"
+            # Only rewrite PRs this workflow stamped. A human title that
+            # happens to say "do not merge" is not ours to clobber.
+            if [ "$stamped" != "true" ]; then
+              return 0
+            fi
+            echo "Content delta present; restoring release checklist on #${pr_number}."
+            gh pr edit "$pr_number" \
+              --title "Release: dev → main" \
+              --body-file /tmp/release-pr-body.md
+            if [ "$is_draft" = "true" ]; then
+              gh pr ready "$pr_number"
+            fi
+          }
+
           if [ -n "${EXISTING_NUM:-}" ]; then
             EXISTING_URL=$(echo "$EXISTING_JSON" | jq -r '.[0].url')
+            EXISTING_STAMPED=$(echo "$EXISTING_JSON" | jq -r \
+              '.[0].body // "" | contains("<!-- empty-tree-release-slot -->") | tostring')
+            EXISTING_DRAFT=$(echo "$EXISTING_JSON" | jq -r '.[0].isDraft | tostring')
 
             echo "Release PR already open: #${EXISTING_NUM} ${EXISTING_URL}"
 
@@ -86,6 +187,18 @@ jobs:
             # (.github/actions/check-pr-mergeable) so it cannot drift from
             # Guard-Main-Origin (#210).
             check_ancestry
+
+            if trees_match; then
+              mark_empty_slot "$EXISTING_NUM"
+              {
+                echo "action=empty-slot"
+                echo "pr_number=${EXISTING_NUM}"
+                echo "pr_url=${EXISTING_URL}"
+              } >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            restore_release_pr "$EXISTING_NUM" "$EXISTING_STAMPED" "$EXISTING_DRAFT"
 
             {
               echo "action=revalidate"
@@ -112,35 +225,17 @@ jobs:
             exit 0
           fi
 
+          # Commits-ahead with the same tree is the post-sync standing slot
+          # (#374 / #375). Do not open a release PR.
+          if trees_match; then
+            echo "dev is $AHEAD commit(s) ahead of main but the trees match; nothing to release."
+            echo "action=noop" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           echo "dev is $AHEAD commit(s) ahead of main; creating release PR."
 
           gh label create automated --color "0e8a16" --description "Automated PR" 2>/dev/null || true
-
-          cat > /tmp/release-pr-body.md <<'EOF'
-          ## Release Checklist
-
-          Automated release PR from `dev` to `main`.
-
-          ### Pre-merge Checklist
-          - [ ] All CI checks pass (Test-Matrix, Guard-Main-Origin, etc.)
-          - [ ] Test PyPI validation successful (version + commit SHA in the bot comment match the tip you are releasing)
-          - [ ] Documentation is up to date
-
-          ### Release Type
-          Add **exactly one** of these labels to determine the version bump:
-          - `release:major` — Breaking changes
-          - `release:minor` — New features (backwards compatible)
-          - `release:patch` — Bug fixes
-
-          ### After Merge
-          The release workflow will automatically:
-          1. Create a new git tag
-          2. Build and publish to PyPI
-          3. Create a GitHub Release
-
-          The Sync-Main-to-Dev workflow then records the squash on `dev` so
-          the *next* release PR stays MERGEABLE. See #202 / #203 / #206.
-          EOF
 
           URL=$(gh pr create --base main --head dev \
             --title "Release: dev → main" \
@@ -165,7 +260,7 @@ jobs:
 
       - name: Fail when the open release PR has merge conflicts
         # Same fail-closed REST contract as Guard-Main-Origin (#207 / #210).
-        if: steps.plan.outputs.action == 'revalidate'
+        if: steps.plan.outputs.action == 'revalidate' || steps.plan.outputs.action == 'empty-slot'
         id: mergeable
         uses: ./.github/actions/check-pr-mergeable
         with:
@@ -177,20 +272,35 @@ jobs:
             For a release PR (dev → main): sync main into dev with a merge
             commit (not squash), then re-push. See #202 / #207.
 
-      - name: Summarize revalidated release PR
-        if: steps.plan.outputs.action == 'revalidate'
+      - name: Summarize existing release PR
+        if: steps.plan.outputs.action == 'revalidate' || steps.plan.outputs.action == 'empty-slot'
         env:
+          ACTION: ${{ steps.plan.outputs.action }}
           PR_URL: ${{ steps.plan.outputs.pr_url }}
           MERGEABLE: ${{ steps.mergeable.outputs.mergeable }}
           MSTATE: ${{ steps.mergeable.outputs.mergeable_state }}
         run: |
           set -euo pipefail
-          echo "Existing release PR is healthy; nothing to create."
-          {
-            echo "## Release PR"
-            echo "Already open and healthy: ${PR_URL}"
-            echo ""
-            echo "- mergeable: \`${MERGEABLE}\`"
-            echo "- mergeable_state: \`${MSTATE}\`"
-            echo "- main is an ancestor of dev: yes"
-          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$ACTION" = "empty-slot" ]; then
+            echo "Existing release PR is an identical-tree slot (draft); nothing to create."
+            {
+              echo "## Release PR"
+              echo "Already open as an **empty slot** (identical trees): ${PR_URL}"
+              echo ""
+              echo "- action: \`empty-slot\`"
+              echo "- mergeable: \`${MERGEABLE}\`"
+              echo "- mergeable_state: \`${MSTATE}\`"
+              echo "- main is an ancestor of dev: yes"
+              echo "- do not squash-merge while trees match (#375)"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Existing release PR is healthy; nothing to create."
+            {
+              echo "## Release PR"
+              echo "Already open and healthy: ${PR_URL}"
+              echo ""
+              echo "- mergeable: \`${MERGEABLE}\`"
+              echo "- mergeable_state: \`${MSTATE}\`"
+              echo "- main is an ancestor of dev: yes"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Async retry tests patch `asyncio.sleep` (#358).** Tenacity 9.1.4
   async retries go through `_portable_async_sleep` → `asyncio.sleep`,
   not `tenacity.nap.sleep`. Sync tests keep the nap patch.
+- **Release-PR skips identical-tree standing slots (#375).** After a
+  squash + history-only sync, `dev` is commits-ahead of `main` with the
+  same tree. The job now treats `git diff --quiet origin/dev origin/main`
+  as nothing-to-release, converts an already-open empty slot to draft,
+  and restores it when a content delta appears. Opening an unlabeled
+  empty squash recreated the #202 ancestry break (#374).
 
 ## [2.7.0] - 2026-08-19
 

--- a/tests/unit/test_release_pr_workflow.py
+++ b/tests/unit/test_release_pr_workflow.py
@@ -1,0 +1,110 @@
+"""Release-PR must not open a slot when ``dev`` and ``main`` share a tree (#375).
+
+After a squash onto ``main`` and a history-only Sync-Main-to-Dev merge,
+``dev`` is commits-ahead of ``main`` with an identical tree. SHA equality
+and ``git rev-list --count`` miss that, so the job used to open an
+unlabeled empty ``Release: dev → main`` PR (#374). Squash-merging that
+slot recreates the #202 ancestry break for no package change.
+
+These assertions walk the workflow source so the tree-identity check cannot
+be deleted without CI failing. Behaviour of ``gh`` itself is not executed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release-pr.yml"
+
+_TREE_DIFF = "git diff --quiet origin/dev origin/main"
+_CREATE = "gh pr create --base main --head dev"
+_EMPTY_ACTION = "action=empty-slot"
+_UNDO_DRAFT = "gh pr ready"
+
+
+def _loaded() -> dict[str, Any]:
+    loaded = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    assert isinstance(loaded, dict), f"{WORKFLOW.name} is not a mapping"
+    return loaded
+
+
+def _plan_script() -> str:
+    jobs = _loaded().get("jobs") or {}
+    job = jobs.get("create-release-pr") or {}
+    steps = job.get("steps") or []
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        if step.get("id") == "plan":
+            run = step.get("run")
+            assert isinstance(run, str) and run.strip(), "plan step has no run script"
+            return run
+    raise AssertionError("create-release-pr job has no plan step")
+
+
+def test_release_pr_workflow_is_parseable() -> None:
+    loaded = _loaded()
+    assert loaded.get("name") == "Release-PR"
+    jobs = loaded.get("jobs") or {}
+    assert "create-release-pr" in jobs
+
+
+def test_trees_match_is_defined_and_used_before_create() -> None:
+    script = _plan_script()
+    assert "trees_match()" in script
+    assert _TREE_DIFF in script
+    tree_at = script.index(_TREE_DIFF)
+    create_at = script.index(_CREATE)
+    assert tree_at < create_at, "tree-identity check must run before gh pr create"
+
+
+def test_create_path_noops_when_trees_match() -> None:
+    """The no-existing-PR path must refuse to open a slot on identical trees."""
+    script = _plan_script()
+    create_at = script.index(_CREATE)
+    prefix = script[:create_at]
+    # Existing-PR path + create path each have their own call.
+    assert prefix.count("if trees_match; then") == 2
+    ahead_at = prefix.index("AHEAD=$(git rev-list --count origin/main..origin/dev)")
+    create_path = prefix[ahead_at:]
+    skip_at = create_path.index("if trees_match; then")
+    then_arm = create_path[skip_at : create_path.index("fi", skip_at)]
+    assert 'echo "action=noop"' in then_arm
+    assert "exit 0" in then_arm
+    assert "gh pr create" not in then_arm
+    # Unique vs the SHA / rev-list noops that #374 already bypassed.
+    assert "trees match; nothing to release" in then_arm
+
+
+def test_existing_pr_becomes_empty_slot_when_trees_match() -> None:
+    script = _plan_script()
+    assert "mark_empty_slot()" in script
+    assert _EMPTY_ACTION in script
+    assert f'{_UNDO_DRAFT} "$pr_number" --undo' in script or (
+        f"{_UNDO_DRAFT} " in script and "--undo" in script
+    )
+    assert "empty slot — do not merge" in script
+    assert "<!-- empty-tree-release-slot -->" in script
+    # Restore the checklist when a later push introduces a content delta.
+    assert "restore_release_pr()" in script
+    assert "Content delta present; restoring release checklist" in script
+    # Restore keys off the HTML stamp, not a title glob like "do not merge".
+    assert 'contains("<!-- empty-tree-release-slot -->")' in script
+    assert '*"do not merge"*' not in script
+
+
+def test_empty_slot_still_runs_mergeable_check() -> None:
+    """CONFLICTING empty slots must still fail closed (#207 / #210)."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "steps.plan.outputs.action == 'empty-slot'" in text
+    loaded = _loaded()
+    steps = loaded["jobs"]["create-release-pr"]["steps"]
+    mergeable = next(step for step in steps if step.get("id") == "mergeable")
+    condition = mergeable.get("if")
+    assert isinstance(condition, str)
+    assert "empty-slot" in condition
+    assert "revalidate" in condition


### PR DESCRIPTION
## Summary

Isolated follow-up from the #374 review. After unlabeled squash #367 and history-only sync #373, `dev` is commits-ahead of `main` with an identical tree. `release-pr.yml` only no-oped on matching SHAs / `rev-list --count == 0`, so it opened #374 (0 files). Squash-merging that slot would recreate the #202 ancestry break for no package change.

## Changes

- Treat `git diff --quiet origin/dev origin/main` as nothing-to-release (do not create a slot).
- If a `dev → main` PR is already open and the trees still match: convert to draft, retitle, stamp `<!-- empty-tree-release-slot -->`, comment once.
- When a later push introduces a content delta, restore the release checklist **only** if that HTML marker is present (do not clobber a human-edited PR).
- Tripwire tests so the create-path skip cannot fall through to `gh pr create`.

Closes #375.

## Out of scope

- #374 stays draft and unlabeled until this lands (then it will pick up this content delta). No `release:patch` / 2.7.1 cut.
- #370, #372, #359 remain standalone leftovers.

## Test plan

- [x] `uv run pytest tests/unit/test_release_pr_workflow.py tests/unit/test_workflow_run_scripts.py tests/unit/test_changelog_headings.py`
- [ ] CI Test-Matrix on this PR