### PR TITLE
fix(release): fold Unreleased into 2.7.1 and lock notes-before-tag (#383)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,6 +150,13 @@ jobs:
             --tag "$RELEASE_TAG" \
             --out release-notes.md
 
+          # Empty-file guard belongs here, before the local tag (#387).
+          # A comment cannot satisfy the tripwire; this must execute.
+          if [ ! -s release-notes.md ]; then
+            echo "::error::release-notes.md is missing or empty."
+            exit 1
+          fi
+
       - name: 🏷️ Create local tag
         run: |
           set -euo pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [2.7.1] - 2026-08-20
+
+Patch of leftover 2.7.0 CI, docs, and tests that landed unlabeled on
+`main` (#380). The published `fmp_data` library is identical to 2.7.0.
+This cut exists so the next labeled release has a `## [X.Y.Z]` heading
+the notes extractor can fail-close on (#383).
+
 ### Changed
 
 - **GitHub Actions pins.** `github/codeql-action` 4.37.6 → 4.37.7
@@ -26,15 +33,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Every `WITHDRAWN_TOOLS` spec now carries **Withdrawn / not in
   DEFAULT_TOOLS** (with successor or none). Docs-sync fails if a
   withdrawn row omits the mark.
+- **releasing.md merge-to-main list matches notes-before-tag (#386).**
+  Version calc → extract `## [X.Y.Z]` (fail-closed) → local annotated
+  tag → build → API tag push → GitHub Release. The job is a no-op
+  without a `release:*` label. Notes are a hand-maintained Keep a
+  Changelog section, not git-log autogen.
 
 ### Removed
 
 - **Claude Code GitHub Actions (#359).** Dropped `claude-code-review.yml`
   (automatic PR review that cloned `anthropics/claude-code` at HEAD) and
   `claude.yml` (`@claude` mention agent with `contents: write`). Required
-  checks stay in `ci.yml`. Claude Desktop MCP setup is unchanged. Delete
-  the `CLAUDE_CODE_OAUTH_TOKEN` repository secret after this reaches
-  `main`.
+  checks stay in `ci.yml`. Claude Desktop MCP setup is unchanged. The
+  `CLAUDE_CODE_OAUTH_TOKEN` repository secret was deleted after this
+  reached `main` (#384).
 
 ### Fixed
 
@@ -67,6 +79,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   level-2 headings. CLI write failures print `error:` and exit 1.
   Manual release docs generate notes before pushing the tag. Async
   retry test asserts both Tenacity waits are 4s.
+- **Generate-step empty-notes check (#387).** `[ ! -s release-notes.md ]`
+  runs on the generate step, before the local tag, so an empty file
+  cannot orphan a remote tag. A comment cannot satisfy the tripwire.
+- **CLI `error:` contract and uniqueness splitter (#387).** Missing
+  section / missing changelog / unwritable `--out` print `error:` on
+  stderr and do not create `--out`. The uniqueness tripwire splits on
+  version headings (and Unreleased), matching the extractor. Claude
+  absence checks are case-insensitive.
 
 ## [2.7.0] - 2026-08-19
 

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -132,7 +132,9 @@ the overlay in a hotfix-shaped PR.
   `pypi`). Existing tags / releases / PyPI versions fail the job instead of
   being skipped. Release notes are the matching `## [X.Y.Z]` section of
   `CHANGELOG.md` (via `scripts/github_release_notes.py`), not the squash
-  commit list (#370). A missing or empty section fails the job.
+  commit list (#370). A missing or empty section fails the job **before
+  the local or remote tag**. The job is a **no-op without a `release:*`
+  label**.
 - External Actions are pinned to full commit SHAs. The PEP 517 frontend
   (`build`) and backend (`hatchling`, `hatch-vcs`) are installed from
   version floors in `.github/requirements-build.txt` (not a hashed lock).
@@ -160,14 +162,22 @@ the overlay in a hotfix-shaped PR.
 
 ### GitHub Actions Workflow (on merge to main)
 
+The job is a **no-op without a `release:*` label**. Unlabeled
+`dev → main` leftover landings do not tag or publish; Sync-Main-to-Dev
+still records the squash (#375, #383).
+
 1. **PR Merge**: When a labeled release PR is merged to `main`
 2. **Label Detection**: Action reads PR labels to determine version bump
-3. **Version Calculation**: New version is calculated based on current version + bump type
-4. **Git Tagging**: New git tag is created with the version
-5. **Release Creation**: GitHub release notes are the matching
-   `## [X.Y.Z]` CHANGELOG section (`scripts/github_release_notes.py`)
-6. **PyPI Publishing**: Package is built and published to PyPI
-7. **History sync**: Sync-Main-to-Dev restores `main` as an ancestor of `dev`
+3. **Version Calculation**: New version from the latest tag + bump type
+4. **Extract notes (fail-closed)**: matching `## [X.Y.Z]` via
+   `scripts/github_release_notes.py`. Missing or empty section fails
+   the job before any tag
+5. **Local annotated tag**: created for hatch-vcs (not pushed yet)
+6. **Build**: sdist/wheel; sdist `Version:` must match the calculated version
+7. **API tag push**: annotated tag object, then the ref
+8. **GitHub Release**: `--notes-file release-notes.md`
+9. **PyPI Publishing**: hashed artifacts from the build job
+10. **History sync**: Sync-Main-to-Dev restores `main` as an ancestor of `dev`
 
 ### Required PR Labels
 
@@ -465,7 +475,8 @@ pip install fmp-data==1.2.2
 - **GitHub Actions**: CI/CD automation
 - **PyPI**: Package distribution
 - **MkDocs**: Documentation generation
-- **Conventional Commits**: Automated changelog generation
+- **CHANGELOG.md**: hand-maintained Keep a Changelog. GitHub Release
+  notes are the matching `## [X.Y.Z]` section, not git-log autogen
 
 ## Troubleshooting
 

--- a/tests/unit/test_changelog_headings.py
+++ b/tests/unit/test_changelog_headings.py
@@ -27,11 +27,18 @@ _VERSION_HEADER = re.compile(
     r"^## (?:Unreleased|\[(\d+)\.(\d+)\.[^\]]+\])(?:\s+-.*)?\s*$"
 )
 _HEADING = re.compile(r"^### (.+)$", re.M)
+# Extractor splits only on ``## [X.Y.Z]`` (#385 / ``_VERSION_CHUNK_START``).
+# Uniqueness does the same for version bodies, plus ``## Unreleased`` so
+# the post-cut bucket stays its own gated section. A bare ``## `` inside
+# a version must not start a new chunk (#387).
+_SECTION_CHUNK_START = re.compile(
+    r"(?=^## (?:Unreleased|\[[^\]]+\])(?:\s+-.*)?\s*$)", re.M
+)
 
 
 def _gated_sections(text: str) -> list[tuple[str, str]]:
     """``(header, body)`` for Unreleased and every ``[X.Y.*]`` with X.Y >= 2.7."""
-    chunks = re.split(r"(?=^## )", text, flags=re.M)
+    chunks = _SECTION_CHUNK_START.split(text)
     out: list[tuple[str, str]] = []
     for chunk in chunks:
         lines = chunk.splitlines()
@@ -58,6 +65,22 @@ def test_version_header_matches_dated_keep_a_changelog() -> None:
     assert _VERSION_HEADER.match("## Unreleased") is not None
     assert _VERSION_HEADER.match("## [2.6.0] - 2026-08-10") is not None
     assert _VERSION_HEADER.match("## Future Roadmap") is None
+
+
+def test_gated_sections_keep_non_version_level_two_inside_version() -> None:
+    """#387: a ``## `` that is not a version heading stays in the section."""
+    text = (
+        "## [2.7.0] - 2026-08-19\n\n"
+        "### Added\n\n- first\n\n"
+        "## Upgrade notes\n\n"
+        "### Added\n\n- second\n\n"
+        "## [2.6.0] - 2026-08-10\n\n"
+        "### Added\n\n- old\n"
+    )
+    sections = _gated_sections(text)
+    assert [header for header, _ in sections] == ["## [2.7.0] - 2026-08-19"]
+    headings = [name for name in _HEADING.findall(sections[0][1]) if name in _STANDARD]
+    assert headings == ["Added", "Added"]
 
 
 def test_gated_sections_include_dated_2_7_and_allow_empty_unreleased() -> None:

--- a/tests/unit/test_checkout_credentials.py
+++ b/tests/unit/test_checkout_credentials.py
@@ -96,8 +96,10 @@ def test_claude_code_action_workflows_are_absent() -> None:
         "claude-code-review.yaml",
     ):
         assert not (WORKFLOWS_DIR / name).exists()
-    remaining = "\n".join(path.read_text(encoding="utf-8") for path in GITHUB_YAML)
+    remaining = "\n".join(
+        path.read_text(encoding="utf-8") for path in GITHUB_YAML
+    ).casefold()
     assert "anthropics/claude-code-action" not in remaining
-    assert "CLAUDE_CODE_OAUTH_TOKEN" not in remaining
+    assert "claude_code_oauth_token" not in remaining
     assert "plugin_marketplaces" not in remaining
     assert "anthropics/claude-code.git" not in remaining

--- a/tests/unit/test_github_release_notes.py
+++ b/tests/unit/test_github_release_notes.py
@@ -132,9 +132,12 @@ def test_cli_writes_release_file(tmp_path: Path) -> None:
     assert "old note" not in expected
 
 
-def test_cli_missing_section_is_nonzero(tmp_path: Path) -> None:
+def test_cli_missing_section_is_nonzero(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     changelog = tmp_path / "CHANGELOG.md"
     changelog.write_text(_SAMPLE, encoding="utf-8")
+    out = tmp_path / "x.md"
     rc = notes.main(
         [
             "--changelog",
@@ -142,13 +145,18 @@ def test_cli_missing_section_is_nonzero(tmp_path: Path) -> None:
             "--version",
             "9.9.9",
             "--out",
-            str(tmp_path / "x.md"),
+            str(out),
         ]
     )
     assert rc == 1
+    err = capsys.readouterr().err
+    assert err.startswith("error:")
+    assert not out.exists()
 
 
-def test_cli_unwritable_out_is_nonzero(tmp_path: Path) -> None:
+def test_cli_unwritable_out_is_nonzero(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     changelog = tmp_path / "CHANGELOG.md"
     changelog.write_text(_SAMPLE, encoding="utf-8")
     rc = notes.main(
@@ -162,3 +170,33 @@ def test_cli_unwritable_out_is_nonzero(tmp_path: Path) -> None:
         ]
     )
     assert rc == 1
+    err = capsys.readouterr().err
+    assert err.startswith("error:")
+    assert "cannot write" in err
+
+
+def test_cli_missing_changelog_file_is_nonzero(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc = notes.main(
+        [
+            "--changelog",
+            str(tmp_path / "missing.md"),
+            "--version",
+            "2.7.0",
+            "--out",
+            str(tmp_path / "x.md"),
+        ]
+    )
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert err.startswith("error:")
+    assert not (tmp_path / "x.md").exists()
+
+
+def test_live_changelog_2_7_1_extracts() -> None:
+    body = notes.extract_section(_CHANGELOG.read_text(encoding="utf-8"), "2.7.1")
+    assert body.startswith("Patch of leftover 2.7.0")
+    assert "## Unreleased" not in body
+    assert "## [2.7.0]" not in body
+    assert "fmp_data" in body

--- a/tests/unit/test_release_tag_push.py
+++ b/tests/unit/test_release_tag_push.py
@@ -149,6 +149,15 @@ def test_github_release_notes_come_from_changelog() -> None:
     assert "git log" not in _code_lines(create_run)
 
 
+def test_generate_step_fails_closed_on_empty_notes() -> None:
+    """#387: empty notes must fail on the generate step, before any tag."""
+    generate = _step("Generate release notes from CHANGELOG")
+    run = _code_lines(generate["run"])
+    assert "! -s release-notes.md" in run
+    assert _index("Generate release notes") < _index("Create local tag")
+    assert _index("Generate release notes") < _index("Push tag")
+
+
 def test_changelog_notes_are_generated_before_tagging() -> None:
     """A missing ## [X.Y.Z] must fail before a remote tag exists."""
     assert _index("Generate release notes") < _index("Create local tag")


### PR DESCRIPTION
## Summary

Prep for a labeled **2.7.1 patch** cut. `origin/dev` and `origin/main` were tree-identical; Unreleased still held post-2.7.0 leftovers and there was no `## [2.7.1]` heading, so `release:*` would fail-closed on purpose (#383). Zero `fmp_data/` changes since `v2.7.0`.

- **#383** — Fold Unreleased into `## [2.7.1] - 2026-08-20`. Empty Unreleased stays as the post-cut bucket. Library identical to 2.7.0.
- **#386** — Rewrite the merge-to-main list to version calc → extract `## [X.Y.Z]` (fail-closed) → local annotated tag → build → API tag push → GitHub Release. Job is a no-op without `release:*`. Unlabeled leftover landings do not tag; Sync-Main-to-Dev still records. Notes are Keep a Changelog, not git-log autogen.
- **#387** — Empty-notes check on the **generate** step (`_code_lines`, before any tag). CLI tests assert `error:` on stderr, `cannot write`, and `--out` is not created on missing section / missing file. Uniqueness splitter aligns with version headings (plus Unreleased). Claude-absence needles are case-folded.

Do **not** put `release:*` on this PR. After it lands on `dev`, the automated Release PR is the one that gets `release:patch`.

Does **not** close #389 (Claude GitHub App uninstall is a UI click).

Preview:

```bash
python3 scripts/github_release_notes.py --version 2.7.1 --tag v2.7.1
```

## Test plan

- [x] `uv run pytest tests/unit/test_release_tag_push.py tests/unit/test_changelog_headings.py tests/unit/test_github_release_notes.py tests/unit/test_checkout_credentials.py tests/unit/test_workflow_run_scripts.py tests/unit/test_release_pr_workflow.py`
- [x] pre-commit (ruff, mypy) on commit
- [ ] Test-Matrix on this PR
- [ ] After merge to `dev`: label the automated `dev → main` PR `release:patch`, confirm TestPyPI comment SHA matches the tip, then merge

Closes #383
Closes #386
Closes #387