### PR TITLE
fix(release): address CodeRabbit leftovers on CHANGELOG notes (#370)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `## [X.Y.Z]` used to fail after the remote tag existed, leaving a tag
   with no GitHub Release or PyPI artifact. The extract step now runs
   immediately after version calculation.
+- **Release-note extractor keeps non-version ``##`` headings (#370).**
+  Split is only on ``## [X.Y.Z]`` so a section body can contain other
+  level-2 headings. CLI write failures print `error:` and exit 1.
+  Manual release docs generate notes before pushing the tag. Async
+  retry test asserts both Tenacity waits are 4s.
 
 ## [2.7.0] - 2026-08-19
 

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -241,11 +241,16 @@ For emergency releases or when automation fails:
    - Add exactly one version label: `release:major`, `release:minor`, or `release:patch`
    - Include release notes in description
 
-7. **Merge and Tag**
+7. **Merge, generate notes, then tag**
    ```bash
    # After PR approval and merge
    git checkout main
    git pull origin main
+   python3 scripts/github_release_notes.py \
+     --changelog CHANGELOG.md \
+     --version 1.2.3 \
+     --tag v1.2.3 \
+     --out release-notes.md
    git tag v1.2.3
    git push origin v1.2.3
    ```
@@ -259,13 +264,8 @@ For emergency releases or when automation fails:
 9. **Create GitHub Release**
    - Happy path: `release.yml` extracts `## [X.Y.Z]` via
      `scripts/github_release_notes.py` (fail-closed, before tagging).
-   - If automation failed, generate the same file locally and publish it:
+   - If automation failed, use the file from step 7:
      ```bash
-     python3 scripts/github_release_notes.py \
-       --changelog CHANGELOG.md \
-       --version 1.2.3 \
-       --tag v1.2.3 \
-       --out release-notes.md
      gh release create v1.2.3 --notes-file release-notes.md
      ```
    - Fold `## Unreleased` into `## [X.Y.Z] - date` *before* adding a

--- a/scripts/github_release_notes.py
+++ b/scripts/github_release_notes.py
@@ -19,6 +19,9 @@ import re
 import sys
 
 _VERSION_HEADING = re.compile(r"^## \[([^\]]+)\](?:\s+-.*)?\s*$")
+# Split only on dated/undated Keep-a-Changelog version headings so a
+# non-version ``## `` inside a section stays in that section's body.
+_VERSION_CHUNK_START = re.compile(r"(?=^## \[[^\]]+\](?:\s+-.*)?\s*$)", re.M)
 
 
 def normalize_version(version: str) -> str:
@@ -33,7 +36,7 @@ def extract_section(text: str, version: str) -> str:
         ValueError: the heading is missing, or the section has no body.
     """
     wanted = normalize_version(version)
-    chunks = re.split(r"(?=^## )", text, flags=re.M)
+    chunks = _VERSION_CHUNK_START.split(text)
     for chunk in chunks:
         lines = chunk.splitlines()
         if not lines:
@@ -108,8 +111,12 @@ def main(argv: list[str] | None = None) -> int:
     rendered = render_github_release(tag=tag, version=args.version, body=body)
     if args.out is None:
         sys.stdout.write(rendered)
-    else:
+        return 0
+    try:
         args.out.write_text(rendered, encoding="utf-8")
+    except OSError as exc:
+        print(f"error: cannot write {args.out}: {exc}", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/tests/unit/test_base_async.py
+++ b/tests/unit/test_base_async.py
@@ -311,7 +311,10 @@ class TestAsyncRetry:
             assert result == {"test": "data"}
             # Two backoffs between the three attempts. Tenacity 9.1.4 async
             # retries go through asyncio.sleep, not tenacity.nap.sleep (#372).
+            # wait_exponential(multiplier=1, min=4, max=10) clamps both
+            # waits to 4s (2^0 and 2^1 are below min).
             assert mock_sleep.await_count == 2
+            assert [call.args[0] for call in mock_sleep.await_args_list] == [4, 4]
 
         await client.aclose()
 

--- a/tests/unit/test_github_release_notes.py
+++ b/tests/unit/test_github_release_notes.py
@@ -66,6 +66,22 @@ def test_extract_section_missing_version_raises() -> None:
         notes.extract_section(_SAMPLE, "2.8.0")
 
 
+def test_extract_section_keeps_non_version_level_two_heading() -> None:
+    text = (
+        "## [2.7.0] - 2026-08-19\n\n"
+        "intro\n\n"
+        "## Upgrade notes\n\n"
+        "keep me\n\n"
+        "## [2.6.0] - 2026-08-10\n\n"
+        "old\n"
+    )
+    body = notes.extract_section(text, "2.7.0")
+    assert "intro" in body
+    assert "## Upgrade notes" in body
+    assert "keep me" in body
+    assert "old" not in body
+
+
 def test_extract_section_empty_body_raises() -> None:
     text = "## [2.7.1] - 2026-08-20\n\n## [2.7.0] - 2026-08-19\n\nbody\n"
     with pytest.raises(ValueError, match=r"## \[2\.7\.1\] is empty"):
@@ -127,6 +143,22 @@ def test_cli_missing_section_is_nonzero(tmp_path: Path) -> None:
             "9.9.9",
             "--out",
             str(tmp_path / "x.md"),
+        ]
+    )
+    assert rc == 1
+
+
+def test_cli_unwritable_out_is_nonzero(tmp_path: Path) -> None:
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(_SAMPLE, encoding="utf-8")
+    rc = notes.main(
+        [
+            "--changelog",
+            str(changelog),
+            "--version",
+            "2.7.0",
+            "--out",
+            str(tmp_path),
         ]
     )
     assert rc == 1


### PR DESCRIPTION
## Summary

Isolated follow-up for CodeRabbit comments on [PR #380](https://github.com/MehdiZare/fmp-data/pull/380) (4 threads). Head of 380 is `dev`, so this lands there after merge.

- Split `extract_section` only on `## [X.Y.Z]` so a non-version `##` inside a section is kept.
- CLI `write_text` OSError prints `error: cannot write <path>` and returns 1.
- Manual release docs generate notes **before** pushing the tag.
- `test_request_async_with_retry_on_transient_failure` asserts wait args `[4, 4]`.

## Test plan

- [x] `uv run pytest tests/unit/test_github_release_notes.py tests/unit/test_base_async.py::TestAsyncRetry tests/unit/test_changelog_headings.py` (15 passed)