### PR TITLE
fix(tests): patch asyncio.sleep in leftover async retry path (#372)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Async retry tests patch `asyncio.sleep` (#358).** Tenacity 9.1.4
   async retries go through `_portable_async_sleep` → `asyncio.sleep`,
   not `tenacity.nap.sleep`. Sync tests keep the nap patch.
+- **Leftover async retry path in `test_base_async.py` patches
+  `asyncio.sleep` (#372).**
+  `test_request_async_with_retry_on_transient_failure` (`max_retries=3`)
+  no longer waits the real Tenacity 4–10s backoff. It asserts two
+  `asyncio.sleep` awaits on the fail-twice-then-succeed path.
 - **Release-PR skips identical-tree standing slots (#375).** After a
   squash + history-only sync, `dev` is commits-ahead of `main` with the
   same tree. The job now treats `git diff --quiet origin/dev origin/main`

--- a/tests/unit/test_base_async.py
+++ b/tests/unit/test_base_async.py
@@ -271,7 +271,11 @@ class TestAsyncRetry:
     async def test_request_async_with_retry_on_transient_failure(
         self, client_config, sample_endpoint
     ):
-        """Test that async request retries on transient failures."""
+        """Test that async request retries on transient failures.
+
+        Patches ``asyncio.sleep`` so the Tenacity 4-10s backoff is not a
+        real wait (#372 leftover of #358).
+        """
         from fmp_data.base import BaseClient
 
         client = BaseClient(client_config)
@@ -292,7 +296,10 @@ class TestAsyncRetry:
                 raise httpx.TimeoutException("Timeout")
             return mock_response
 
-        with patch.object(client, "_setup_async_client") as mock_setup:
+        with (
+            patch.object(client, "_setup_async_client") as mock_setup,
+            patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+        ):
             mock_async_client = AsyncMock()
             mock_async_client.request = mock_request
             mock_setup.return_value = mock_async_client
@@ -302,6 +309,9 @@ class TestAsyncRetry:
             # Should have been called 3 times (2 failures + 1 success)
             assert call_count == 3
             assert result == {"test": "data"}
+            # Two backoffs between the three attempts. Tenacity 9.1.4 async
+            # retries go through asyncio.sleep, not tenacity.nap.sleep (#372).
+            assert mock_sleep.await_count == 2
 
         await client.aclose()
 


### PR DESCRIPTION
## Summary

Leftover of #358 / #369. `tests/unit/test_base.py` already patches `asyncio.sleep` for async Tenacity retries. `tests/unit/test_base_async.py::test_request_async_with_retry_on_transient_failure` still used the fixture `max_retries=3` without that patch, so CI could wait the real 4–10s backoff twice.

- Patch `asyncio.sleep` with `AsyncMock`.
- Assert `await_count == 2` on the fail-twice-then-succeed path.

Closes #372.

## Test plan

- [x] `uv run pytest tests/unit/test_base_async.py::TestAsyncRetry tests/unit/test_changelog_headings.py` (5 passed, 0.05s — was a real backoff wait before)