### PR TITLE
fix(release): generate GitHub Release notes from CHANGELOG (#370)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,73 +233,31 @@ jobs:
           gh api "repos/${REPO}/git/ref/tags/${RELEASE_TAG}" > /dev/null
           echo "Pushed tag ${RELEASE_TAG} -> ${COMMIT_SHA}"
 
-      - name: 📋 Generate release notes from PR
-        id: release_notes
+      - name: 📋 Generate release notes from CHANGELOG
         env:
-          # Untrusted PR fields via env to avoid script injection.
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          RELEASE_TAG: ${{ steps.version.outputs.VERSION }}
+          RELEASE_VERSION: ${{ steps.version.outputs.VERSION_NUMBER }}
         run: |
           set -euo pipefail
-
-          if [[ "$PR_BRANCH" =~ ^hotfix-.* ]]; then
-            RELEASE_TYPE="🔥 Hotfix"
-          else
-            RELEASE_TYPE="🚀 Release"
-          fi
-
-          # Get commits since last *previous* tag (HEAD is the new tag tip)
-          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
-          if [ -z "$PREV_TAG" ]; then
-            COMMIT_NOTES="Initial release"
-          else
-            COMMIT_NOTES=$(git log --pretty=format:"- %s" "$PREV_TAG"..HEAD)
-          fi
-
-          # Random per-run delimiter. A fixed `EOF` is only safe here by
-          # accident: `--pretty=format:"- %s"` prefixes every commit line, so a
-          # commit subject of literally `EOF` emits `- EOF` and cannot close
-          # the heredoc. Drop the `- ` prefix and it becomes a live injection --
-          # every following line would be parsed by the runner as a workflow
-          # command. Verified both ways; the guard should not be a side effect
-          # of a format string (#252).
-          DELIM="NOTES_EOF_$(openssl rand -hex 16)"
-          {
-            echo "NOTES<<$DELIM"
-            echo "### $RELEASE_TYPE"
-            echo ""
-            echo "**$PR_TITLE** (#$PR_NUMBER) by @$PR_AUTHOR"
-            echo ""
-            echo "### 📝 Commits"
-            echo "$COMMIT_NOTES"
-            echo "$DELIM"
-          } >> "$GITHUB_OUTPUT"
+          # Body is the matching ## [X.Y.Z] section, not the squash commit
+          # list. Missing / empty section fails the job (#370).
+          python3 scripts/github_release_notes.py \
+            --changelog CHANGELOG.md \
+            --version "$RELEASE_VERSION" \
+            --tag "$RELEASE_TAG" \
+            --out release-notes.md
 
       - name: 🚀 Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.version.outputs.VERSION }}
-          RELEASE_VERSION: ${{ steps.version.outputs.VERSION_NUMBER }}
-          RELEASE_NOTES: ${{ steps.release_notes.outputs.NOTES }}
         run: |
           set -euo pipefail
 
-          {
-            echo "## 🎉 Release ${RELEASE_TAG}"
-            echo ""
-            echo "${RELEASE_NOTES}"
-            echo ""
-            echo "### 📦 Installation"
-            echo '```bash'
-            echo "pip install fmp-data==${RELEASE_VERSION}"
-            echo '```'
-            echo ""
-            echo "### 🔗 Links"
-            echo "- [PyPI Package](https://pypi.org/project/fmp-data/${RELEASE_VERSION}/)"
-            echo "- [Documentation](https://mehdizare.github.io/fmp-data/)"
-          } > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "::error::release-notes.md is missing or empty."
+            exit 1
+          fi
 
           if gh release view "$RELEASE_TAG" > /dev/null 2>&1; then
             echo "::error::GitHub Release $RELEASE_TAG already exists. Refusing to overwrite."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **2.7.0 changelog subsections are unique (#360).** One Added / Changed /
   Fixed / Security under the version heading. `### FMP API surface` sits
   immediately under the intro. The uniqueness tripwire matches dated
-  `## [X.Y.Z] - date` headings; empty Unreleased stays valid. The
-  published GitHub Release notes are unchanged (they never used this
-  file's body).
+  `## [X.Y.Z] - date` headings; empty Unreleased stays valid.
+- **GitHub Release notes come from CHANGELOG.md (#370).** `release.yml`
+  extracts the matching `## [X.Y.Z]` section (fail-closed if missing or
+  empty) and wraps it with install / docs links. The published `v2.7.0`
+  notes were rewritten to that body. They are no longer the squash
+  commit stub.
 - **Withdrawn MCP catalog rows are marked in `docs/mcp/tools.md` (#361).**
   Every `WITHDRAWN_TOOLS` spec now carries **Withdrawn / not in
   DEFAULT_TOOLS** (with successor or none). Docs-sync fails if a

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -130,7 +130,9 @@ the overlay in a hotfix-shaped PR.
   `contents: write` build job, then publishes to PyPI from a second job that
   only downloads the hashed artifacts and has `id-token: write` (environment
   `pypi`). Existing tags / releases / PyPI versions fail the job instead of
-  being skipped.
+  being skipped. Release notes are the matching `## [X.Y.Z]` section of
+  `CHANGELOG.md` (via `scripts/github_release_notes.py`), not the squash
+  commit list (#370). A missing or empty section fails the job.
 - External Actions are pinned to full commit SHAs. The PEP 517 frontend
   (`build`) and backend (`hatchling`, `hatch-vcs`) are installed from
   version floors in `.github/requirements-build.txt` (not a hashed lock).
@@ -256,10 +258,11 @@ For emergency releases or when automation fails:
    ```
 
 9. **Create GitHub Release**
-   - Go to GitHub Releases
-   - Create release from tag
-   - Add release notes
-   - Publish release
+   - Automated `release.yml` does this. Notes are the matching
+     `## [X.Y.Z]` section of `CHANGELOG.md`, wrapped with install /
+     docs links (`scripts/github_release_notes.py`). They are **not**
+     the squash commit list. Keep CHANGELOG updated before the release
+     PR merges; a missing section fails the job.
 
 ## Pre-release Process
 

--- a/scripts/github_release_notes.py
+++ b/scripts/github_release_notes.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Build GitHub Release notes from a Keep-a-Changelog version section (#370).
+
+The published GitHub Release used to be the squash-commit stub that
+``release.yml`` generated from ``git log``. That body is not
+``CHANGELOG.md``. This script extracts ``## [X.Y.Z]`` (minus the heading
+and minus Unreleased / other versions) and wraps it with the install /
+docs footer the Release page already carried.
+
+Stdlib only: the release job runs this after ``setup-python``, before
+any project install.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import re
+import sys
+
+_VERSION_HEADING = re.compile(r"^## \[([^\]]+)\](?:\s+-.*)?\s*$")
+
+
+def normalize_version(version: str) -> str:
+    """Strip a leading ``v`` so ``v2.7.0`` and ``2.7.0`` match the heading."""
+    return version[1:] if version.startswith("v") else version
+
+
+def extract_section(text: str, version: str) -> str:
+    """Return the body of ``## [version]`` (no heading).
+
+    Raises:
+        ValueError: the heading is missing, or the section has no body.
+    """
+    wanted = normalize_version(version)
+    chunks = re.split(r"(?=^## )", text, flags=re.M)
+    for chunk in chunks:
+        lines = chunk.splitlines()
+        if not lines:
+            continue
+        match = _VERSION_HEADING.match(lines[0].strip())
+        if match is None or match.group(1) != wanted:
+            continue
+        body = "\n".join(lines[1:]).strip()
+        if not body:
+            raise ValueError(f"CHANGELOG section ## [{wanted}] is empty")
+        return body
+    raise ValueError(f"CHANGELOG has no ## [{wanted}] section")
+
+
+def render_github_release(*, tag: str, version: str, body: str) -> str:
+    """Wrap a changelog section with the GitHub Release title and footer."""
+    number = normalize_version(version)
+    release_tag = tag if tag.startswith("v") else f"v{tag}"
+    return "\n".join(
+        (
+            f"## 🎉 Release {release_tag}",
+            "",
+            body,
+            "",
+            "### 📦 Installation",
+            "```bash",
+            f"pip install fmp-data=={number}",
+            "```",
+            "",
+            "### 🔗 Links",
+            f"- [PyPI Package](https://pypi.org/project/fmp-data/{number}/)",
+            "- [Documentation](https://mehdizare.github.io/fmp-data/)",
+            "",
+        )
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--changelog",
+        type=Path,
+        default=Path("CHANGELOG.md"),
+        help="Path to CHANGELOG.md (default: ./CHANGELOG.md)",
+    )
+    parser.add_argument(
+        "--version",
+        required=True,
+        help="Version to extract, with or without a leading v",
+    )
+    parser.add_argument(
+        "--tag",
+        default="",
+        help="Git tag for the Release title (default: v + version)",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Write notes here. Default: stdout",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        text = args.changelog.read_text(encoding="utf-8")
+        body = extract_section(text, args.version)
+    except (OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    tag = args.tag or f"v{normalize_version(args.version)}"
+    rendered = render_github_release(tag=tag, version=args.version, body=body)
+    if args.out is None:
+        sys.stdout.write(rendered)
+    else:
+        args.out.write_text(rendered, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_github_release_notes.py
+++ b/tests/unit/test_github_release_notes.py
@@ -1,0 +1,131 @@
+"""GitHub Release notes come from CHANGELOG.md, not the squash log (#370)."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "github_release_notes.py"
+_CHANGELOG = Path(__file__).resolve().parents[2] / "CHANGELOG.md"
+_SPEC = importlib.util.spec_from_file_location("github_release_notes", _SCRIPT)
+assert _SPEC and _SPEC.loader
+notes = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(notes)
+
+_SAMPLE = """# Changelog
+
+## Unreleased
+
+### Added
+
+- unreleased note
+
+## [2.7.0] - 2026-08-19
+
+Released from `dev`.
+
+### FMP API surface (scan this first)
+
+- diluted P/E
+
+### Added
+
+- senate trades
+
+## [2.6.0] - 2026-08-10
+
+### Added
+
+- old note
+"""
+
+
+def test_extract_section_drops_heading_and_neighbors() -> None:
+    body = notes.extract_section(_SAMPLE, "2.7.0")
+    assert body.startswith("Released from `dev`.")
+    assert "### FMP API surface (scan this first)" in body
+    assert "### Added" in body
+    assert "senate trades" in body
+    assert "## [2.7.0]" not in body
+    assert "unreleased note" not in body
+    assert "old note" not in body
+    assert "## Unreleased" not in body
+    assert "## [2.6.0]" not in body
+
+
+def test_extract_section_strips_v_prefix() -> None:
+    assert notes.extract_section(_SAMPLE, "v2.7.0") == notes.extract_section(
+        _SAMPLE, "2.7.0"
+    )
+
+
+def test_extract_section_missing_version_raises() -> None:
+    with pytest.raises(ValueError, match=r"no ## \[2\.8\.0\] section"):
+        notes.extract_section(_SAMPLE, "2.8.0")
+
+
+def test_extract_section_empty_body_raises() -> None:
+    text = "## [2.7.1] - 2026-08-20\n\n## [2.7.0] - 2026-08-19\n\nbody\n"
+    with pytest.raises(ValueError, match=r"## \[2\.7\.1\] is empty"):
+        notes.extract_section(text, "2.7.1")
+
+
+def test_render_github_release_wraps_install_and_links() -> None:
+    rendered = notes.render_github_release(
+        tag="v2.7.0", version="2.7.0", body="Released from `dev`."
+    )
+    assert rendered.startswith("## 🎉 Release v2.7.0\n")
+    assert "Released from `dev`." in rendered
+    assert "pip install fmp-data==2.7.0" in rendered
+    assert "https://pypi.org/project/fmp-data/2.7.0/" in rendered
+    assert "https://mehdizare.github.io/fmp-data/" in rendered
+    assert "### 📝 Commits" not in rendered
+
+
+def test_live_changelog_2_7_0_extracts_fmp_surface_first() -> None:
+    body = notes.extract_section(_CHANGELOG.read_text(encoding="utf-8"), "2.7.0")
+    assert "### FMP API surface (scan this first)" in body
+    assert body.index("### FMP API surface") < body.index("### Added")
+    assert "## Unreleased" not in body
+    assert "## [2.6.0]" not in body
+
+
+def test_cli_writes_release_file(tmp_path: Path) -> None:
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(_SAMPLE, encoding="utf-8")
+    out = tmp_path / "release-notes.md"
+    rc = notes.main(
+        [
+            "--changelog",
+            str(changelog),
+            "--version",
+            "2.7.0",
+            "--tag",
+            "v2.7.0",
+            "--out",
+            str(out),
+        ]
+    )
+    assert rc == 0
+    text = out.read_text(encoding="utf-8")
+    assert "Released from `dev`." in text
+    assert "pip install fmp-data==2.7.0" in text
+    assert "unreleased note" not in text
+
+
+def test_cli_missing_section_is_nonzero(tmp_path: Path) -> None:
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(_SAMPLE, encoding="utf-8")
+    rc = notes.main(
+        [
+            "--changelog",
+            str(changelog),
+            "--version",
+            "9.9.9",
+            "--out",
+            str(tmp_path / "x.md"),
+        ]
+    )
+    assert rc == 1

--- a/tests/unit/test_release_tag_push.py
+++ b/tests/unit/test_release_tag_push.py
@@ -121,3 +121,19 @@ def test_token_scoped_steps_still_fail_closed(fragment: str) -> None:
     run = _step(fragment)["run"]
     assert "set -euo pipefail" in run
     assert "|| true" not in run
+
+
+def test_github_release_notes_come_from_changelog() -> None:
+    """#370: notes are CHANGELOG.md, not the squash commit list."""
+    generate = _step("Generate release notes from CHANGELOG")
+    run = generate["run"]
+    assert "set -euo pipefail" in run
+    assert "scripts/github_release_notes.py" in run
+    assert "git log" not in _code_lines(run)
+    assert "GITHUB_OUTPUT" not in run
+
+    create = _step("Create GitHub Release")
+    create_run = create["run"]
+    assert "--notes-file release-notes.md" in create_run
+    assert "RELEASE_NOTES" not in (create.get("env") or {})
+    assert "git log" not in _code_lines(create_run)


### PR DESCRIPTION
## Summary

The published GitHub Release for `v2.7.0` was the squash-commit stub (`git log` of the release PR). In-repo `CHANGELOG.md` already had the rewritten Keep-a-Changelog body from #360 / #369.

- `scripts/github_release_notes.py` extracts the matching `## [X.Y.Z]` section (fail-closed if missing or empty) and wraps it with install / docs links.
- `release.yml` uses that file instead of the commit list / `GITHUB_OUTPUT` heredoc.
- The live [v2.7.0 Release](https://github.com/MehdiZare/fmp-data/releases/tag/v2.7.0) body was rewritten with the same script.
- `docs/contributing/releasing.md` documents that GitHub notes track CHANGELOG, not the squash log.

Closes #370.

## Test plan

- [x] `uv run pytest tests/unit/test_github_release_notes.py tests/unit/test_release_tag_push.py tests/unit/test_changelog_headings.py tests/unit/test_workflow_run_scripts.py` (27 passed)
- [x] Generated notes start with the 2.7.0 intro and `### FMP API surface`, end with install / links, and omit Unreleased / 2.6.0
- [x] `gh release view v2.7.0` shows the CHANGELOG body