### PR TITLE
fix(release): generate CHANGELOG notes before tagging (#370)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,22 @@ jobs:
             echo "VERSION_NUMBER=$NEW_VERSION"
           } >> "$GITHUB_OUTPUT"
 
+      - name: 📋 Generate release notes from CHANGELOG
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.VERSION }}
+          RELEASE_VERSION: ${{ steps.version.outputs.VERSION_NUMBER }}
+        run: |
+          set -euo pipefail
+          # Body is the matching ## [X.Y.Z] section, not the squash commit
+          # list. Missing / empty section fails the job *before* the tag is
+          # created or pushed, so a missing heading cannot leave a remote
+          # tag with no GitHub Release / PyPI artifact (#370 leftover).
+          python3 scripts/github_release_notes.py \
+            --changelog CHANGELOG.md \
+            --version "$RELEASE_VERSION" \
+            --tag "$RELEASE_TAG" \
+            --out release-notes.md
+
       - name: 🏷️ Create local tag
         run: |
           set -euo pipefail
@@ -232,20 +248,6 @@ jobs:
           # and less legibly).
           gh api "repos/${REPO}/git/ref/tags/${RELEASE_TAG}" > /dev/null
           echo "Pushed tag ${RELEASE_TAG} -> ${COMMIT_SHA}"
-
-      - name: 📋 Generate release notes from CHANGELOG
-        env:
-          RELEASE_TAG: ${{ steps.version.outputs.VERSION }}
-          RELEASE_VERSION: ${{ steps.version.outputs.VERSION_NUMBER }}
-        run: |
-          set -euo pipefail
-          # Body is the matching ## [X.Y.Z] section, not the squash commit
-          # list. Missing / empty section fails the job (#370).
-          python3 scripts/github_release_notes.py \
-            --changelog CHANGELOG.md \
-            --version "$RELEASE_VERSION" \
-            --tag "$RELEASE_TAG" \
-            --out release-notes.md
 
       - name: 🚀 Create GitHub Release
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   immediately under the intro. The uniqueness tripwire matches dated
   `## [X.Y.Z] - date` headings; empty Unreleased stays valid.
 - **GitHub Release notes come from CHANGELOG.md (#370).** `release.yml`
-  extracts the matching `## [X.Y.Z]` section (fail-closed if missing or
-  empty) and wraps it with install / docs links. The published `v2.7.0`
-  notes were rewritten to that body. They are no longer the squash
-  commit stub.
+  runs `scripts/github_release_notes.py` to extract the matching
+  `## [X.Y.Z]` section (fail-closed if missing or empty) and wrap it
+  with install / docs links. The published `v2.7.0` notes were rewritten
+  to that body. They are no longer the squash commit stub.
 - **Withdrawn MCP catalog rows are marked in `docs/mcp/tools.md` (#361).**
   Every `WITHDRAWN_TOOLS` spec now carries **Withdrawn / not in
   DEFAULT_TOOLS** (with successor or none). Docs-sync fails if a
@@ -58,6 +58,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   as nothing-to-release, converts an already-open empty slot to draft,
   and restores it when a content delta appears. Opening an unlabeled
   empty squash recreated the #202 ancestry break (#374).
+- **CHANGELOG notes generate before tagging (#370 leftover).** A missing
+  `## [X.Y.Z]` used to fail after the remote tag existed, leaving a tag
+  with no GitHub Release or PyPI artifact. The extract step now runs
+  immediately after version calculation.
 
 ## [2.7.0] - 2026-08-19
 

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -164,7 +164,8 @@ the overlay in a hotfix-shaped PR.
 2. **Label Detection**: Action reads PR labels to determine version bump
 3. **Version Calculation**: New version is calculated based on current version + bump type
 4. **Git Tagging**: New git tag is created with the version
-5. **Release Creation**: GitHub release is created with auto-generated notes
+5. **Release Creation**: GitHub release notes are the matching
+   `## [X.Y.Z]` CHANGELOG section (`scripts/github_release_notes.py`)
 6. **PyPI Publishing**: Package is built and published to PyPI
 7. **History sync**: Sync-Main-to-Dev restores `main` as an ancestor of `dev`
 
@@ -256,11 +257,20 @@ For emergency releases or when automation fails:
    ```
 
 9. **Create GitHub Release**
-   - Automated `release.yml` does this. Notes are the matching
-     `## [X.Y.Z]` section of `CHANGELOG.md`, wrapped with install /
-     docs links (`scripts/github_release_notes.py`). They are **not**
-     the squash commit list. Keep CHANGELOG updated before the release
-     PR merges; a missing section fails the job.
+   - Happy path: `release.yml` extracts `## [X.Y.Z]` via
+     `scripts/github_release_notes.py` (fail-closed, before tagging).
+   - If automation failed, generate the same file locally and publish it:
+     ```bash
+     python3 scripts/github_release_notes.py \
+       --changelog CHANGELOG.md \
+       --version 1.2.3 \
+       --tag v1.2.3 \
+       --out release-notes.md
+     gh release create v1.2.3 --notes-file release-notes.md
+     ```
+   - Fold `## Unreleased` into `## [X.Y.Z] - date` *before* adding a
+     `release:*` label. A heading that exists only under Unreleased
+     fails the job. Preview with `--version X.Y.Z`.
 
 ## Pre-release Process
 
@@ -301,58 +311,21 @@ pip install --pre fmp-data
 
 ## Release Notes
 
-### Automated Generation
+GitHub Release notes are the matching `## [X.Y.Z]` section of
+`CHANGELOG.md`, wrapped with install / docs links by
+`scripts/github_release_notes.py`. They are **not** the squash commit
+list, PR titles, or GitHub autogen.
 
-Release notes are automatically generated from:
-- PR titles and descriptions
-- Commit messages
-- Issue references
-- Breaking change callouts
+Before adding a `release:*` label, fold `## Unreleased` into
+`## [X.Y.Z] - YYYY-MM-DD` for the version that label will produce.
+Preview:
 
-### Manual Enhancement
-
-Enhance auto-generated notes with:
-- **Overview**: High-level summary of changes
-- **Highlights**: Key new features or improvements
-- **Breaking Changes**: Required user actions
-- **Migration Guide**: How to upgrade from previous version
-- **Contributors**: Thank contributors
-
-### Example Release Notes
-
-```markdown
-# v1.2.0 - Enhanced Market Data Support
-
-## Overview
-This release adds comprehensive market intelligence features and improves error handling across all clients.
-
-## ✨ New Features
-- Market Intelligence client with sentiment analysis
-- Enhanced company search with filtering options
-- Async support for all fundamental data endpoints
-
-## 🐛 Bug Fixes
-- Fixed rate limiting calculation for concurrent requests
-- Resolved memory leak in async client cleanup
-- Improved error messages for invalid API responses
-
-## 💥 Breaking Changes
-- `MarketClient.get_quotes()` now returns `List[Quote]` instead of `Dict`
-- Minimum Python version increased to 3.10
-
-## 📖 Documentation
-- Added comprehensive API reference
-- Updated getting started guide
-- New examples for market intelligence features
-
-## 🏗️ Internal Changes
-- Upgraded to Pydantic v2
-- Improved test coverage to 95%
-- Enhanced CI/CD pipeline
-
-## Contributors
-Thanks to @contributor1, @contributor2, and @contributor3 for their contributions!
+```bash
+python3 scripts/github_release_notes.py --version X.Y.Z --tag vX.Y.Z
 ```
+
+A missing or empty section fails the release job before the tag is
+created.
 
 ## Version Strategy
 

--- a/scripts/github_release_notes.py
+++ b/scripts/github_release_notes.py
@@ -7,8 +7,8 @@ The published GitHub Release used to be the squash-commit stub that
 and minus Unreleased / other versions) and wraps it with the install /
 docs footer the Release page already carried.
 
-Stdlib only: the release job runs this after ``setup-python``, before
-any project install.
+Stdlib only: do not import ``fmp_data``. The release job fails closed
+on a missing or empty section *before* it creates or pushes the tag.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_github_release_notes.py
+++ b/tests/unit/test_github_release_notes.py
@@ -109,10 +109,11 @@ def test_cli_writes_release_file(tmp_path: Path) -> None:
         ]
     )
     assert rc == 0
-    text = out.read_text(encoding="utf-8")
-    assert "Released from `dev`." in text
-    assert "pip install fmp-data==2.7.0" in text
-    assert "unreleased note" not in text
+    body = notes.extract_section(_SAMPLE, "2.7.0")
+    expected = notes.render_github_release(tag="v2.7.0", version="2.7.0", body=body)
+    assert out.read_text(encoding="utf-8") == expected
+    assert "unreleased note" not in expected
+    assert "old note" not in expected
 
 
 def test_cli_missing_section_is_nonzero(tmp_path: Path) -> None:

--- a/tests/unit/test_release_tag_push.py
+++ b/tests/unit/test_release_tag_push.py
@@ -116,7 +116,10 @@ def test_the_push_is_verified_before_downstream_steps_rely_on_it() -> None:
     assert "git/ref/tags/" in _step("Push tag")["run"]
 
 
-@pytest.mark.parametrize("fragment", ["Push tag", "Create GitHub Release"])
+@pytest.mark.parametrize(
+    "fragment",
+    ["Push tag", "Create GitHub Release", "Generate release notes from CHANGELOG"],
+)
 def test_token_scoped_steps_still_fail_closed(fragment: str) -> None:
     run = _step(fragment)["run"]
     assert "set -euo pipefail" in run
@@ -126,14 +129,28 @@ def test_token_scoped_steps_still_fail_closed(fragment: str) -> None:
 def test_github_release_notes_come_from_changelog() -> None:
     """#370: notes are CHANGELOG.md, not the squash commit list."""
     generate = _step("Generate release notes from CHANGELOG")
-    run = generate["run"]
-    assert "set -euo pipefail" in run
+    run = _code_lines(generate["run"])
     assert "scripts/github_release_notes.py" in run
-    assert "git log" not in _code_lines(run)
+    assert "--changelog CHANGELOG.md" in run
+    assert '--version "$RELEASE_VERSION"' in run
+    assert '--tag "$RELEASE_TAG"' in run
+    assert "--out release-notes.md" in run
+    assert "git log" not in run
     assert "GITHUB_OUTPUT" not in run
+    env = generate.get("env") or {}
+    assert "steps.version.outputs.VERSION_NUMBER" in str(env.get("RELEASE_VERSION"))
+    assert "steps.version.outputs.VERSION" in str(env.get("RELEASE_TAG"))
 
     create = _step("Create GitHub Release")
     create_run = create["run"]
     assert "--notes-file release-notes.md" in create_run
+    assert "! -s release-notes.md" in create_run
     assert "RELEASE_NOTES" not in (create.get("env") or {})
     assert "git log" not in _code_lines(create_run)
+
+
+def test_changelog_notes_are_generated_before_tagging() -> None:
+    """A missing ## [X.Y.Z] must fail before a remote tag exists."""
+    assert _index("Generate release notes") < _index("Create local tag")
+    assert _index("Generate release notes") < _index("Push tag")
+    assert _index("Generate release notes") < _index("Create GitHub Release")


### PR DESCRIPTION
## Summary

Isolated leftover of #370 / review of [PR #380](https://github.com/MehdiZare/fmp-data/pull/380).

`release.yml` extracted CHANGELOG notes *after* pushing the annotated tag. A missing `## [X.Y.Z]` (the next labeled cut, with notes still under Unreleased) would then fail closed with a remote tag and no GitHub Release / PyPI publish. Re-runs hit “tag already exists.”

- Move generate-notes to immediately after version calculation (Python is already set up).
- Pin argv (`--changelog`, `--version`, `--tag`, `--out`), env (`VERSION` / `VERSION_NUMBER`), empty-file guard, and step order.
- CLI output must equal `render(extract(...))`.
- `docs/contributing/releasing.md` no longer describes git-log autogen.

Closes nothing on its own; keeps #370’s fail-closed policy from leaving orphan tags.

## Test plan

- [x] `uv run pytest tests/unit/test_release_tag_push.py tests/unit/test_github_release_notes.py tests/unit/test_changelog_headings.py tests/unit/test_workflow_run_scripts.py` (29 passed)